### PR TITLE
Add threadpool prefix and change threadpool name

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunner.java
@@ -34,7 +34,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.ExecutorService;
 
-import static com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin.AD_JOB_THREAD_POOL_NAME;
+import static com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin.AD_THREAD_POOL_NAME;
 
 /**
  * JobScheduler will call AD job runner to get anomaly result periodically
@@ -102,7 +102,7 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
             }
         };
 
-        ExecutorService executor = threadPool.executor(AD_JOB_THREAD_POOL_NAME);
+        ExecutorService executor = threadPool.executor(AD_THREAD_POOL_NAME);
         executor.submit(runnable);
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -128,7 +128,7 @@ import com.amazon.opendistroforelasticsearch.ad.dataprocessor.LinearUniformInter
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.SingleFeatureLinearUniformInterpolator;
 import com.amazon.randomcutforest.serialize.RandomCutForestSerDe;
 
-import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.AD_JOB_THEAD_POOL_QUEUE_SIZE;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.AD_THEAD_POOL_QUEUE_SIZE;
 
 /**
  * Entry point of AD plugin.
@@ -137,7 +137,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
 
     public static final String AD_BASE_URI = "/_opendistro/_anomaly_detection";
     public static final String AD_BASE_DETECTORS_URI = AD_BASE_URI + "/detectors";
-    public static final String AD_JOB_THREAD_POOL_NAME = "ad-job";
+    public static final String AD_THREAD_POOL_NAME = "ad-threadpool";
     public static final String AD_JOB_TYPE = "opendistro_anomaly_detector";
     private static Gson gson;
     private AnomalyDetectionIndices anomalyDetectionIndices;
@@ -346,10 +346,10 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             .singletonList(
                 new FixedExecutorBuilder(
                     settings,
-                    AD_JOB_THREAD_POOL_NAME,
+                    AD_THREAD_POOL_NAME,
                     Math.max(1, EsExecutors.numberOfProcessors(settings) / 4),
-                    AD_JOB_THEAD_POOL_QUEUE_SIZE,
-                    null
+                    AD_THEAD_POOL_QUEUE_SIZE,
+                    "opendistro.ad.ad_thread_pool"
                 )
             );
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -349,7 +349,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                     AD_THREAD_POOL_NAME,
                     Math.max(1, EsExecutors.numberOfProcessors(settings) / 4),
                     AD_THEAD_POOL_QUEUE_SIZE,
-                    "opendistro.ad.ad_thread_pool"
+                    "opendistro.ad." + AD_THREAD_POOL_NAME
                 )
             );
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -187,5 +187,5 @@ public final class AnomalyDetectorSettings {
     public static final long DEFAULT_AD_JOB_LOC_DURATION_SECONDS = 60;
 
     // Thread pool
-    public static final int AD_JOB_THEAD_POOL_QUEUE_SIZE = 1000;
+    public static final int AD_THEAD_POOL_QUEUE_SIZE = 1000;
 }


### PR DESCRIPTION
When we run AD and SQL plugin together, ES fails to start with registering a setting twice error. AD's threadpool setting prefix is null. Since SQL plugin uses null as well, we would have a register setting conflict because we cannot register setting [null.size] twice. The fix is to give our threadpool a setting name prefix instead of null

Also, this threadpool would be used by other components besides AD job.  Rename it to make it not ad job specific.

Testing done:
- run all unit and integration tests
- ES can start with AD and SQL plugin enabled

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
