### PR TITLE
Improve log message when we cannot get anomaly result

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
@@ -793,7 +793,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                 } else if (failure.get() != null) {
                     listener.onFailure(failure.get());
                 } else {
-                    listener.onFailure(new InternalFailure(adID, "Unexpected exception"));
+                    listener.onFailure(new InternalFailure(adID, "Node connection problem or unexpected exception"));
                 }
             } catch (Exception ex) {
                 handleExecuteException(ex, listener, adID);


### PR DESCRIPTION
A connection request to a threshold model node can be rejected.  Previously, we count exceptions due to connection problem as "unexpected". But we should not as this might happen when the cluster is unstable.  This PR fixes the log message.

Testing:
- unit and integration test pass

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
