### PR TITLE
adjust preview configuration for more data

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -259,10 +259,11 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             AnomalyDetectorSettings.SHINGLE_SIZE,
             AnomalyDetectorSettings.MAX_MISSING_POINTS,
             AnomalyDetectorSettings.MAX_NEIGHBOR_DISTANCE,
+            AnomalyDetectorSettings.PREVIEW_SAMPLE_RATE,
             AnomalyDetectorSettings.MAX_PREVIEW_SAMPLES,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE
         );
-        anomalyDetectorRunner = new AnomalyDetectorRunner(modelManager, featureManager);
+        anomalyDetectorRunner = new AnomalyDetectorRunner(modelManager, featureManager, AnomalyDetectorSettings.MAX_PREVIEW_RESULTS);
 
         DeleteDetector deleteUtil = new DeleteDetector(clusterService, clock);
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
@@ -42,10 +42,12 @@ public final class AnomalyDetectorRunner {
     private final Logger logger = LogManager.getLogger(AnomalyDetectorRunner.class);
     private final ModelManager modelManager;
     private final FeatureManager featureManager;
+    private final int maxPreviewResults;
 
-    public AnomalyDetectorRunner(ModelManager modelManager, FeatureManager featureManager) {
+    public AnomalyDetectorRunner(ModelManager modelManager, FeatureManager featureManager, int maxPreviewResults) {
         this.modelManager = modelManager;
         this.featureManager = featureManager;
+        this.maxPreviewResults = maxPreviewResults;
     }
 
     /**
@@ -69,7 +71,7 @@ public final class AnomalyDetectorRunner {
         featureManager.getPreviewFeatures(detector, startTime.toEpochMilli(), endTime.toEpochMilli(), ActionListener.wrap(features -> {
             try {
                 List<ThresholdingResult> results = modelManager.getPreviewResults(features.getProcessedFeatures());
-                listener.onResponse(sample(parsePreviewResult(detector, features, results), 200));
+                listener.onResponse(sample(parsePreviewResult(detector, features, results), maxPreviewResults));
             } catch (Exception e) {
                 onFailure(e, listener, detector.getDetectorId());
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -64,6 +64,7 @@ public class FeatureManager {
     private final int shingleSize;
     private final int maxMissingPoints;
     private final int maxNeighborDistance;
+    private final double previewSampleRate;
     private final int maxPreviewSamples;
     private final Duration featureBufferTtl;
 
@@ -78,6 +79,7 @@ public class FeatureManager {
      * @param shingleSize size of feature shingles
      * @param maxMissingPoints max number of missing points allowed to generate a shingle
      * @param maxNeighborDistance max distance (number of intervals) between a missing point and a replacement neighbor
+     * @param previewSampleRate number of samples to number of all the data points in the preview time range
      * @param maxPreviewSamples max number of samples from search for preview features
      * @param featureBufferTtl time to live for stale feature buffers
      */
@@ -90,6 +92,7 @@ public class FeatureManager {
         int shingleSize,
         int maxMissingPoints,
         int maxNeighborDistance,
+        double previewSampleRate,
         int maxPreviewSamples,
         Duration featureBufferTtl
     ) {
@@ -101,6 +104,7 @@ public class FeatureManager {
         this.shingleSize = shingleSize;
         this.maxMissingPoints = maxMissingPoints;
         this.maxNeighborDistance = maxNeighborDistance;
+        this.previewSampleRate = previewSampleRate;
         this.maxPreviewSamples = maxPreviewSamples;
         this.featureBufferTtl = featureBufferTtl;
 
@@ -317,7 +321,8 @@ public class FeatureManager {
         long end = truncateToMinute(endMilli);
         long bucketSize = ((IntervalTimeConfiguration) detector.getDetectionInterval()).toDuration().toMillis();
         int numBuckets = (int) Math.floor((end - start) / (double) bucketSize);
-        int stride = (int) Math.max(1, Math.floor((double) numBuckets / maxPreviewSamples));
+        int numSamples = (int) Math.max(Math.min(numBuckets * previewSampleRate, maxPreviewSamples), 1);
+        int stride = (int) Math.max(1, Math.floor((double) numBuckets / numSamples));
         int numStrides = (int) Math.ceil(numBuckets / (double) stride);
         List<Entry<Long, Long>> sampleRanges = Stream
             .iterate(start, i -> i + stride * bucketSize)

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -151,7 +151,7 @@ public final class AnomalyDetectorSettings {
 
     public static final long THRESHOLD_MAX_SAMPLES = 50_000;
 
-    public static final int MIN_PREVIEW_SIZE = 500; // ok to lower
+    public static final int MIN_PREVIEW_SIZE = 400; // ok to lower
 
     // Feature processing
     public static final int MAX_TRAIN_SAMPLE = 24;
@@ -164,6 +164,9 @@ public final class AnomalyDetectorSettings {
 
     public static final int MAX_NEIGHBOR_DISTANCE = Math.min(2, SHINGLE_SIZE);
 
-    public static final int MAX_PREVIEW_SAMPLES = 60; // ok to adjust, higher for more data, lower for lower latency
+    public static final double PREVIEW_SAMPLE_RATE = 0.25; // ok to adjust, higher for more data, lower for lower latency
 
+    public static final int MAX_PREVIEW_SAMPLES = 300; // ok to adjust, higher for more data, lower for lower latency
+
+    public static final int MAX_PREVIEW_RESULTS = 1_000; // ok to adjust, higher for more data, lower for lower latency
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
@@ -72,6 +72,7 @@ public class FeatureManagerTests {
     private int shingleSize;
     private int maxMissingPoints;
     private int maxNeighborDistance;
+    private double previewSampleRate;
     private int maxPreviewSamples;
     private Duration featureBufferTtl;
 
@@ -98,6 +99,7 @@ public class FeatureManagerTests {
         shingleSize = 3;
         maxMissingPoints = 2;
         maxNeighborDistance = 2;
+        previewSampleRate = 0.5;
         maxPreviewSamples = 2;
         featureBufferTtl = Duration.ofMillis(1_000L);
 
@@ -115,6 +117,7 @@ public class FeatureManagerTests {
                 shingleSize,
                 maxMissingPoints,
                 maxNeighborDistance,
+                previewSampleRate,
                 maxPreviewSamples,
                 featureBufferTtl
             )
@@ -213,6 +216,7 @@ public class FeatureManagerTests {
                 4,
                 maxMissingPoints,
                 maxNeighborDistance,
+                previewSampleRate,
                 maxPreviewSamples,
                 featureBufferTtl
             )


### PR DESCRIPTION
Currently, for preview requests, up to 60 data points are sampled and up to 200 results are returned to the client to reduce latency from processing and network. To improve visualization for human eyes, the changes increase the number of samples to match the requested time range, the upper limit of samples, and the number of returned results to clients.

![preview](https://user-images.githubusercontent.com/57818076/73485995-0a2b9480-4359-11ea-8d30-9edbb4932903.png)
