### PR TITLE
return no data error message to preview

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -283,6 +283,7 @@ public class FeatureManager {
      * @param endMilli end of the range in epoch milliseconds
      * @param listener onResponse is called with time ranges, unprocessed features,
      *                                      and processed features of the data points from the period
+     *                 onFailure is called with IllegalArgumentException when there is no data to preview
      */
     public void getPreviewFeatures(AnomalyDetector detector, long startMilli, long endMilli, ActionListener<Features> listener) {
         Entry<List<Entry<Long, Long>>, Integer> sampleRangeResults = getSampleRanges(detector, startMilli, endMilli);
@@ -291,6 +292,10 @@ public class FeatureManager {
 
         getSamplesForRanges(detector, sampleRanges, ActionListener.wrap(samples -> {
             List<Entry<Long, Long>> searchTimeRange = samples.getKey();
+            if (searchTimeRange.size() == 0) {
+                listener.onFailure(new IllegalArgumentException("No data to preview anomaly detection."));
+                return;
+            }
             double[][] sampleFeatures = samples.getValue();
 
             List<Entry<Long, Long>> previewRanges = getPreviewRanges(searchTimeRange, stride);


### PR DESCRIPTION
Current preview returns an internal exception when there is no data. For an example, see https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/28 This pr handles the case with a clear error message, as shown below.

````
[elasticsearch] java.lang.IllegalArgumentException: No data to preview anomaly detection.
[elasticsearch]         at com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager.lambda$getPreviewFeatures$14(FeatureManager.java:277) [opendistro-anomaly-detection-1.2.1.0-alpha.jar:1.2.1.0-alpha]
[elasticsearch]         at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.2.1.jar:7.2.1]
[elasticsearch]         at com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager.lambda$getSamplesForRanges$19(FeatureManager.java:347) [opendistro-anomaly-detection-1.2.1.0-alpha.jar:1.2.1.0-alpha]
[elasticsearch]         at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.2.1.jar:7.2.1]
[elasticsearch]         at com.amazon.opendistroforelasticsearch.ad.feature.SearchFeatureDao.lambda$getFeatureSamplesForPeriods$24(SearchFeatureDao.java:196) [opendistro-anomaly-detection-1.2.1.0-alpha.jar:1.2.1.0-alpha]
[elasticsearch]         at org.elasticsearch.action.ActionListener$1.onResponse(ActionListener.java:62) [elasticsearch-7.2.1.jar:7.2.1]
[elasticsearch]         at org.elasticsearch.action.support.TransportAction$1.onResponse(TransportAction.java:68) [elasticsearch-7.2.1.jar:7.2.1]
[elasticsearch]         at org.elasticsearch.action.support.TransportAction$1.onResponse(TransportAction.java:64) [elasticsearch-7.2.1.jar:7.2.1]
````