### PR TITLE
record error and execution start/end time in AD result; handle except…

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunner.java
@@ -231,7 +231,7 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
      *       know which exception is transient and retryable in
      *       {@link AnomalyResultTransportAction}. So we don't add backoff retry
      *       now to avoid bring extra load to cluster, expecially the code start
-     *       process is relatively heavey by sending out 24 queries, initializing
+     *       process is relatively heavy by sending out 24 queries, initializing
      *       models, and saving checkpoints.
      *       Sometimes missing anomaly and notification is not acceptable. For example,
      *       current detection interval is 1hour, and there should be anomaly in

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunner.java
@@ -15,26 +15,54 @@
 
 package com.amazon.opendistroforelasticsearch.ad;
 
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.InternalFailure;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.model.FeatureData;
+import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultRequest;
+import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultResponse;
+import com.amazon.opendistroforelasticsearch.ad.transport.handler.AnomalyResultHandler;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.JobExecutionContext;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.LockModel;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobParameter;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobRunner;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule.IntervalSchedule;
+import com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule.Schedule;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.utils.LockService;
+import com.google.common.base.Throwables;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.time.Duration;
+import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.concurrent.ExecutorService;
 
 import static com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin.AD_THREAD_POOL_NAME;
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
+import static org.elasticsearch.action.DocWriteResponse.Result.CREATED;
+import static org.elasticsearch.action.DocWriteResponse.Result.UPDATED;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * JobScheduler will call AD job runner to get anomaly result periodically
@@ -43,6 +71,8 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
     private static final Logger log = LogManager.getLogger(AnomalyDetectorJobRunner.class);
 
     private static AnomalyDetectorJobRunner INSTANCE;
+    private Settings settings;
+    private BackoffPolicy backoffPolicy;
 
     public static AnomalyDetectorJobRunner getJobRunnerInstance() {
         if (INSTANCE != null) {
@@ -59,6 +89,8 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
 
     private Client client;
     private ThreadPool threadPool;
+    private AnomalyResultHandler anomalyResultHandler;
+    private static final long JOB_RUN_BUFFER_IN_MILLISECONDS = 10 * 1000;
 
     private AnomalyDetectorJobRunner() {
         // Singleton class, use getJobRunnerInstance method instead of constructor
@@ -72,6 +104,23 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
         this.threadPool = threadPool;
     }
 
+    public void setAnomalyResultHandler(AnomalyResultHandler anomalyResultHandler) {
+        this.anomalyResultHandler = anomalyResultHandler;
+    }
+
+    public void setSettings(Settings settings) {
+        this.settings = settings;
+        this.backoffPolicy = BackoffPolicy
+            .exponentialBackoff(
+                AnomalyDetectorSettings.BACKOFF_INITIAL_DELAY.get(settings),
+                AnomalyDetectorSettings.MAX_RETRY_FOR_BACKOFF.get(settings)
+            );
+    }
+
+    public BackoffPolicy getBackoffPolicy() {
+        return this.backoffPolicy;
+    }
+
     @Override
     public void runJob(ScheduledJobParameter jobParameter, JobExecutionContext context) {
         log.info("Start to run AD job {}", jobParameter.getName());
@@ -80,6 +129,11 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
                 "Job parameter is not instance of AnomalyDetectorJob, type: " + jobParameter.getClass().getCanonicalName()
             );
         }
+
+        Instant executionStartTime = Instant.now();
+        IntervalSchedule schedule = (IntervalSchedule) jobParameter.getSchedule();
+        Instant endTime = Instant.now();
+        Instant startTime = endTime.minus(schedule.getInterval(), schedule.getUnit());
 
         final LockService lockService = context.getLockService();
 
@@ -91,8 +145,17 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
                         context,
                         ActionListener
                             .wrap(
-                                lock -> runAdJob(jobParameter, lockService, lock),
+                                lock -> runAdJob(
+                                    jobParameter,
+                                    lockService,
+                                    lock,
+                                    startTime,
+                                    endTime,
+                                    executionStartTime,
+                                    backoffPolicy.iterator()
+                                ),
                                 exception -> {
+                                    indexAnomalyResultExceptionSilently(jobParameter, startTime, endTime, executionStartTime, exception);
                                     throw new IllegalStateException("Failed to acquire lock for AD job: " + jobParameter.getName());
                                 }
                             )
@@ -106,33 +169,298 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
         executor.submit(runnable);
     }
 
-    protected void runAdJob(ScheduledJobParameter jobParameter, LockService lockService, LockModel lock) {
+    protected void runAdJob(
+        ScheduledJobParameter jobParameter,
+        LockService lockService,
+        LockModel lock,
+        Instant startTime,
+        Instant endTime,
+        Instant executionStartTime,
+        Iterator<TimeValue> backoff
+    ) {
+
         if (lock == null) {
+            indexAnomalyResultExceptionSilently(
+                jobParameter,
+                startTime,
+                endTime,
+                executionStartTime,
+                new AnomalyDetectionException(jobParameter.getName(), "Can't run AD job due to null lock")
+            );
             return;
         }
 
         try {
-            IntervalSchedule schedule = (IntervalSchedule) jobParameter.getSchedule();
-            // TODO: handle jitter of job scheduler
-            Instant endTime = Instant.now();
-            Duration duration = Duration.of(schedule.getInterval(), schedule.getUnit());
-            Instant startTime = endTime.minusMillis(duration.toMillis());
-
             AnomalyResultRequest request = new AnomalyResultRequest(
                 jobParameter.getName(),
                 startTime.toEpochMilli(),
                 endTime.toEpochMilli()
             );
-            client.execute(AnomalyResultAction.INSTANCE, request, ActionListener.wrap(response -> {
-                log.info("Anomaly result action ran successfully for " + jobParameter.getName());
-                releaseLock(jobParameter, lockService, lock);
-            }, exception -> {
-                log.error("Failed to execute anomaly result action", exception);
-                releaseLock(jobParameter, lockService, lock);
-            }));
+            client
+                .execute(
+                    AnomalyResultAction.INSTANCE,
+                    request,
+                    ActionListener
+                        .wrap(
+                            response -> {
+                                indexAnomalyResultSilently(
+                                    jobParameter,
+                                    lockService,
+                                    lock,
+                                    startTime,
+                                    endTime,
+                                    executionStartTime,
+                                    response
+                                );
+                            },
+                            exception -> {
+                                handleAdException(
+                                    jobParameter,
+                                    lockService,
+                                    lock,
+                                    startTime,
+                                    endTime,
+                                    executionStartTime,
+                                    backoff,
+                                    exception
+                                );
+                            }
+                        )
+                );
         } catch (Exception e) {
-            log.error("Failed to execute AD job", e);
+            indexAnomalyResultExceptionSilently(jobParameter, startTime, endTime, executionStartTime, e);
+            log.error("Failed to execute AD job " + jobParameter.getName(), e);
             releaseLock(jobParameter, lockService, lock);
+        }
+    }
+
+    protected void handleAdException(
+        ScheduledJobParameter jobParameter,
+        LockService lockService,
+        LockModel lock,
+        Instant startTime,
+        Instant endTime,
+        Instant executionStartTime,
+        Iterator<TimeValue> backoff,
+        Exception exception
+    ) {
+        if (exception instanceof EndRunException) {
+            log.error("EndRunException happened when executed anomaly result action for " + jobParameter.getName(), exception);
+
+            if (((EndRunException) exception).isEndNow()) {
+                // Stop AD job if EndRunException shows we should end job now.
+                stopAdJobSilently(jobParameter.getName());
+                indexAnomalyResultExceptionSilently(
+                    jobParameter,
+                    startTime,
+                    endTime,
+                    executionStartTime,
+                    "Stopped detector: " + exception.getMessage()
+                );
+                releaseLock(jobParameter, lockService, lock);
+            } else {
+                // retry AD job, if all retries failed or have no enough time to retry, will stop AD job.
+                Schedule schedule = jobParameter.getSchedule();
+                long nextExecutionTime = jobParameter.getSchedule().getNextExecutionTime(executionStartTime).toEpochMilli();
+                long now = Instant.now().toEpochMilli();
+                long leftTime = nextExecutionTime - now - JOB_RUN_BUFFER_IN_MILLISECONDS;
+                long usedTime = now - executionStartTime.toEpochMilli();
+
+                if (!backoff.hasNext()) {
+                    stopAdJobForEndRunException(
+                        jobParameter,
+                        lockService,
+                        lock,
+                        startTime,
+                        endTime,
+                        executionStartTime,
+                        (EndRunException) exception
+                    );
+                } else {
+                    if (backoff.hasNext()) {
+                        TimeValue nextRunDelay = backoff.next();
+                        if (leftTime > (usedTime + nextRunDelay.getMillis())) {
+                            threadPool
+                                .schedule(
+                                    () -> runAdJob(jobParameter, lockService, lock, startTime, endTime, executionStartTime, backoff),
+                                    nextRunDelay,
+                                    ThreadPool.Names.SAME
+                                );
+                        } else {
+                            stopAdJobForEndRunException(
+                                jobParameter,
+                                lockService,
+                                lock,
+                                startTime,
+                                endTime,
+                                executionStartTime,
+                                (EndRunException) exception
+                            );
+                        }
+                    }
+                }
+            }
+        } else {
+            if (exception instanceof InternalFailure) {
+                // AnomalyResultTransportAction already prints exception stack trace
+                log.error("InternalFailure happened when executed anomaly result action for " + jobParameter.getName());
+            } else {
+                log.error("Failed to execute anomaly result action for " + jobParameter.getName(), exception);
+            }
+            indexAnomalyResultExceptionSilently(jobParameter, startTime, endTime, executionStartTime, exception);
+            releaseLock(jobParameter, lockService, lock);
+        }
+    }
+
+    private void stopAdJobForEndRunException(
+        ScheduledJobParameter jobParameter,
+        LockService lockService,
+        LockModel lock,
+        Instant startTime,
+        Instant endTime,
+        Instant executionStartTime,
+        EndRunException exception
+    ) {
+        stopAdJobSilently(jobParameter.getName());
+        indexAnomalyResultExceptionSilently(
+            jobParameter,
+            startTime,
+            endTime,
+            executionStartTime,
+            "Stopped detector: " + exception.getMessage()
+        );
+        releaseLock(jobParameter, lockService, lock);
+    }
+
+    private void stopAdJobSilently(String detectorId) {
+        try {
+            GetRequest getRequest = new GetRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX).id(detectorId);
+
+            client.get(getRequest, ActionListener.wrap(response -> {
+                if (response.isExists()) {
+                    String s = response.getSourceAsString();
+                    try (
+                        XContentParser parser = XContentType.JSON
+                            .xContent()
+                            .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getSourceAsString())
+                    ) {
+                        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+                        AnomalyDetectorJob job = AnomalyDetectorJob.parse(parser);
+                        if (job.isEnabled()) {
+                            AnomalyDetectorJob newJob = new AnomalyDetectorJob(
+                                job.getName(),
+                                job.getSchedule(),
+                                job.getWindowDelay(),
+                                false,
+                                job.getEnabledTime(),
+                                Instant.now(),
+                                Instant.now(),
+                                job.getLockDurationSeconds()
+                            );
+                            IndexRequest indexRequest = new IndexRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)
+                                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                                .source(newJob.toXContent(XContentBuilder.builder(XContentType.JSON.xContent()), XCONTENT_WITH_TYPE))
+                                .id(detectorId);
+                            client.index(indexRequest, ActionListener.wrap(indexResponse -> {
+                                if (indexResponse != null
+                                    && (indexResponse.getResult() == CREATED || indexResponse.getResult() == UPDATED)) {
+                                    log.info("AD Job was disabled by JobRunner for " + detectorId);
+                                } else {
+                                    log.warn("Failed to disable AD job for " + detectorId);
+                                }
+                            }, exception -> log.error("JobRunner failed to update AD job as disabled for " + detectorId, exception)));
+                        }
+                    } catch (IOException e) {
+                        log.error("JobRunner failed to stop detector job " + detectorId, e);
+                    }
+                }
+            }, exception -> log.error("JobRunner failed to get detector job " + detectorId, exception)));
+        } catch (Exception e) {
+            log.error("JobRunner failed to stop AD job " + detectorId, e);
+        }
+    }
+
+    private void indexAnomalyResultSilently(
+        ScheduledJobParameter jobParameter,
+        LockService lockService,
+        LockModel lock,
+        Instant startTime,
+        Instant endTime,
+        Instant executionStartTime,
+        AnomalyResultResponse response
+    ) {
+        try {
+            IntervalTimeConfiguration windowDelay = (IntervalTimeConfiguration) ((AnomalyDetectorJob) jobParameter).getWindowDelay();
+            Instant dataStartTime = startTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
+            Instant dataEndTime = endTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
+
+            if (response.getError() != null) {
+                log.info("Anomaly result action run successfully for {} with error {}", jobParameter.getName(), response.getError());
+            }
+            AnomalyResult anomalyResult = new AnomalyResult(
+                jobParameter.getName(),
+                response.getAnomalyScore(),
+                response.getAnomalyGrade(),
+                response.getConfidence(),
+                response.getFeatures(),
+                dataStartTime,
+                dataEndTime,
+                executionStartTime,
+                Instant.now(),
+                response.getError()
+            );
+            anomalyResultHandler.indexAnomalyResult(anomalyResult);
+        } catch (Exception e) {
+            log.error("Failed to index anomaly result for " + jobParameter.getName(), e);
+        } finally {
+            releaseLock(jobParameter, lockService, lock);
+        }
+    }
+
+    private void indexAnomalyResultExceptionSilently(
+        ScheduledJobParameter jobParameter,
+        Instant startTime,
+        Instant endTime,
+        Instant executionStartTime,
+        Exception exception
+    ) {
+        try {
+            String errorMessage = exception instanceof AnomalyDetectionException
+                ? exception.getMessage()
+                : Throwables.getStackTraceAsString(exception);
+            indexAnomalyResultExceptionSilently(jobParameter, startTime, endTime, executionStartTime, errorMessage);
+        } catch (Exception e) {
+            log.error("Failed to index anomaly result for " + jobParameter.getName(), e);
+        }
+    }
+
+    private void indexAnomalyResultExceptionSilently(
+        ScheduledJobParameter jobParameter,
+        Instant startTime,
+        Instant endTime,
+        Instant executionStartTime,
+        String errorMessage
+    ) {
+        try {
+            IntervalTimeConfiguration windowDelay = (IntervalTimeConfiguration) ((AnomalyDetectorJob) jobParameter).getWindowDelay();
+            Instant dataStartTime = startTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
+            Instant dataEndTime = endTime.minus(windowDelay.getInterval(), windowDelay.getUnit());
+
+            AnomalyResult anomalyResult = new AnomalyResult(
+                jobParameter.getName(),
+                Double.NaN,
+                Double.NaN,
+                Double.NaN,
+                new ArrayList<FeatureData>(),
+                dataStartTime,
+                dataEndTime,
+                executionStartTime,
+                Instant.now(),
+                errorMessage
+            );
+            anomalyResultHandler.indexAnomalyResult(anomalyResult);
+        } catch (Exception e) {
+            log.error("Failed to index anomaly result for " + jobParameter.getName(), e);
         }
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -23,7 +23,10 @@ import com.amazon.opendistroforelasticsearch.ad.cluster.DeleteDetector;
 import com.amazon.opendistroforelasticsearch.ad.cluster.HashRing;
 import com.amazon.opendistroforelasticsearch.ad.cluster.MasterEventListener;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.dataprocessor.IntegerSensitiveSingleFeatureLinearUniformInterpolator;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.Interpolator;
+import com.amazon.opendistroforelasticsearch.ad.dataprocessor.LinearUniformInterpolator;
+import com.amazon.opendistroforelasticsearch.ad.dataprocessor.SingleFeatureLinearUniformInterpolator;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.feature.SearchFeatureDao;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
@@ -31,7 +34,6 @@ import com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao;
 import com.amazon.opendistroforelasticsearch.ad.ml.HybridThresholdingModel;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
-
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.rest.RestAnomalyDetectorJobAction;
@@ -43,10 +45,8 @@ import com.amazon.opendistroforelasticsearch.ad.rest.RestSearchAnomalyDetectorAc
 import com.amazon.opendistroforelasticsearch.ad.rest.RestSearchAnomalyResultAction;
 import com.amazon.opendistroforelasticsearch.ad.rest.RestStatsAnomalyDetectorAction;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
-
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStat;
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStats;
-
 import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.CounterSupplier;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.DocumentCountSupplier;
@@ -70,26 +70,17 @@ import com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorTransportA
 import com.amazon.opendistroforelasticsearch.ad.transport.ThresholdResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ThresholdResultTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.AnomalyResultHandler;
+import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
+import com.amazon.opendistroforelasticsearch.ad.util.ColdStartRunner;
 import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
+import com.amazon.opendistroforelasticsearch.ad.util.Throttler;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.JobSchedulerExtension;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobParser;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobRunner;
-import com.amazon.opendistroforelasticsearch.ad.util.Throttler;
+import com.amazon.randomcutforest.serialize.RandomCutForestSerDe;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.time.Clock;
-
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -123,12 +114,15 @@ import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
-import com.amazon.opendistroforelasticsearch.ad.util.ColdStartRunner;
-import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
-import com.amazon.opendistroforelasticsearch.ad.dataprocessor.IntegerSensitiveSingleFeatureLinearUniformInterpolator;
-import com.amazon.opendistroforelasticsearch.ad.dataprocessor.LinearUniformInterpolator;
-import com.amazon.opendistroforelasticsearch.ad.dataprocessor.SingleFeatureLinearUniformInterpolator;
-import com.amazon.randomcutforest.serialize.RandomCutForestSerDe;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.AD_THEAD_POOL_QUEUE_SIZE;
 
@@ -182,7 +176,6 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         jobRunner.setClient(client);
         jobRunner.setThreadPool(threadPool);
         jobRunner.setAnomalyResultHandler(anomalyResultHandler);
-        jobRunner.setDetectorEndRunExceptionCount(new ConcurrentHashMap<>());
         jobRunner.setSettings(settings);
 
         RestGetAnomalyDetectorAction restGetAnomalyDetectorAction = new RestGetAnomalyDetectorAction(restController);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -84,6 +84,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -181,6 +182,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         jobRunner.setClient(client);
         jobRunner.setThreadPool(threadPool);
         jobRunner.setAnomalyResultHandler(anomalyResultHandler);
+        jobRunner.setDetectorEndRunExceptionCount(new ConcurrentHashMap<>());
         jobRunner.setSettings(settings);
 
         RestGetAnomalyDetectorAction restGetAnomalyDetectorAction = new RestGetAnomalyDetectorAction(restController);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
@@ -114,7 +114,10 @@ public final class AnomalyDetectorRunner {
                         thresholdingResult.getConfidence(),
                         featureDatas,
                         Instant.ofEpochMilli(timeRange.getKey()),
-                        Instant.ofEpochMilli(timeRange.getValue())
+                        Instant.ofEpochMilli(timeRange.getValue()),
+                        null,
+                        null,
+                        null
                     );
                 } else {
                     result = new AnomalyResult(
@@ -124,7 +127,10 @@ public final class AnomalyDetectorRunner {
                         null,
                         featureDatas,
                         Instant.ofEpochMilli(timeRange.getKey()),
-                        Instant.ofEpochMilli(timeRange.getValue())
+                        Instant.ofEpochMilli(timeRange.getValue()),
+                        null,
+                        null,
+                        null
                     );
                 }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/cluster/DeleteDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/cluster/DeleteDetector.java
@@ -107,7 +107,7 @@ public class DeleteDetector {
                     .filter(QueryBuilders.termsQuery(AnomalyResult.DETECTOR_ID_FIELD, detectorID))
                     .filter(
                         QueryBuilders
-                            .rangeQuery(AnomalyResult.END_TIME_FIELD)
+                            .rangeQuery(AnomalyResult.DATA_END_TIME_FIELD)
                             .lte(deleteBeforeEpochMillis)
                             .format(CommonName.EPOCH_MILLIS_FORMAT)
                     )

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorJob.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorJob.java
@@ -41,12 +41,14 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
     public static final String LOCK_DURATION_SECONDS = "lock_duration_seconds";
 
     private static final String SCHEDULE_FIELD = "schedule";
+    private static final String WINDOW_DELAY_FIELD = "window_delay";
     private static final String IS_ENABLED_FIELD = "enabled";
     private static final String ENABLED_TIME_FIELD = "enabled_time";
     private static final String DISABLED_TIME_FIELD = "disabled_time";
 
     private final String name;
     private final Schedule schedule;
+    private final TimeConfiguration windowDelay;
     private final Boolean isEnabled;
     private final Instant enabledTime;
     private final Instant disabledTime;
@@ -56,6 +58,7 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
     public AnomalyDetectorJob(
         String name,
         Schedule schedule,
+        TimeConfiguration windowDelay,
         Boolean isEnabled,
         Instant enabledTime,
         Instant disabledTime,
@@ -64,6 +67,7 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
     ) {
         this.name = name;
         this.schedule = schedule;
+        this.windowDelay = windowDelay;
         this.isEnabled = isEnabled;
         this.enabledTime = enabledTime;
         this.disabledTime = disabledTime;
@@ -77,6 +81,7 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
             .startObject()
             .field(NAME_FIELD, name)
             .field(SCHEDULE_FIELD, schedule)
+            .field(WINDOW_DELAY_FIELD, windowDelay)
             .field(IS_ENABLED_FIELD, isEnabled)
             .field(ENABLED_TIME_FIELD, enabledTime.toEpochMilli())
             .field(LAST_UPDATE_TIME_FIELD, lastUpdateTime.toEpochMilli())
@@ -90,6 +95,7 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
     public static AnomalyDetectorJob parse(XContentParser parser) throws IOException {
         String name = null;
         Schedule schedule = null;
+        TimeConfiguration windowDelay = null;
         Boolean isEnabled = null;
         Instant enabledTime = null;
         Instant disabledTime = null;
@@ -107,6 +113,9 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
                     break;
                 case SCHEDULE_FIELD:
                     schedule = ScheduleParser.parse(parser);
+                    break;
+                case WINDOW_DELAY_FIELD:
+                    windowDelay = TimeConfiguration.parse(parser);
                     break;
                 case IS_ENABLED_FIELD:
                     isEnabled = parser.booleanValue();
@@ -128,7 +137,16 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
                     break;
             }
         }
-        return new AnomalyDetectorJob(name, schedule, isEnabled, enabledTime, disabledTime, lastUpdateTime, lockDurationSeconds);
+        return new AnomalyDetectorJob(
+            name,
+            schedule,
+            windowDelay,
+            isEnabled,
+            enabledTime,
+            disabledTime,
+            lastUpdateTime,
+            lockDurationSeconds
+        );
     }
 
     @Override
@@ -160,6 +178,10 @@ public class AnomalyDetectorJob implements ToXContentObject, ScheduledJobParamet
     @Override
     public Schedule getSchedule() {
         return schedule;
+    }
+
+    public TimeConfiguration getWindowDelay() {
+        return windowDelay;
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
@@ -42,16 +42,22 @@ public class AnomalyResult implements ToXContentObject {
     private static final String ANOMALY_GRADE_FIELD = "anomaly_grade";
     private static final String CONFIDENCE_FIELD = "confidence";
     private static final String FEATURE_DATA_FIELD = "feature_data";
-    private static final String START_TIME_FIELD = "start_time";
-    public static final String END_TIME_FIELD = "end_time";
+    private static final String DATA_START_TIME_FIELD = "data_start_time";
+    public static final String DATA_END_TIME_FIELD = "data_end_time";
+    private static final String EXECUTION_START_TIME_FIELD = "execution_start_time";
+    public static final String EXECUTION_END_TIME_FIELD = "execution_end_time";
+    public static final String ERROR_FIELD = "error";
 
     private final String detectorId;
     private final Double anomalyScore;
     private final Double anomalyGrade;
     private final Double confidence;
     private final List<FeatureData> featureData;
-    private final Instant startTime;
-    private final Instant endTime;
+    private final Instant dataStartTime;
+    private final Instant dataEndTime;
+    private final Instant executionStartTime;
+    private final Instant executionEndTime;
+    private final String error;
 
     public AnomalyResult(
         String detectorId,
@@ -59,16 +65,22 @@ public class AnomalyResult implements ToXContentObject {
         Double anomalyGrade,
         Double confidence,
         List<FeatureData> featureData,
-        Instant startTime,
-        Instant endTime
+        Instant dataStartTime,
+        Instant dataEndTime,
+        Instant executionStartTime,
+        Instant executionEndTime,
+        String error
     ) {
         this.detectorId = detectorId;
         this.anomalyScore = anomalyScore;
         this.anomalyGrade = anomalyGrade;
         this.confidence = confidence;
         this.featureData = featureData;
-        this.startTime = startTime;
-        this.endTime = endTime;
+        this.dataStartTime = dataStartTime;
+        this.dataEndTime = dataEndTime;
+        this.executionStartTime = executionStartTime;
+        this.executionEndTime = executionEndTime;
+        this.error = error;
     }
 
     @Override
@@ -76,12 +88,23 @@ public class AnomalyResult implements ToXContentObject {
         XContentBuilder xContentBuilder = builder
             .startObject()
             .field(DETECTOR_ID_FIELD, detectorId)
-            .field(ANOMALY_SCORE_FIELD, anomalyScore)
-            .field(ANOMALY_GRADE_FIELD, anomalyGrade)
-            .field(CONFIDENCE_FIELD, confidence)
             .field(FEATURE_DATA_FIELD, featureData.toArray())
-            .field(START_TIME_FIELD, startTime.toEpochMilli())
-            .field(END_TIME_FIELD, endTime.toEpochMilli());
+            .field(DATA_START_TIME_FIELD, dataStartTime.toEpochMilli())
+            .field(DATA_END_TIME_FIELD, dataEndTime.toEpochMilli())
+            .field(EXECUTION_START_TIME_FIELD, executionStartTime.toEpochMilli())
+            .field(EXECUTION_END_TIME_FIELD, executionEndTime.toEpochMilli());
+        if (anomalyScore != null && !anomalyScore.isNaN()) {
+            xContentBuilder.field(ANOMALY_SCORE_FIELD, anomalyScore);
+        }
+        if (anomalyGrade != null && !anomalyGrade.isNaN()) {
+            xContentBuilder.field(ANOMALY_GRADE_FIELD, anomalyGrade);
+        }
+        if (confidence != null && !confidence.isNaN()) {
+            xContentBuilder.field(CONFIDENCE_FIELD, confidence);
+        }
+        if (error != null) {
+            xContentBuilder.field(ERROR_FIELD, error);
+        }
         return xContentBuilder.endObject();
     }
 
@@ -91,8 +114,11 @@ public class AnomalyResult implements ToXContentObject {
         Double anomalyGrade = null;
         Double confidence = null;
         List<FeatureData> featureData = new ArrayList<>();
-        Instant startTime = null;
-        Instant endTime = null;
+        Instant dataStartTime = null;
+        Instant dataEndTime = null;
+        Instant executionStartTime = null;
+        Instant executionEndTime = null;
+        String error = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -118,18 +144,38 @@ public class AnomalyResult implements ToXContentObject {
                         featureData.add(FeatureData.parse(parser));
                     }
                     break;
-                case START_TIME_FIELD:
-                    startTime = ParseUtils.toInstant(parser);
+                case DATA_START_TIME_FIELD:
+                    dataStartTime = ParseUtils.toInstant(parser);
                     break;
-                case END_TIME_FIELD:
-                    endTime = ParseUtils.toInstant(parser);
+                case DATA_END_TIME_FIELD:
+                    dataEndTime = ParseUtils.toInstant(parser);
+                    break;
+                case EXECUTION_START_TIME_FIELD:
+                    executionStartTime = ParseUtils.toInstant(parser);
+                    break;
+                case EXECUTION_END_TIME_FIELD:
+                    executionEndTime = ParseUtils.toInstant(parser);
+                    break;
+                case ERROR_FIELD:
+                    error = parser.text();
                     break;
                 default:
                     parser.skipChildren();
                     break;
             }
         }
-        return new AnomalyResult(detectorId, anomalyScore, anomalyGrade, confidence, featureData, startTime, endTime);
+        return new AnomalyResult(
+            detectorId,
+            anomalyScore,
+            anomalyGrade,
+            confidence,
+            featureData,
+            dataStartTime,
+            dataEndTime,
+            executionStartTime,
+            executionEndTime,
+            error
+        );
     }
 
     @Generated
@@ -145,8 +191,11 @@ public class AnomalyResult implements ToXContentObject {
             && Objects.equal(getAnomalyGrade(), that.getAnomalyGrade())
             && Objects.equal(getConfidence(), that.getConfidence())
             && Objects.equal(getFeatureData(), that.getFeatureData())
-            && Objects.equal(getStartTime(), that.getStartTime())
-            && Objects.equal(getEndTime(), that.getEndTime());
+            && Objects.equal(getDataStartTime(), that.getDataStartTime())
+            && Objects.equal(getDataEndTime(), that.getDataEndTime())
+            && Objects.equal(getExecutionStartTime(), that.getExecutionStartTime())
+            && Objects.equal(getExecutionEndTime(), that.getExecutionEndTime())
+            && Objects.equal(getError(), that.getError());
     }
 
     @Generated
@@ -159,8 +208,11 @@ public class AnomalyResult implements ToXContentObject {
                 getAnomalyGrade(),
                 getConfidence(),
                 getFeatureData(),
-                getStartTime(),
-                getEndTime()
+                getDataStartTime(),
+                getDataEndTime(),
+                getExecutionStartTime(),
+                getExecutionEndTime(),
+                getError()
             );
     }
 
@@ -184,11 +236,23 @@ public class AnomalyResult implements ToXContentObject {
         return featureData;
     }
 
-    public Instant getStartTime() {
-        return startTime;
+    public Instant getDataStartTime() {
+        return dataStartTime;
     }
 
-    public Instant getEndTime() {
-        return endTime;
+    public Instant getDataEndTime() {
+        return dataEndTime;
+    }
+
+    public Instant getExecutionStartTime() {
+        return executionStartTime;
+    }
+
+    public Instant getExecutionEndTime() {
+        return executionEndTime;
+    }
+
+    public String getError() {
+        return error;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/AnomalyDetectorFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/AnomalyDetectorFunction.java
@@ -21,7 +21,7 @@ public interface AnomalyDetectorFunction {
     /**
      * Performs this operation.
      *
-     * Notes: don't forget to send back responds via channel if you process response with this method.
+     * Notes: don't forget to send back responses via channel if you process response with this method.
      */
     void execute();
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/AnomalyDetectorFunction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/AnomalyDetectorFunction.java
@@ -21,7 +21,7 @@ public interface AnomalyDetectorFunction {
     /**
      * Performs this operation.
      *
-     * Notes: don't forget to send back response via channel if you process response with this method.
+     * Notes: don't forget to send back responds via channel if you process response with this method.
      */
     void execute();
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
@@ -161,6 +161,7 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
             AnomalyDetectorJob job = new AnomalyDetectorJob(
                 detector.getDetectorId(),
                 schedule,
+                detector.getWindowDelay(),
                 true,
                 Instant.now(),
                 null,
@@ -198,6 +199,7 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
                     AnomalyDetectorJob newJob = new AnomalyDetectorJob(
                         job.getName(),
                         job.getSchedule(),
+                        job.getWindowDelay(),
                         job.isEnabled(),
                         Instant.now(),
                         currentAdJob.getDisabledTime(),
@@ -274,6 +276,7 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
                         AnomalyDetectorJob newJob = new AnomalyDetectorJob(
                             job.getName(),
                             job.getSchedule(),
+                            job.getWindowDelay(),
                             false,
                             job.getEnabledTime(),
                             Instant.now(),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -127,6 +127,15 @@ public final class AnomalyDetectorSettings {
     public static final Setting<Integer> MAX_RETRY_FOR_BACKOFF = Setting
         .intSetting("opendistro.anomaly_detection.max_retry_for_backoff", 3, 0, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
+    public static final Setting<Integer> MAX_RETRY_FOR_END_RUN_EXCEPTION = Setting
+        .intSetting(
+            "opendistro.anomaly_detection.max_retry_for_end_run_exception",
+            3,
+            0,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
     public static final String ANOMALY_DETECTORS_INDEX_MAPPING_FILE = "mappings/anomaly-detectors.json";
     public static final String ANOMALY_DETECTOR_JOBS_INDEX_MAPPING_FILE = "mappings/anomaly-detector-jobs.json";
     public static final String ANOMALY_RESULTS_INDEX_MAPPING_FILE = "mappings/anomaly-results.json";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
@@ -15,18 +15,13 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
-
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.time.Instant;
 
 import com.amazon.opendistroforelasticsearch.ad.breaker.ADCircuitBreakerService;
 import com.amazon.opendistroforelasticsearch.ad.cluster.HashRing;
@@ -44,28 +39,22 @@ import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.RcfResult;
 import com.amazon.opendistroforelasticsearch.ad.ml.rcf.CombinedRcfResult;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
-import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.model.FeatureData;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStats;
 import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
 import com.amazon.opendistroforelasticsearch.ad.util.ColdStartRunner;
-import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.bulk.BackoffPolicy;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -78,9 +67,6 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -97,12 +83,8 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         + " models are not ready or all nodes are unresponsive or the system might have bugs.";
     static final String WAIT_FOR_THRESHOLD_ERR_MSG = "Exception in waiting for threshold result";
     static final String NODE_UNRESPONSIVE_ERR_MSG = "Model node is unresponsive.  Mute model";
-    static final String FAIL_TO_SAVE_ERR_MSG = "Fail to save anomaly index: ";
-    static final String RETRY_SAVING_ERR_MSG = "Retry in saving anomaly index: ";
-    static final String SUCCESS_SAVING_MSG = "Success in saving anomaly index: ";
     static final String READ_WRITE_BLOCKED = "Cannot read/write due to global block.";
     static final String INDEX_READ_BLOCKED = "Cannot read user index due to read block.";
-    static final String CANNOT_SAVE_ERR_MSG = "Cannot save anomaly result due to write block.";
     static final String LIMIT_EXCEEDED_EXCEPTION_NAME_UNDERSCORE = ElasticsearchException
         .getExceptionName(new LimitExceededException("", ""));
     static final String RESOURCE_NOT_FOUND_EXCEPTION_NAME_UNDERSCORE = ElasticsearchException
@@ -270,10 +252,10 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                 .ofNullable((IntervalTimeConfiguration) anomalyDetector.getWindowDelay())
                 .map(t -> t.toDuration().toMillis())
                 .orElse(0L);
-            long startTime = request.getStart() - delayMillis;
-            long endTime = request.getEnd() - delayMillis;
+            long dataStartTime = request.getStart() - delayMillis;
+            long dataEndTime = request.getEnd() - delayMillis;
 
-            SinglePointFeatures featureOptional = featureManager.getCurrentFeatures(anomalyDetector, startTime, endTime);
+            SinglePointFeatures featureOptional = featureManager.getCurrentFeatures(anomalyDetector, dataStartTime, dataEndTime);
 
             List<FeatureData> featureInResponse = null;
 
@@ -287,10 +269,28 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                     // Feature not available is common when we have data holes. Respond empty response
                     // so that alerting will not print stack trace to avoid bloating our logs.
                     LOG.info("No data in current detection window for {}", adID);
-                    listener.onResponse(new AnomalyResultResponse(Double.NaN, Double.NaN, new ArrayList<FeatureData>()));
+                    listener
+                        .onResponse(
+                            new AnomalyResultResponse(
+                                Double.NaN,
+                                Double.NaN,
+                                Double.NaN,
+                                new ArrayList<FeatureData>(),
+                                "No data in current detection window"
+                            )
+                        );
                 } else {
                     LOG.info("Return at least current feature for {}", adID);
-                    listener.onResponse(new AnomalyResultResponse(Double.NaN, Double.NaN, featureInResponse));
+                    listener
+                        .onResponse(
+                            new AnomalyResultResponse(
+                                Double.NaN,
+                                Double.NaN,
+                                Double.NaN,
+                                featureInResponse,
+                                "No full shingle in current detection window"
+                            )
+                        );
                 }
                 return;
             }
@@ -331,8 +331,8 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                     thresholdModelID,
                     thresholdNode,
                     featureInResponse,
-                    startTime,
-                    endTime,
+                    dataStartTime,
+                    dataEndTime,
                     rcfPartitionNum,
                     responseCount,
                     adID
@@ -455,121 +455,6 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
             rcfResultLib.add(new RcfResult(result.getRCFScore(), result.getConfidence(), result.getForestSize()));
         }
         return modelManager.combineRcfResults(rcfResultLib);
-    }
-
-    CountDownLatch createCountDownLatch(int count) {
-        return new CountDownLatch(count);
-    }
-
-    /**
-     * Saves the result unless an exception is thrown. The anomaly result index is
-     * implicitly created if it does not exist.
-     *
-     * @param anomalyResult one anomaly result
-     */
-    void indexAnomalyResult(AnomalyResult anomalyResult) {
-        try {
-            if (checkIndicesBlocked(clusterService.state(), ClusterBlockLevel.WRITE, AnomalyResult.ANOMALY_RESULT_INDEX)) {
-                LOG.warn(CANNOT_SAVE_ERR_MSG);
-                return;
-            }
-            if (!anomalyDetectionIndices.doesAnomalyResultIndexExist()) {
-                anomalyDetectionIndices
-                    .initAnomalyResultIndex(
-                        ActionListener.wrap(initResponse -> onCreateAnomalyResultIndexResponse(initResponse, anomalyResult), exception -> {
-                            if (ExceptionsHelper.unwrapCause(exception) instanceof ResourceAlreadyExistsException) {
-                                // It is possible the index has been created while we sending the create request
-                                saveDetectorResult(anomalyResult);
-                            } else {
-                                throw new AnomalyDetectionException(
-                                    anomalyResult.getDetectorId(),
-                                    "Unexpected error creating anomaly result index",
-                                    exception
-                                );
-                            }
-                        })
-                    );
-            } else {
-                saveDetectorResult(anomalyResult);
-            }
-        } catch (Exception e) {
-            throw new AnomalyDetectionException(
-                anomalyResult.getDetectorId(),
-                String
-                    .format(
-                        Locale.ROOT,
-                        "Error in saving anomaly index for ID %s from %s to %s",
-                        anomalyResult.getDetectorId(),
-                        anomalyResult.getStartTime(),
-                        anomalyResult.getEndTime()
-                    )
-            );
-        }
-    }
-
-    private void onCreateAnomalyResultIndexResponse(CreateIndexResponse response, AnomalyResult anomalyResult) {
-        if (response.isAcknowledged()) {
-            saveDetectorResult(anomalyResult);
-        } else {
-            throw new AnomalyDetectionException(
-                anomalyResult.getDetectorId(),
-                "Creating anomaly result index with mappings call not acknowledged."
-            );
-        }
-    }
-
-    private void saveDetectorResult(AnomalyResult anomalyResult) {
-        try (XContentBuilder builder = jsonBuilder()) {
-            IndexRequest indexRequest = new IndexRequest(AnomalyResult.ANOMALY_RESULT_INDEX)
-                .source(anomalyResult.toXContent(builder, RestHandlerUtils.XCONTENT_WITH_TYPE));
-            saveDetectorResult(
-                indexRequest,
-                String
-                    .format(
-                        Locale.ROOT,
-                        "ID %s from %s to %s",
-                        anomalyResult.getDetectorId(),
-                        anomalyResult.getStartTime(),
-                        anomalyResult.getEndTime()
-                    ),
-                resultSavingBackoffPolicy.iterator()
-            );
-        } catch (Exception e) {
-            throw new AnomalyDetectionException(anomalyResult.getDetectorId(), "Cannot save result");
-        }
-    }
-
-    void saveDetectorResult(IndexRequest indexRequest, String context, Iterator<TimeValue> backoff) {
-        client
-            .index(
-                indexRequest,
-                ActionListener
-                    .<IndexResponse>wrap(
-                        response -> LOG.debug(SUCCESS_SAVING_MSG + context),
-                        exception -> {
-                            // Elasticsearch has a thread pool and a queue for write per node. A thread
-                            // pool will have N number of workers ready to handle the requests. When a
-                            // request comes and if a worker is free , this is handled by the worker. Now by
-                            // default the number of workers is equal to the number of cores on that CPU.
-                            // When the workers are full and there are more write requests, the request
-                            // will go to queue. The size of queue is also limited. If by default size is,
-                            // say, 200 and if there happens more parallel requests than this, then those
-                            // requests would be rejected as you can see EsRejectedExecutionException.
-                            // So EsRejectedExecutionException is the way that Elasticsearch tells us that
-                            // it cannot keep up with the current indexing rate.
-                            // When it happens, we should pause indexing a bit before trying again, ideally
-                            // with randomized exponential backoff.
-                            if (!(exception instanceof EsRejectedExecutionException) || !backoff.hasNext()) {
-                                LOG.error(FAIL_TO_SAVE_ERR_MSG + context);
-                            } else {
-                                TimeValue nextDelay = backoff.next();
-                                LOG.info(RETRY_SAVING_ERR_MSG + context);
-                                threadPool
-                                    .schedule(() -> saveDetectorResult(indexRequest, context, backoff), nextDelay, ThreadPool.Names.SAME);
-                            }
-                        }
-                    )
-            );
     }
 
     void handleExecuteException(Exception ex, ActionListener<AnomalyResultResponse> listener, String adID) {
@@ -747,7 +632,8 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         @Override
         public void onResponse(ThresholdResultResponse response) {
             try {
-                anomalyResultResponse.set(new AnomalyResultResponse(response.getAnomalyGrade(), response.getConfidence(), features));
+                anomalyResultResponse
+                    .set(new AnomalyResultResponse(response.getAnomalyGrade(), response.getConfidence(), Double.NaN, features));
                 stateManager.resetBackpressureCounter(thresholdNodeID);
             } catch (Exception ex) {
                 LOG.error("Unexpected exception: {} for {}", ex, adID);
@@ -777,19 +663,13 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                 if (anomalyResultResponse.get() != null) {
                     AnomalyResultResponse response = anomalyResultResponse.get();
                     double confidence = response.getConfidence() * combinedResult.getConfidence();
-                    response = new AnomalyResultResponse(response.getAnomalyGrade(), confidence, response.getFeatures());
-                    listener.onResponse(response);
-                    indexAnomalyResult(
-                        new AnomalyResult(
-                            adID,
-                            Double.valueOf(combinedResult.getScore()),
-                            Double.valueOf(response.getAnomalyGrade()),
-                            Double.valueOf(confidence),
-                            featureInResponse,
-                            Instant.ofEpochMilli(startTime),
-                            Instant.ofEpochMilli(endTime)
-                        )
+                    response = new AnomalyResultResponse(
+                        response.getAnomalyGrade(),
+                        confidence,
+                        combinedResult.getScore(),
+                        response.getFeatures()
                     );
+                    listener.onResponse(response);
                 } else if (failure.get() != null) {
                     listener.onFailure(failure.get());
                 } else {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandler.java
@@ -116,7 +116,8 @@ public class AnomalyResultHandler {
                         anomalyResult.getDetectorId(),
                         anomalyResult.getDataStartTime(),
                         anomalyResult.getDataEndTime()
-                    )
+                    ),
+                e
             );
         }
     }
@@ -165,7 +166,7 @@ public class AnomalyResultHandler {
                 resultSavingBackoffPolicy.iterator()
             );
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error("Failed to save anomaly result", e);
             throw new AnomalyDetectionException(anomalyResult.getDetectorId(), "Cannot save result");
         }
     }
@@ -191,10 +192,10 @@ public class AnomalyResultHandler {
                             // When it happens, we should pause indexing a bit before trying again, ideally
                             // with randomized exponential backoff.
                             if (!(exception instanceof EsRejectedExecutionException) || !backoff.hasNext()) {
-                                LOG.error(FAIL_TO_SAVE_ERR_MSG + context);
+                                LOG.error(FAIL_TO_SAVE_ERR_MSG + context, exception);
                             } else {
                                 TimeValue nextDelay = backoff.next();
-                                LOG.info(RETRY_SAVING_ERR_MSG + context);
+                                LOG.warn(RETRY_SAVING_ERR_MSG + context, exception);
                                 threadPool
                                     .schedule(() -> saveDetectorResult(indexRequest, context, backoff), nextDelay, ThreadPool.Names.SAME);
                             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandler.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport.handler;
+
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Iterator;
+import java.util.Locale;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+public class AnomalyResultHandler {
+    private static final Logger LOG = LogManager.getLogger(AnomalyResultHandler.class);
+
+    static final String CANNOT_SAVE_ERR_MSG = "Cannot save anomaly result due to write block.";
+    static final String FAIL_TO_SAVE_ERR_MSG = "Fail to save anomaly index: ";
+    static final String RETRY_SAVING_ERR_MSG = "Retry in saving anomaly index: ";
+    static final String SUCCESS_SAVING_MSG = "SSUCCESS_SAVING_MSGuccess in saving anomaly index: ";
+
+    private final Client client;
+    private final ClusterService clusterService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final AnomalyDetectionIndices anomalyDetectionIndices;
+    private final ThreadPool threadPool;
+    private final BackoffPolicy resultSavingBackoffPolicy;
+
+    public AnomalyResultHandler(
+        Client client,
+        Settings settings,
+        ClusterService clusterService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        AnomalyDetectionIndices anomalyDetectionIndices,
+        ThreadPool threadPool
+    ) {
+        this.client = client;
+        this.clusterService = clusterService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.anomalyDetectionIndices = anomalyDetectionIndices;
+        this.threadPool = threadPool;
+        this.resultSavingBackoffPolicy = BackoffPolicy
+            .exponentialBackoff(
+                AnomalyDetectorSettings.BACKOFF_INITIAL_DELAY.get(settings),
+                AnomalyDetectorSettings.MAX_RETRY_FOR_BACKOFF.get(settings)
+            );
+    }
+
+    public void indexAnomalyResult(AnomalyResult anomalyResult) {
+        try {
+            if (checkIndicesBlocked(clusterService.state(), ClusterBlockLevel.WRITE, AnomalyResult.ANOMALY_RESULT_INDEX)) {
+                LOG.warn(CANNOT_SAVE_ERR_MSG);
+                return;
+            }
+            if (!anomalyDetectionIndices.doesAnomalyResultIndexExist()) {
+                anomalyDetectionIndices
+                    .initAnomalyResultIndexDirectly(
+                        ActionListener.wrap(initResponse -> onCreateAnomalyResultIndexResponse(initResponse, anomalyResult), exception -> {
+                            if (ExceptionsHelper.unwrapCause(exception) instanceof ResourceAlreadyExistsException) {
+                                // It is possible the index has been created while we sending the create request
+                                saveDetectorResult(anomalyResult);
+                            } else {
+                                throw new AnomalyDetectionException(
+                                    anomalyResult.getDetectorId(),
+                                    "Unexpected error creating anomaly result index",
+                                    exception
+                                );
+                            }
+                        })
+                    );
+            } else {
+                saveDetectorResult(anomalyResult);
+            }
+        } catch (Exception e) {
+            throw new AnomalyDetectionException(
+                anomalyResult.getDetectorId(),
+                String
+                    .format(
+                        Locale.ROOT,
+                        "Error in saving anomaly index for ID %s from %s to %s",
+                        anomalyResult.getDetectorId(),
+                        anomalyResult.getDataStartTime(),
+                        anomalyResult.getDataEndTime()
+                    )
+            );
+        }
+    }
+
+    /**
+     * Similar to checkGlobalBlock, we check block on the indices level.
+     *
+     * @param state   Cluster state
+     * @param level   block level
+     * @param indices the indices on which to check block
+     * @return whether any of the index has block on the level.
+     */
+    private boolean checkIndicesBlocked(ClusterState state, ClusterBlockLevel level, String... indices) {
+        // the original index might be an index expression with wildcards like "log*",
+        // so we need to expand the expression to concrete index name
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(state, IndicesOptions.lenientExpandOpen(), indices);
+
+        return state.blocks().indicesBlockedException(level, concreteIndices) != null;
+    }
+
+    private void onCreateAnomalyResultIndexResponse(CreateIndexResponse response, AnomalyResult anomalyResult) {
+        if (response.isAcknowledged()) {
+            saveDetectorResult(anomalyResult);
+        } else {
+            throw new AnomalyDetectionException(
+                anomalyResult.getDetectorId(),
+                "Creating anomaly result index with mappings call not acknowledged."
+            );
+        }
+    }
+
+    private void saveDetectorResult(AnomalyResult anomalyResult) {
+        try (XContentBuilder builder = jsonBuilder()) {
+            IndexRequest indexRequest = new IndexRequest(AnomalyResult.ANOMALY_RESULT_INDEX)
+                .source(anomalyResult.toXContent(builder, RestHandlerUtils.XCONTENT_WITH_TYPE));
+            saveDetectorResult(
+                indexRequest,
+                String
+                    .format(
+                        Locale.ROOT,
+                        "ID %s from %s to %s",
+                        anomalyResult.getDetectorId(),
+                        anomalyResult.getDataStartTime(),
+                        anomalyResult.getDataEndTime()
+                    ),
+                resultSavingBackoffPolicy.iterator()
+            );
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new AnomalyDetectionException(anomalyResult.getDetectorId(), "Cannot save result");
+        }
+    }
+
+    void saveDetectorResult(IndexRequest indexRequest, String context, Iterator<TimeValue> backoff) {
+        client
+            .index(
+                indexRequest,
+                ActionListener
+                    .<IndexResponse>wrap(
+                        response -> LOG.debug(SUCCESS_SAVING_MSG + context),
+                        exception -> {
+                            // Elasticsearch has a thread pool and a queue for write per node. A thread
+                            // pool will have N number of workers ready to handle the requests. When a
+                            // request comes and if a worker is free , this is handled by the worker. Now by
+                            // default the number of workers is equal to the number of cores on that CPU.
+                            // When the workers are full and there are more write requests, the request
+                            // will go to queue. The size of queue is also limited. If by default size is,
+                            // say, 200 and if there happens more parallel requests than this, then those
+                            // requests would be rejected as you can see EsRejectedExecutionException.
+                            // So EsRejectedExecutionException is the way that Elasticsearch tells us that
+                            // it cannot keep up with the current indexing rate.
+                            // When it happens, we should pause indexing a bit before trying again, ideally
+                            // with randomized exponential backoff.
+                            if (!(exception instanceof EsRejectedExecutionException) || !backoff.hasNext()) {
+                                LOG.error(FAIL_TO_SAVE_ERR_MSG + context);
+                            } else {
+                                TimeValue nextDelay = backoff.next();
+                                LOG.info(RETRY_SAVING_ERR_MSG + context);
+                                threadPool
+                                    .schedule(() -> saveDetectorResult(indexRequest, context, backoff), nextDelay, ThreadPool.Names.SAME);
+                            }
+                        }
+                    )
+            );
+    }
+}

--- a/src/main/resources/mappings/anomaly-detector-jobs.json
+++ b/src/main/resources/mappings/anomaly-detector-jobs.json
@@ -21,6 +21,20 @@
         }
       }
     },
+    "window_delay": {
+      "properties": {
+        "period": {
+          "properties": {
+            "interval": {
+              "type": "integer"
+            },
+            "unit": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
     "enabled": {
       "type": "boolean"
     },

--- a/src/main/resources/mappings/anomaly-results.json
+++ b/src/main/resources/mappings/anomaly-results.json
@@ -30,11 +30,19 @@
         }
       }
     },
-    "start_time": {
+    "data_start_time": {
       "type": "date",
       "format": "strict_date_time||epoch_millis"
     },
-    "end_time": {
+    "data_end_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "execution_start_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "execution_end_time": {
       "type": "date",
       "format": "strict_date_time||epoch_millis"
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
@@ -57,7 +57,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -124,7 +123,6 @@ public class AnomalyDetectorJobRunnerTests extends AbstractADTest {
         runner.setThreadPool(mockedThreadPool);
         runner.setClient(client);
         runner.setAnomalyResultHandler(anomalyResultHandler);
-        runner.setDetectorEndRunExceptionCount(new ConcurrentHashMap<>());
 
         setUpJobParameter();
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -41,10 +41,17 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.CheckedConsumer;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -245,7 +252,10 @@ public class TestHelpers {
             randomDouble(),
             ImmutableList.of(randomFeatureData(), randomFeatureData()),
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
-            Instant.now().truncatedTo(ChronoUnit.SECONDS)
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            randomAlphaOfLength(5)
         );
     }
 
@@ -253,6 +263,7 @@ public class TestHelpers {
         return new AnomalyDetectorJob(
             randomAlphaOfLength(10),
             randomIntervalSchedule(),
+            randomIntervalTimeConfiguration(),
             true,
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
@@ -289,5 +300,31 @@ public class TestHelpers {
             Version.CURRENT
         );
         return ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings);
+    }
+
+    public static ClusterState createIndexBlockedState(String indexName, Settings hackedSettings, String alias) {
+        ClusterState blockedClusterState = null;
+        IndexMetaData.Builder builder = IndexMetaData.builder(indexName);
+        if (alias != null) {
+            builder.putAlias(AliasMetaData.builder(alias));
+        }
+        IndexMetaData indexMetaData = builder
+            .settings(
+                Settings
+                    .builder()
+                    .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
+                    .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(hackedSettings)
+            )
+            .build();
+        MetaData metaData = MetaData.builder().put(indexMetaData, false).build();
+        blockedClusterState = ClusterState
+            .builder(new ClusterName("test cluster"))
+            .metaData(metaData)
+            .blocks(ClusterBlocks.builder().addBlocks(indexMetaData))
+            .build();
+        return blockedClusterState;
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -329,6 +329,7 @@ public class TestHelpers {
             .blocks(ClusterBlocks.builder().addBlocks(indexMetaData))
             .build();
         return blockedClusterState;
+    }
 
     public static ThreadContext createThreadContext() {
         Settings build = Settings.builder().put("request.headers.default", "1").build();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.createIndexBlockedState;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.empty;
@@ -48,7 +49,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
@@ -56,7 +56,6 @@ import com.amazon.opendistroforelasticsearch.ad.breaker.ADCircuitBreakerService;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
-import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.cluster.HashRing;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.ClientException;
@@ -84,7 +83,6 @@ import com.amazon.opendistroforelasticsearch.ad.util.ColdStartRunner;
 import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
 import com.amazon.opendistroforelasticsearch.ad.util.Throttler;
 import org.elasticsearch.ElasticsearchTimeoutException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
@@ -96,20 +94,15 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
-import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.Index;
@@ -278,14 +271,14 @@ public class AnomalyResultTests extends AbstractADTest {
             });
 
             return null;
-        }).when(anomalyDetectionIndices).initAnomalyResultIndex(any());
+        }).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());
 
         when(anomalyDetectionIndices.doesAnomalyResultIndexExist()).thenReturn(anomalyResultIndexExists);
     }
 
     public void setupInitResultIndexException(Class<? extends Throwable> exceptionType) throws IOException {
         anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
-        doThrow(exceptionType).when(anomalyDetectionIndices).initAnomalyResultIndex(any());
+        doThrow(exceptionType).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());
 
         when(anomalyDetectionIndices.doesAnomalyResultIndexExist()).thenReturn(false);
     }
@@ -833,6 +826,7 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultResponse response = new AnomalyResultResponse(
             4,
             0.993,
+            1.01,
             Collections.singletonList(new FeatureData(featureId, featureName, 0d))
         );
         BytesStreamOutput output = new BytesStreamOutput();
@@ -847,6 +841,7 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultResponse response = new AnomalyResultResponse(
             4,
             0.993,
+            1.01,
             Collections.singletonList(new FeatureData(featureId, featureName, 0d))
         );
         XContentBuilder builder = jsonBuilder();
@@ -868,6 +863,7 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultResponse readResponse = new AnomalyResultResponse(
             JsonDeserializer.getDoubleValue(json, AnomalyResultResponse.ANOMALY_GRADE_JSON_KEY),
             JsonDeserializer.getDoubleValue(json, AnomalyResultResponse.CONFIDENCE_JSON_KEY),
+            JsonDeserializer.getDoubleValue(json, AnomalyResultResponse.ANOMALY_SCORE_JSON_KEY),
             JsonDeserializer.getListValue(json, function, AnomalyResultResponse.FEATURES_JSON_KEY)
         );
         assertAnomalyResultResponse(readResponse, readResponse.getAnomalyGrade(), readResponse.getConfidence(), 0d);
@@ -993,104 +989,6 @@ public class AnomalyResultTests extends AbstractADTest {
         expectThrows(ClientException.class, () -> job.call());
     }
 
-    /**
-     * Template to test exponential backoff retry during saving anomaly result.
-     *
-     * @param throwEsRejectedExecutionException whether to throw
-     *                                          EsRejectedExecutionException in the
-     *                                          client::index mock or not
-     * @param latchCount                        used for coordinating. Equal to
-     *                                          number of expected retries plus 1.
-     * @throws InterruptedException if thread execution is interrupted
-     * @throws IOException          if IO failures
-     */
-    @SuppressWarnings("unchecked")
-    public void savingFailureTemplate(boolean throwEsRejectedExecutionException, int latchCount) throws InterruptedException, IOException {
-        setUpSavingAnomalyResultIndex(false);
-
-        final CountDownLatch backoffLatch = new CountDownLatch(latchCount);
-
-        Client badClient = mock(Client.class);
-        doAnswer(invocation -> {
-            Object[] args = invocation.getArguments();
-            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 2);
-
-            IndexRequest request = null;
-            ActionListener<IndexResponse> listener = null;
-            if (args[0] instanceof IndexRequest) {
-                request = (IndexRequest) args[0];
-            }
-            if (args[1] instanceof ActionListener) {
-                listener = (ActionListener<IndexResponse>) args[1];
-            }
-
-            assertTrue(request != null && listener != null);
-            if (throwEsRejectedExecutionException) {
-                listener.onFailure(new EsRejectedExecutionException(""));
-            } else {
-                listener.onFailure(new IllegalArgumentException());
-            }
-
-            backoffLatch.countDown();
-            return null;
-        }).when(badClient).index(any(), any());
-
-        Settings backoffSettings = Settings
-            .builder()
-            .put("opendistro.anomaly_detection.max_retry_for_backoff", 2)
-            .put("opendistro.anomaly_detection.backoff_initial_delay", TimeValue.timeValueMillis(1))
-            .build();
-
-        // These constructors register handler in transport service
-        new RCFResultTransportAction(
-            new ActionFilters(Collections.emptySet()),
-            transportService,
-            normalModelManager,
-            adCircuitBreakerService
-        );
-        new ThresholdResultTransportAction(new ActionFilters(Collections.emptySet()), transportService, normalModelManager);
-
-        AnomalyResultTransportAction action = new AnomalyResultTransportAction(
-            new ActionFilters(Collections.emptySet()),
-            transportService,
-            badClient,
-            backoffSettings,
-            stateManager,
-            runner,
-            anomalyDetectionIndices,
-            featureQuery,
-            normalModelManager,
-            hashRing,
-            clusterService,
-            indexNameResolver,
-            threadPool,
-            adCircuitBreakerService,
-            adStats
-        );
-
-        AnomalyResultRequest request = new AnomalyResultRequest(adID, 100, 200);
-        PlainActionFuture<AnomalyResultResponse> listener = new PlainActionFuture<>();
-        action.doExecute(null, request, listener);
-
-        backoffLatch.await();
-    }
-
-    public void testSavingFailureNotRetry() throws InterruptedException, IOException {
-        savingFailureTemplate(false, 1);
-
-        assertEquals(1, testAppender.countMessage((AnomalyResultTransportAction.FAIL_TO_SAVE_ERR_MSG)));
-        assertTrue(!testAppender.containsMessage(AnomalyResultTransportAction.SUCCESS_SAVING_MSG));
-        assertTrue(!testAppender.containsMessage(AnomalyResultTransportAction.RETRY_SAVING_ERR_MSG));
-    }
-
-    public void testSavingFailureRetry() throws InterruptedException, IOException {
-        savingFailureTemplate(true, 3);
-
-        assertEquals(2, testAppender.countMessage((AnomalyResultTransportAction.RETRY_SAVING_ERR_MSG)));
-        assertEquals(1, testAppender.countMessage((AnomalyResultTransportAction.FAIL_TO_SAVE_ERR_MSG)));
-        assertTrue(!testAppender.containsMessage(AnomalyResultTransportAction.SUCCESS_SAVING_MSG));
-    }
-
     enum FeatureTestMode {
         FEATURE_NOT_AVAILABLE,
         ILLEGAL_STATE,
@@ -1135,6 +1033,7 @@ public class AnomalyResultTests extends AbstractADTest {
             AnomalyResultResponse response = listener.actionGet();
             assertEquals(Double.NaN, response.getAnomalyGrade(), 0.001);
             assertEquals(Double.NaN, response.getConfidence(), 0.001);
+            assertEquals(Double.NaN, response.getAnomalyScore(), 0.001);
             assertThat(response.getFeatures(), is(empty()));
         } else if (mode == FeatureTestMode.ILLEGAL_STATE || mode == FeatureTestMode.AD_EXCEPTION) {
             assertException(listener, InternalFailure.class);
@@ -1219,32 +1118,6 @@ public class AnomalyResultTests extends AbstractADTest {
         assertException(listener, AnomalyDetectionException.class, errLogMsg);
     }
 
-    private ClusterState createIndexBlockedState(String indexName, Settings hackedSettings, String alias) {
-        ClusterState blockedClusterState = null;
-        IndexMetaData.Builder builder = IndexMetaData.builder(indexName);
-        if (alias != null) {
-            builder.putAlias(AliasMetaData.builder(alias));
-        }
-        IndexMetaData indexMetaData = builder
-            .settings(
-                Settings
-                    .builder()
-                    .put(IndexMetaData.SETTING_INDEX_UUID, UUIDs.randomBase64UUID())
-                    .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
-                    .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
-                    .put(IndexMetaData.SETTING_VERSION_CREATED, Version.CURRENT)
-                    .put(hackedSettings)
-            )
-            .build();
-        MetaData metaData = MetaData.builder().put(indexMetaData, false).build();
-        blockedClusterState = ClusterState
-            .builder(new ClusterName("test cluster"))
-            .metaData(metaData)
-            .blocks(ClusterBlocks.builder().addBlocks(indexMetaData))
-            .build();
-        return blockedClusterState;
-    }
-
     private void globalBlockTemplate(BlockType type, String errLogMsg) {
         globalBlockTemplate(type, errLogMsg, null, null);
     }
@@ -1264,38 +1137,6 @@ public class AnomalyResultTests extends AbstractADTest {
             Settings.builder().put(IndexMetaData.INDEX_BLOCKS_READ_SETTING.getKey(), true).build(),
             "test1"
         );
-    }
-
-    public void testIndexWriteBlock() {
-
-        ClusterState blockedClusterState = createIndexBlockedState(
-            UUIDs.randomBase64UUID(),
-            Settings.builder().put(IndexMetaData.INDEX_BLOCKS_WRITE_SETTING.getKey(), true).build(),
-            AnomalyResult.ANOMALY_RESULT_INDEX
-        );
-        ClusterService hackedClusterService = spy(clusterService);
-        when(hackedClusterService.state()).thenReturn(blockedClusterState);
-
-        AnomalyResultTransportAction action = new AnomalyResultTransportAction(
-            new ActionFilters(Collections.emptySet()),
-            transportService,
-            client,
-            settings,
-            stateManager,
-            runner,
-            anomalyDetectionIndices,
-            featureQuery,
-            normalModelManager,
-            hashRing,
-            hackedClusterService,
-            indexNameResolver,
-            threadPool,
-            adCircuitBreakerService,
-            adStats
-        );
-        action.indexAnomalyResult(TestHelpers.randomAnomalyDetectResult());
-
-        assertTrue(testAppender.containsMessage(AnomalyResultTransportAction.CANNOT_SAVE_ERR_MSG));
     }
 
     public void testNullRCFResult() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandlerTests.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport.handler;
+
+import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultTests;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.createIndexBlockedState;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AnomalyResultHandlerTests extends AbstractADTest {
+    private static Settings settings;
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private AnomalyDetectionIndices anomalyDetectionIndices;
+
+    @Mock
+    private IndexNameExpressionResolver indexNameResolver;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        setUpThreadPool(AnomalyResultTests.class.getSimpleName());
+        settings = Settings.EMPTY;
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        tearDownThreadPool();
+        settings = null;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        super.setUpLog4jForJUnit(AnomalyResultHandler.class);
+        MockitoAnnotations.initMocks(this);
+        setWriteBlockAdResultIndex(false);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        super.tearDownLog4jForJUnit();
+    }
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Test
+    public void testSavingAdResult() throws IOException {
+        setUpSavingAnomalyResultIndex(false);
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 2);
+            IndexRequest request = invocation.getArgument(0);
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            assertTrue(request != null && listener != null);
+            listener.onResponse(mock(IndexResponse.class));
+            return null;
+        }).when(client).index(any(IndexRequest.class), ArgumentMatchers.<ActionListener<IndexResponse>>any());
+        AnomalyResultHandler handler = new AnomalyResultHandler(
+            client,
+            settings,
+            clusterService,
+            indexNameResolver,
+            anomalyDetectionIndices,
+            threadPool
+        );
+        handler.indexAnomalyResult(TestHelpers.randomAnomalyDetectResult());
+        assertEquals(1, testAppender.countMessage((AnomalyResultHandler.SUCCESS_SAVING_MSG)));
+    }
+
+    @Test
+    public void testSavingFailureNotRetry() throws InterruptedException, IOException {
+        savingFailureTemplate(false, 1, true);
+
+        assertEquals(1, testAppender.countMessage((AnomalyResultHandler.FAIL_TO_SAVE_ERR_MSG)));
+        assertTrue(!testAppender.containsMessage(AnomalyResultHandler.SUCCESS_SAVING_MSG));
+        assertTrue(!testAppender.containsMessage(AnomalyResultHandler.RETRY_SAVING_ERR_MSG));
+    }
+
+    @Test
+    public void testSavingFailureRetry() throws InterruptedException, IOException {
+        setWriteBlockAdResultIndex(false);
+        savingFailureTemplate(true, 3, true);
+
+        assertEquals(2, testAppender.countMessage((AnomalyResultHandler.RETRY_SAVING_ERR_MSG)));
+        assertEquals(1, testAppender.countMessage((AnomalyResultHandler.FAIL_TO_SAVE_ERR_MSG)));
+        assertTrue(!testAppender.containsMessage(AnomalyResultHandler.SUCCESS_SAVING_MSG));
+    }
+
+    @Test
+    public void testIndexWriteBlock() {
+        setWriteBlockAdResultIndex(true);
+        AnomalyResultHandler handler = new AnomalyResultHandler(
+            client,
+            settings,
+            clusterService,
+            indexNameResolver,
+            anomalyDetectionIndices,
+            threadPool
+        );
+        handler.indexAnomalyResult(TestHelpers.randomAnomalyDetectResult());
+
+        assertTrue(testAppender.containsMessage(AnomalyResultHandler.CANNOT_SAVE_ERR_MSG));
+    }
+
+    @Test
+    public void testAdResultIndexExist() throws IOException {
+        setInitAnomalyResultIndexException(true);
+        AnomalyResultHandler handler = new AnomalyResultHandler(
+            client,
+            settings,
+            clusterService,
+            indexNameResolver,
+            anomalyDetectionIndices,
+            threadPool
+        );
+        handler.indexAnomalyResult(TestHelpers.randomAnomalyDetectResult());
+        verify(client, times(1)).index(any(), any());
+    }
+
+    @Test
+    public void testAdResultIndexOtherException() throws IOException {
+        expectedEx.expect(AnomalyDetectionException.class);
+        expectedEx.expectMessage("Error in saving anomaly index for ID");
+
+        setInitAnomalyResultIndexException(false);
+        AnomalyResultHandler handler = new AnomalyResultHandler(
+            client,
+            settings,
+            clusterService,
+            indexNameResolver,
+            anomalyDetectionIndices,
+            threadPool
+        );
+        handler.indexAnomalyResult(TestHelpers.randomAnomalyDetectResult());
+        verify(client, never()).index(any(), any());
+    }
+
+    private void setInitAnomalyResultIndexException(boolean indexExistException) throws IOException {
+        Exception e = indexExistException ? mock(ResourceAlreadyExistsException.class) : mock(RuntimeException.class);
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 1);
+            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
+            assertTrue(listener != null);
+            listener.onFailure(e);
+            return null;
+        }).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());
+    }
+
+    private void setWriteBlockAdResultIndex(boolean blocked) {
+        String indexName = randomAlphaOfLength(10);
+        Settings settings = blocked
+            ? Settings.builder().put(IndexMetaData.INDEX_BLOCKS_WRITE_SETTING.getKey(), true).build()
+            : Settings.EMPTY;
+        ClusterState blockedClusterState = createIndexBlockedState(indexName, settings, AnomalyResult.ANOMALY_RESULT_INDEX);
+        when(clusterService.state()).thenReturn(blockedClusterState);
+        when(indexNameResolver.concreteIndexNames(any(), any(), any())).thenReturn(new String[] { indexName });
+    }
+
+    /**
+     * Template to test exponential backoff retry during saving anomaly result.
+     *
+     * @param throwEsRejectedExecutionException whether to throw
+     *                                          EsRejectedExecutionException in the
+     *                                          client::index mock or not
+     * @param latchCount                        used for coordinating. Equal to
+     *                                          number of expected retries plus 1.
+     * @throws InterruptedException if thread execution is interrupted
+     * @throws IOException          if IO failures
+     */
+    @SuppressWarnings("unchecked")
+    private void savingFailureTemplate(boolean throwEsRejectedExecutionException, int latchCount, boolean adResultIndexExists)
+        throws InterruptedException,
+        IOException {
+        setUpSavingAnomalyResultIndex(adResultIndexExists);
+
+        final CountDownLatch backoffLatch = new CountDownLatch(latchCount);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 2);
+            IndexRequest request = invocation.getArgument(0);
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            assertTrue(request != null && listener != null);
+            if (throwEsRejectedExecutionException) {
+                listener.onFailure(new EsRejectedExecutionException(""));
+            } else {
+                listener.onFailure(new IllegalArgumentException());
+            }
+
+            backoffLatch.countDown();
+            return null;
+        }).when(client).index(any(IndexRequest.class), ArgumentMatchers.<ActionListener<IndexResponse>>any());
+
+        Settings backoffSettings = Settings
+            .builder()
+            .put("opendistro.anomaly_detection.max_retry_for_backoff", 2)
+            .put("opendistro.anomaly_detection.backoff_initial_delay", TimeValue.timeValueMillis(1))
+            .build();
+
+        AnomalyResultHandler handler = new AnomalyResultHandler(
+            client,
+            backoffSettings,
+            clusterService,
+            indexNameResolver,
+            anomalyDetectionIndices,
+            threadPool
+        );
+
+        handler.indexAnomalyResult(TestHelpers.randomAnomalyDetectResult());
+
+        backoffLatch.await();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setUpSavingAnomalyResultIndex(boolean anomalyResultIndexExists) throws IOException {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 1);
+            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
+            assertTrue(listener != null);
+            listener.onResponse(new CreateIndexResponse(true, true, AnomalyResult.ANOMALY_RESULT_INDEX) {
+            });
+            return null;
+        }).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());
+        when(anomalyDetectionIndices.doesAnomalyResultIndexExist()).thenReturn(anomalyResultIndexExists);
+    }
+
+}


### PR DESCRIPTION
* Issue #47

*Description of changes:*
* record error and execution start/end time in AD result
* handle exception from AD result action. 
  If exception is EndRunException: 1).if `endNow=true`, will stop AD job run; otherwise; 2). if `endNow=false`, will retry AD job, if all retries failed or have no enough time to retry, will stop AD job. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
