### PR TITLE
Send back error response when failing to stop detector

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestDeleteAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestDeleteAnomalyDetectorAction.java
@@ -133,6 +133,7 @@ public class RestDeleteAnomalyDetectorAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 logger.error("Failed to delete AD model for detector " + detectorId, e);
+                channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, "Failed to delete AD model"));
             }
         };
     }


### PR DESCRIPTION
Previously, a stop detector api request hangs until timeout if there is a failure.

Testing done:
* verified the issue is fixed