### PR TITLE
add window delay support

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
@@ -46,6 +46,7 @@ import com.amazon.opendistroforelasticsearch.ad.ml.rcf.CombinedRcfResult;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.model.FeatureData;
+import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.amazon.opendistroforelasticsearch.ad.util.ColdStartRunner;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
@@ -221,6 +222,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                 listener.onFailure(new EndRunException(adID, "AnomalyDetector is not available.", true));
                 return;
             }
+            AnomalyDetector anomalyDetector = detector.get();
 
             String thresholdModelID = modelManager.getThresholdModelId(adID);
             Optional<DiscoveryNode> thresholdNode = hashRing.getOwningNode(thresholdModelID);
@@ -235,8 +237,13 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                 return;
             }
 
-            SinglePointFeatures featureOptional = featureManager.getCurrentFeatures(detector.get(),
-                    request.getStart(), request.getEnd());
+            long delayMillis = Optional.ofNullable((IntervalTimeConfiguration)anomalyDetector.getWindowDelay())
+                .map(t -> t.toDuration().toMillis()).orElse(0L);
+            long startTime = request.getStart() - delayMillis;
+            long endTime = request.getEnd() - delayMillis;
+
+            SinglePointFeatures featureOptional = featureManager.getCurrentFeatures(anomalyDetector,
+                    startTime, endTime);
 
             List<FeatureData> featureInResponse = null;
 
@@ -342,8 +349,8 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                 listener.onResponse(response);
                 indexAnomalyResult(new AnomalyResult(adID, Double.valueOf(combinedScore),
                         Double.valueOf(response.getAnomalyGrade()), Double.valueOf(confidence),
-                        featureInResponse, Instant.ofEpochMilli(request.getStart()),
-                        Instant.ofEpochMilli(request.getEnd())));
+                        featureInResponse, Instant.ofEpochMilli(startTime),
+                        Instant.ofEpochMilli(endTime)));
             } else if (failure.get() != null) {
                 listener.onFailure(failure.get());
             } else {


### PR DESCRIPTION
This pr adds support for the window delay field. It is designed to allow real-time data enough time to arrive at the cluster. When set, the data used for detection is from window delay ago rather than current time.

Passed e2e test.