### PR TITLE
Change build instruction for JDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please see our [documentation](https://opendistro.github.io/for-elasticsearch-do
 
 1. Checkout source code of this package from Github repo.
 1. Launch Intellij IDEA, Choose Import Project and select the settings.gradle file in the root of this package.
-1. To build from command line set JAVA_HOME to point to a JDK >=12 before running ./gradlew
+1. To build from command line set JAVA_HOME to point to a JDK 12 before running ./gradlew
 
   * Unix System
     * export JAVA_HOME=jdk-install-dir: Replace jdk-install-dir by the JAVA_HOME directory of your system.

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
@@ -802,7 +802,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
     }
 
     private void handlePredictionFailure(Exception e, String adID, String nodeID, AtomicReference<AnomalyDetectionException> failure) {
-        LOG.error(new ParameterizedMessage("Received an error from node {} when fetch anomaly grade for {}", nodeID, adID), e);
+        LOG.error(new ParameterizedMessage("Received an error from node {} while fetching anomaly grade for {}", nodeID, adID), e);
         if (e == null) {
             return;
         }


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/57

*Description of changes:*
This PR change build instruction for JDK as we have a build error using JDK 13. This PR also fixes a grammar issue in the log message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
