### PR TITLE
support return AD job when get detector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@
 
 buildscript {
     ext {
-        es_mv = '7.2'
         es_group = "org.elasticsearch"
         es_version = '7.4.2'
         es_distribution = 'oss-zip'

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -69,7 +69,6 @@ public class AnomalyDetector implements ToXContentObject {
     private static final String WINDOW_DELAY_FIELD = "window_delay";
     private static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
     public static final String UI_METADATA_FIELD = "ui_metadata";
-    public static final String ENABLED_FIELD = "enabled";
 
     private final String detectorId;
     private final Long version;
@@ -161,9 +160,6 @@ public class AnomalyDetector implements ToXContentObject {
             .field(DETECTION_INTERVAL_FIELD, detectionInterval)
             .field(WINDOW_DELAY_FIELD, windowDelay)
             .field(SCHEMA_VERSION_FIELD, schemaVersion);
-        if (params.param(ENABLED_FIELD) != null) {
-            xContentBuilder.field(ENABLED_FIELD, params.paramAsBoolean(ENABLED_FIELD, false));
-        }
 
         if (uiMetadata != null && !uiMetadata.isEmpty()) {
             xContentBuilder.field(UI_METADATA_FIELD, uiMetadata);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorJob.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorJob.java
@@ -43,11 +43,13 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
     private static final String SCHEDULE_FIELD = "schedule";
     private static final String IS_ENABLED_FIELD = "enabled";
     private static final String ENABLED_TIME_FIELD = "enabled_time";
+    private static final String DISABLED_TIME_FIELD = "disabled_time";
 
     private final String name;
     private final Schedule schedule;
     private final Boolean isEnabled;
     private final Instant enabledTime;
+    private final Instant disabledTime;
     private final Instant lastUpdateTime;
     private final Long lockDurationSeconds;
 
@@ -56,6 +58,7 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
         Schedule schedule,
         Boolean isEnabled,
         Instant enabledTime,
+        Instant disabledTime,
         Instant lastUpdateTime,
         Long lockDurationSeconds
     ) {
@@ -63,6 +66,7 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
         this.schedule = schedule;
         this.isEnabled = isEnabled;
         this.enabledTime = enabledTime;
+        this.disabledTime = disabledTime;
         this.lastUpdateTime = lastUpdateTime;
         this.lockDurationSeconds = lockDurationSeconds;
     }
@@ -77,6 +81,9 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
             .field(ENABLED_TIME_FIELD, enabledTime.toEpochMilli())
             .field(LAST_UPDATE_TIME_FIELD, lastUpdateTime.toEpochMilli())
             .field(LOCK_DURATION_SECONDS, lockDurationSeconds);
+        if (disabledTime != null) {
+            xContentBuilder.field(DISABLED_TIME_FIELD, disabledTime.toEpochMilli());
+        }
         return xContentBuilder.endObject();
     }
 
@@ -85,6 +92,7 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
         Schedule schedule = null;
         Boolean isEnabled = null;
         Instant enabledTime = null;
+        Instant disabledTime = null;
         Instant lastUpdateTime = null;
         Long lockDurationSeconds = DEFAULT_AD_JOB_LOC_DURATION_SECONDS;
 
@@ -106,6 +114,9 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
                 case ENABLED_TIME_FIELD:
                     enabledTime = ParseUtils.toInstant(parser);
                     break;
+                case DISABLED_TIME_FIELD:
+                    disabledTime = ParseUtils.toInstant(parser);
+                    break;
                 case LAST_UPDATE_TIME_FIELD:
                     lastUpdateTime = ParseUtils.toInstant(parser);
                     break;
@@ -117,7 +128,7 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
                     break;
             }
         }
-        return new AnomalyDetectorJob(name, schedule, isEnabled, enabledTime, lastUpdateTime, lockDurationSeconds);
+        return new AnomalyDetectorJob(name, schedule, isEnabled, enabledTime, disabledTime, lastUpdateTime, lockDurationSeconds);
     }
 
     @Override
@@ -131,6 +142,7 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
             && Objects.equal(getSchedule(), that.getSchedule())
             && Objects.equal(isEnabled(), that.isEnabled())
             && Objects.equal(getEnabledTime(), that.getEnabledTime())
+            && Objects.equal(getDisabledTime(), that.getDisabledTime())
             && Objects.equal(getLastUpdateTime(), that.getLastUpdateTime())
             && Objects.equal(getLockDurationSeconds(), that.getLockDurationSeconds());
     }
@@ -158,6 +170,10 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
     @Override
     public Instant getEnabledTime() {
         return enabledTime;
+    }
+
+    public Instant getDisabledTime() {
+        return disabledTime;
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestAnomalyDetectorJobAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestAnomalyDetectorJobAction.java
@@ -110,9 +110,9 @@ public class RestAnomalyDetectorJobAction extends BaseRestHandler {
             String rawPath = request.rawPath();
 
             if (rawPath.endsWith(START_JOB)) {
-                handler.createAnomalyDetectorJob();
+                handler.startAnomalyDetectorJob();
             } else if (rawPath.endsWith(STOP_JOB)) {
-                handler.deleteAnomalyDetectorJob(detectorId);
+                handler.stopAnomalyDetectorJob(detectorId);
             }
         };
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestDeleteAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestDeleteAnomalyDetectorAction.java
@@ -16,15 +16,20 @@
 package com.amazon.opendistroforelasticsearch.ad.rest;
 
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.rest.handler.AnomalyDetectorActionHandler;
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -69,8 +74,38 @@ public class RestDeleteAnomalyDetectorAction extends BaseRestHandler {
         return channel -> {
             logger.info("Delete anomaly detector {}", detectorId);
             handler
-                .getDetectorJob(clusterService, client, detectorId, channel, () -> deleteAnomalyDetectorDoc(client, detectorId, channel));
+                .getDetectorJob(
+                    clusterService,
+                    client,
+                    detectorId,
+                    channel,
+                    () -> deleteAnomalyDetectorJobDoc(client, detectorId, channel)
+                );
         };
+    }
+
+    private void deleteAnomalyDetectorJobDoc(NodeClient client, String detectorId, RestChannel channel) {
+        logger.info("Delete anomaly detector job {}", detectorId);
+        DeleteRequest deleteRequest = new DeleteRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, detectorId)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client.delete(deleteRequest, ActionListener.wrap(response -> {
+            if (response.getResult() == DocWriteResponse.Result.DELETED || response.getResult() == DocWriteResponse.Result.NOT_FOUND) {
+                deleteAnomalyDetectorDoc(client, detectorId, channel);
+            } else {
+                logger.error("Fail to delete anomaly detector job {}", detectorId);
+            }
+        }, exception -> {
+            if (exception instanceof IndexNotFoundException) {
+                deleteAnomalyDetectorDoc(client, detectorId, channel);
+            } else {
+                logger.error("Failed to delete anomaly detector job", exception);
+                try {
+                    channel.sendResponse(new BytesRestResponse(channel, exception));
+                } catch (IOException e) {
+                    logger.error("Failed to send response of delete anomaly detector job exception", e);
+                }
+            }
+        }));
     }
 
     private void deleteAnomalyDetectorDoc(NodeClient client, String detectorId, RestChannel channel) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -16,9 +16,9 @@
 package com.amazon.opendistroforelasticsearch.ad.rest;
 
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
-import com.google.common.collect.ImmutableMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -27,12 +27,8 @@ import org.elasticsearch.action.get.MultiGetItemResponse;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.client.node.NodeClient;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
@@ -47,9 +43,9 @@ import java.io.IOException;
 import java.util.Locale;
 
 import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
-import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ENABLED_FIELD;
 import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.DETECTOR_ID;
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.createXContentParser;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
@@ -74,26 +70,31 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         String detectorId = request.param(DETECTOR_ID);
+        boolean returnJob = request.paramAsBoolean("job", false);
         MultiGetRequest.Item adItem = new MultiGetRequest.Item(ANOMALY_DETECTORS_INDEX, detectorId)
             .version(RestActions.parseVersion(request));
-        MultiGetRequest.Item adJobItem = new MultiGetRequest.Item(ANOMALY_DETECTOR_JOB_INDEX, detectorId)
-            .version(RestActions.parseVersion(request));
-        MultiGetRequest multiGetRequest = new MultiGetRequest().add(adItem).add(adJobItem);
-        return channel -> client.multiGet(multiGetRequest, onMultiGetResponse(channel));
+        MultiGetRequest multiGetRequest = new MultiGetRequest().add(adItem);
+        if (returnJob) {
+            MultiGetRequest.Item adJobItem = new MultiGetRequest.Item(ANOMALY_DETECTOR_JOB_INDEX, detectorId)
+                .version(RestActions.parseVersion(request));
+            multiGetRequest.add(adJobItem);
+        }
+
+        return channel -> client.multiGet(multiGetRequest, onMultiGetResponse(channel, returnJob, detectorId));
     }
 
-    private ActionListener<MultiGetResponse> onMultiGetResponse(RestChannel channel) {
+    private ActionListener<MultiGetResponse> onMultiGetResponse(RestChannel channel, boolean returnJob, String detectorId) {
         return new RestResponseListener<MultiGetResponse>(channel) {
             @Override
             public RestResponse buildResponse(MultiGetResponse multiGetResponse) throws Exception {
                 MultiGetItemResponse[] responses = multiGetResponse.getResponses();
-                AnomalyDetector detector = null;
                 XContentBuilder builder = null;
-                Boolean adJobEnabled = false;
+                AnomalyDetector detector = null;
+                AnomalyDetectorJob adJob = null;
                 for (MultiGetItemResponse response : responses) {
                     if (ANOMALY_DETECTORS_INDEX.equals(response.getIndex())) {
-                        if (!response.getResponse().isExists()) {
-                            return new BytesRestResponse(RestStatus.NOT_FOUND, channel.newBuilder());
+                        if (response.getResponse() == null || !response.getResponse().isExists()) {
+                            return new BytesRestResponse(RestStatus.NOT_FOUND, "Can't find detector with id: " + detectorId);
                         }
                         builder = channel
                             .newBuilder()
@@ -103,33 +104,44 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
                             .field(RestHandlerUtils._PRIMARY_TERM, response.getResponse().getPrimaryTerm())
                             .field(RestHandlerUtils._SEQ_NO, response.getResponse().getSeqNo());
                         if (!response.getResponse().isSourceEmpty()) {
-                            XContentParser parser = XContentHelper
-                                .createParser(
-                                    channel.request().getXContentRegistry(),
-                                    LoggingDeprecationHandler.INSTANCE,
-                                    response.getResponse().getSourceAsBytesRef(),
-                                    XContentType.JSON
-                                );
-                            try {
+                            try (
+                                XContentParser parser = RestHandlerUtils
+                                    .createXContentParser(channel, response.getResponse().getSourceAsBytesRef())
+                            ) {
                                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
                                 detector = parser.namedObject(AnomalyDetector.class, AnomalyDetector.PARSE_FIELD_NAME, null);
                             } catch (Throwable t) {
                                 logger.error("Fail to parse detector", t);
-                                throw t;
-                            } finally {
-                                parser.close();
+                                return new BytesRestResponse(
+                                    RestStatus.INTERNAL_SERVER_ERROR,
+                                    "Failed to parse detector with id: " + detectorId
+                                );
                             }
                         }
                     }
 
                     if (ANOMALY_DETECTOR_JOB_INDEX.equals(response.getIndex())) {
-                        if (!response.isFailed() && response.getResponse().isExists()) {
-                            adJobEnabled = true;
+                        if (response.getResponse() != null
+                            && response.getResponse().isExists()
+                            && !response.getResponse().isSourceEmpty()) {
+                            try (XContentParser parser = createXContentParser(channel, response.getResponse().getSourceAsBytesRef())) {
+                                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+                                adJob = AnomalyDetectorJob.parse(parser);
+                            } catch (Throwable t) {
+                                logger.error("Fail to parse detector job ", t);
+                                return new BytesRestResponse(
+                                    RestStatus.INTERNAL_SERVER_ERROR,
+                                    "Failed to parse detector job with id: " + detectorId
+                                );
+                            }
                         }
                     }
                 }
-                ToXContent.Params params = new ToXContent.MapParams(ImmutableMap.of(ENABLED_FIELD, adJobEnabled.toString()));
-                builder.field(RestHandlerUtils.ANOMALY_DETECTOR, detector, params);
+
+                builder.field(RestHandlerUtils.ANOMALY_DETECTOR, detector);
+                if (returnJob) {
+                    builder.field(RestHandlerUtils.ANOMALY_DETECTOR_JOB, adJob);
+                }
                 builder.endObject();
                 return new BytesRestResponse(RestStatus.OK, builder);
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/AnomalyDetectorFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/AnomalyDetectorFunction.java
@@ -20,6 +20,8 @@ public interface AnomalyDetectorFunction {
 
     /**
      * Performs this operation.
+     *
+     * Notes: don't forget to send back response via channel if you process response with this method.
      */
     void execute();
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
@@ -232,6 +232,7 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
     private void onIndexAnomalyDetectorJobResponse(IndexResponse response, AnomalyDetectorFunction function) throws IOException {
         if (response.getShardInfo().getSuccessful() < 1) {
             channel.sendResponse(new BytesRestResponse(response.status(), response.toXContent(channel.newErrorBuilder(), EMPTY_PARAMS)));
+            return;
         }
         if (function != null) {
             function.execute();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
@@ -15,7 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.ad.rest.handler;
 
-import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
@@ -29,9 +28,7 @@ import com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule.Schedule;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
@@ -40,23 +37,19 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.BytesRestResponse;
 import org.elasticsearch.rest.RestChannel;
-import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.rest.action.RestResponseListener;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Locale;
 
 import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.createXContentParser;
 import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -110,11 +103,13 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
     }
 
     /**
-     * Create anomaly detector job.
+     * Start anomaly detector job.
+     * 1.If job not exists, create new job.
+     * 2.If job exists: a). if job enabled, return error message; b). if job disabled, enable job.
      *
      * @throws IOException IOException from {@link AnomalyDetectionIndices#getAnomalyDetectorJobMappings}
      */
-    public void createAnomalyDetectorJob() throws IOException {
+    public void startAnomalyDetectorJob() throws IOException {
         if (!anomalyDetectionIndices.doesAnomalyDetectorJobIndexExist()) {
             anomalyDetectionIndices
                 .initAnomalyDetectorJobIndex(
@@ -122,6 +117,19 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
                 );
         } else {
             prepareAnomalyDetectorJobIndexing();
+        }
+    }
+
+    private void onCreateMappingsResponse(CreateIndexResponse response) throws IOException {
+        if (response.isAcknowledged()) {
+            logger.info("Created {} with mappings.", ANOMALY_DETECTORS_INDEX);
+            prepareAnomalyDetectorJobIndexing();
+        } else {
+            logger.warn("Created {} with mappings call not acknowledged.", ANOMALY_DETECTORS_INDEX);
+            channel
+                .sendResponse(
+                    new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, response.toXContent(channel.newErrorBuilder(), EMPTY_PARAMS))
+                );
         }
     }
 
@@ -140,147 +148,154 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
             channel.sendResponse(new BytesRestResponse(RestStatus.NOT_FOUND, response.toXContent(builder, EMPTY_PARAMS)));
             return;
         }
-        XContentParser parser = XContentType.JSON
-            .xContent()
-            .createParser(
-                channel.request().getXContentRegistry(),
-                LoggingDeprecationHandler.INSTANCE,
-                response.getSourceAsBytesRef().streamInput()
+        try (XContentParser parser = RestHandlerUtils.createXContentParser(channel, response.getSourceAsBytesRef())) {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+            AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
+
+            IntervalTimeConfiguration interval = (IntervalTimeConfiguration) detector.getDetectionInterval();
+            Schedule schedule = new IntervalSchedule(Instant.now(), (int) interval.getInterval(), interval.getUnit());
+            Duration duration = Duration.of(interval.getInterval(), interval.getUnit());
+
+            AnomalyDetectorJob job = new AnomalyDetectorJob(
+                detector.getDetectorId(),
+                schedule,
+                true,
+                Instant.now(),
+                null,
+                Instant.now(),
+                duration.getSeconds()
             );
 
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
-        AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
-
-        IntervalTimeConfiguration interval = (IntervalTimeConfiguration) detector.getDetectionInterval();
-        Schedule schedule = new IntervalSchedule(Instant.now(), (int) interval.getInterval(), interval.getUnit());
-        Duration duration = Duration.of(interval.getInterval(), interval.getUnit());
-        AnomalyDetectorJob job = new AnomalyDetectorJob(
-            detector.getDetectorId(),
-            schedule,
-            true,
-            Instant.now(),
-            Instant.now(),
-            duration.getSeconds()
-        );
-
-        getAnomalyDetectorJob(job);
-    }
-
-    private void getAnomalyDetectorJob(AnomalyDetectorJob job) {
-        GetRequest getRequest = new GetRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX).id(detectorId);
-
-        client.get(getRequest, ActionListener.wrap(response -> onGetAnomalyDetectorJob(response, job), exception -> onFailure(exception)));
-    }
-
-    private void onGetAnomalyDetectorJob(GetResponse response, AnomalyDetectorJob job) throws IOException {
-        if (response.isExists()) {
-            XContentBuilder builder = channel
-                .newErrorBuilder()
-                .startObject()
-                .field("Message", "AnomalyDetectorJob exists: " + detectorId)
-                .endObject();
-            channel.sendResponse(new BytesRestResponse(RestStatus.NOT_FOUND, response.toXContent(builder, EMPTY_PARAMS)));
-            return;
-        }
-
-        indexAnomalyDetectorJob(job);
-    }
-
-    private void indexAnomalyDetectorJob(AnomalyDetectorJob job) throws IOException {
-        IndexRequest indexRequest = new IndexRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)
-            .setRefreshPolicy(refreshPolicy)
-            .source(job.toXContent(channel.newBuilder(), XCONTENT_WITH_TYPE))
-            .setIfSeqNo(seqNo)
-            .setIfPrimaryTerm(primaryTerm)
-            .timeout(requestTimeout)
-            .id(detectorId);
-        client.index(indexRequest, indexAnomalyDetectorJobResponse());
-    }
-
-    private ActionListener<IndexResponse> indexAnomalyDetectorJobResponse() {
-        return new RestResponseListener<IndexResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(IndexResponse response) throws Exception {
-                if (response.getShardInfo().getSuccessful() < 1) {
-                    return new BytesRestResponse(response.status(), response.toXContent(channel.newErrorBuilder(), EMPTY_PARAMS));
-                }
-
-                XContentBuilder builder = channel
-                    .newBuilder()
-                    .startObject()
-                    .field(RestHandlerUtils._ID, response.getId())
-                    .field(RestHandlerUtils._VERSION, response.getVersion())
-                    .field(RestHandlerUtils._SEQ_NO, response.getSeqNo())
-                    .field(RestHandlerUtils._PRIMARY_TERM, response.getPrimaryTerm())
-                    .endObject();
-
-                BytesRestResponse restResponse = new BytesRestResponse(response.status(), builder);
-                if (response.status() == RestStatus.CREATED) {
-                    String location = String.format(Locale.ROOT, "%s/%s", AnomalyDetectorPlugin.AD_BASE_URI, response.getId());
-                    restResponse.addHeader("Location", location);
-                }
-                return restResponse;
-            }
-        };
-    }
-
-    private void onCreateMappingsResponse(CreateIndexResponse response) throws IOException {
-        if (response.isAcknowledged()) {
-            logger.info("Created {} with mappings.", ANOMALY_DETECTORS_INDEX);
-            prepareAnomalyDetectorJobIndexing();
-        } else {
-            logger.warn("Created {} with mappings call not acknowledged.", ANOMALY_DETECTORS_INDEX);
-            channel
-                .sendResponse(
-                    new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, response.toXContent(channel.newErrorBuilder(), EMPTY_PARAMS))
-                );
+            getAnomalyDetectorJobForWrite(job);
+        } catch (IOException e) {
+            String message = "Failed to parse anomaly detector job " + detectorId;
+            logger.error(message, e);
+            channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, message));
         }
     }
 
-    /**
-     * Delete anomaly detector job
-     * @param detectorId detector identifier
-     */
-    public void deleteAnomalyDetectorJob(String detectorId) {
+    private void getAnomalyDetectorJobForWrite(AnomalyDetectorJob job) {
         GetRequest getRequest = new GetRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX).id(detectorId);
 
         client
             .get(
                 getRequest,
-                ActionListener
-                    .wrap(
-                        response -> deleteAnomalyDetectorJobDoc(client, detectorId, channel, refreshPolicy),
-                        exception -> onFailure(exception)
-                    )
+                ActionListener.wrap(response -> onGetAnomalyDetectorJobForWrite(response, job), exception -> onFailure(exception))
             );
     }
 
-    private void deleteAnomalyDetectorJobDoc(
-        NodeClient client,
-        String detectorId,
-        RestChannel channel,
-        WriteRequest.RefreshPolicy refreshPolicy
-    ) {
-        logger.info("Delete anomaly detector job {}", detectorId);
-        DeleteRequest deleteRequest = new DeleteRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, detectorId)
-            .setRefreshPolicy(refreshPolicy);
-        client.delete(deleteRequest, ActionListener.wrap(response -> {
-            if (response.getResult() == DocWriteResponse.Result.DELETED) {
-                logger.info("Stop anomaly detector {}", detectorId);
-                StopDetectorRequest stopDetectorRequest = new StopDetectorRequest(detectorId);
-                client.execute(StopDetectorAction.INSTANCE, stopDetectorRequest, stopAdDetectorListener(channel, detectorId));
-            } else if (response.getResult() == DocWriteResponse.Result.NOT_FOUND) {
-                logger.info("Anomaly detector job not found: {}", detectorId);
-                StopDetectorRequest stopDetectorRequest = new StopDetectorRequest(detectorId);
-                client.execute(StopDetectorAction.INSTANCE, stopDetectorRequest, stopAdDetectorListener(channel, detectorId));
-            } else {
-                channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "Failed to stop AD job " + detectorId));
+    private void onGetAnomalyDetectorJobForWrite(GetResponse response, AnomalyDetectorJob job) throws IOException {
+        if (response.isExists()) {
+            try (XContentParser parser = createXContentParser(channel, response.getSourceAsBytesRef())) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+                AnomalyDetectorJob currentAdJob = AnomalyDetectorJob.parse(parser);
+                if (currentAdJob.isEnabled()) {
+                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, "Anomaly detector job is already running: " + detectorId));
+                    return;
+                } else {
+                    AnomalyDetectorJob newJob = new AnomalyDetectorJob(
+                        job.getName(),
+                        job.getSchedule(),
+                        job.isEnabled(),
+                        Instant.now(),
+                        currentAdJob.getDisabledTime(),
+                        Instant.now(),
+                        job.getLockDurationSeconds()
+                    );
+                    indexAnomalyDetectorJob(newJob, null);
+                }
+            } catch (IOException e) {
+                String message = "Failed to parse anomaly detector job " + job.getName();
+                logger.error(message, e);
+                channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, message));
             }
-        }, exception -> {
-            logger.error("Failed to stop AD job " + detectorId, exception);
-            onFailure(exception);
-        }));
+        } else {
+            indexAnomalyDetectorJob(job, null);
+        }
+    }
 
+    private void indexAnomalyDetectorJob(AnomalyDetectorJob job, AnomalyDetectorFunction function) throws IOException {
+        IndexRequest indexRequest = new IndexRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .source(job.toXContent(channel.newBuilder(), XCONTENT_WITH_TYPE))
+            .setIfSeqNo(seqNo)
+            .setIfPrimaryTerm(primaryTerm)
+            .timeout(requestTimeout)
+            .id(detectorId);
+        client
+            .index(
+                indexRequest,
+                ActionListener.wrap(response -> onIndexAnomalyDetectorJobResponse(response, function), exception -> onFailure(exception))
+            );
+    }
+
+    private void onIndexAnomalyDetectorJobResponse(IndexResponse response, AnomalyDetectorFunction function) throws IOException {
+        if (response.getShardInfo().getSuccessful() < 1) {
+            channel.sendResponse(new BytesRestResponse(response.status(), response.toXContent(channel.newErrorBuilder(), EMPTY_PARAMS)));
+        }
+        if (function != null) {
+            function.execute();
+        } else {
+            XContentBuilder builder = channel
+                .newBuilder()
+                .startObject()
+                .field(RestHandlerUtils._ID, response.getId())
+                .field(RestHandlerUtils._VERSION, response.getVersion())
+                .field(RestHandlerUtils._SEQ_NO, response.getSeqNo())
+                .field(RestHandlerUtils._PRIMARY_TERM, response.getPrimaryTerm())
+                .endObject();
+            channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+        }
+    }
+
+    /**
+     * Stop anomaly detector job.
+     * 1.If job not exists, return error message
+     * 2.If job exists: a).if job state is disabled, return error message; b).if job state is enabled, disable job.
+     *
+     * @param detectorId detector identifier
+     */
+    public void stopAnomalyDetectorJob(String detectorId) {
+        GetRequest getRequest = new GetRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX).id(detectorId);
+
+        client.get(getRequest, ActionListener.wrap(response -> {
+            if (response.isExists()) {
+                try (XContentParser parser = createXContentParser(channel, response.getSourceAsBytesRef())) {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+                    AnomalyDetectorJob job = AnomalyDetectorJob.parse(parser);
+                    if (!job.isEnabled()) {
+                        channel
+                            .sendResponse(new BytesRestResponse(RestStatus.OK, "Anomaly detector job is already stopped: " + detectorId));
+                        return;
+                    } else {
+                        AnomalyDetectorJob newJob = new AnomalyDetectorJob(
+                            job.getName(),
+                            job.getSchedule(),
+                            false,
+                            job.getEnabledTime(),
+                            Instant.now(),
+                            Instant.now(),
+                            job.getLockDurationSeconds()
+                        );
+                        indexAnomalyDetectorJob(
+                            newJob,
+                            () -> client
+                                .execute(
+                                    StopDetectorAction.INSTANCE,
+                                    new StopDetectorRequest(detectorId),
+                                    stopAdDetectorListener(channel, detectorId)
+                                )
+                        );
+                    }
+                } catch (IOException e) {
+                    String message = "Failed to parse anomaly detector job " + detectorId;
+                    logger.error(message, e);
+                    channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, message));
+                }
+            } else {
+                channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "Anomaly detector job not exist: " + detectorId));
+            }
+        }, exception -> onFailure(exception)));
     }
 
     private ActionListener<StopDetectorResponse> stopAdDetectorListener(RestChannel channel, String detectorId) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
@@ -50,6 +50,8 @@ import java.time.Instant;
 import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.createXContentParser;
+import static org.elasticsearch.action.DocWriteResponse.Result.CREATED;
+import static org.elasticsearch.action.DocWriteResponse.Result.UPDATED;
 import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -230,7 +232,7 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
     }
 
     private void onIndexAnomalyDetectorJobResponse(IndexResponse response, AnomalyDetectorFunction function) throws IOException {
-        if (response.getShardInfo().getSuccessful() < 1) {
+        if (response == null || (response.getResult() != CREATED && response.getResult() != UPDATED)) {
             channel.sendResponse(new BytesRestResponse(response.status(), response.toXContent(channel.newErrorBuilder(), EMPTY_PARAMS)));
             return;
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtils.java
@@ -18,9 +18,17 @@ package com.amazon.opendistroforelasticsearch.ad.util;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.google.common.collect.ImmutableMap;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
+
+import java.io.IOException;
 
 /**
  * Utility functions for REST handlers.
@@ -36,6 +44,7 @@ public final class RestHandlerUtils {
     public static final String REFRESH = "refresh";
     public static final String DETECTOR_ID = "detectorID";
     public static final String ANOMALY_DETECTOR = "anomaly_detector";
+    public static final String ANOMALY_DETECTOR_JOB = "anomaly_detector_job";
     public static final String RUN = "_run";
     public static final String PREVIEW = "_preview";
     public static final String START_JOB = "_start";
@@ -61,5 +70,10 @@ public final class RestHandlerUtils {
         } else {
             return null;
         }
+    }
+
+    public static XContentParser createXContentParser(RestChannel channel, BytesReference bytesReference) throws IOException {
+        return XContentHelper
+            .createParser(channel.request().getXContentRegistry(), LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON);
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -256,6 +256,7 @@ public class TestHelpers {
             true,
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
             60L
         );
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtilsTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtilsTests.java
@@ -17,11 +17,20 @@ package com.amazon.opendistroforelasticsearch.ad.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
+
+import java.io.IOException;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.builder;
 
 public class RestHandlerUtilsTests extends ESTestCase {
 
@@ -38,4 +47,12 @@ public class RestHandlerUtilsTests extends ESTestCase {
         assertNull(context);
     }
 
+    public void testCreateXContentParser() throws IOException {
+        RestRequest request = new FakeRestRequest();
+        RestChannel channel = new FakeRestChannel(request, false, 1);
+        XContentBuilder builder = builder().startObject().field("test", "value").endObject();
+        BytesReference bytesReference = BytesReference.bytes(builder);
+        XContentParser parser = RestHandlerUtils.createXContentParser(channel, bytesReference);
+        parser.close();
+    }
 }


### PR DESCRIPTION
* Add job disabled time
* Support return AD job when get detector if set `?job=true`
* Tune start job logic: 
     1). If job not exists, create new job.
     2). If job exists: a). if job state is enabled, return warning message; b). if job state is disabled, enable job.
* Tune stop job logic:
     1). If job not exists, return error message
     2). If job exists: a).if job state is disabled, return warning message; b).if job state is enabled, disable job and stop AD model.
* Tune delete detector logic:
     1). If no AD job index or AD job not found or AD job is disabled, delete detector directly
     2). If AD job state is enabled, return warning message, not delete detector