### PR TITLE
Add async CheckpointDao methods.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDao.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetRequest;
@@ -68,9 +69,12 @@ public class CheckpointDao {
     /**
      * Puts a model checkpoint in the storage.
      *
+     * @deprecated use putModelCheckpoint with listener instead
+     *
      * @param modelId Id of the model
      * @param modelCheckpoint Checkpoint data of the model
      */
+    @Deprecated
     public void putModelCheckpoint(String modelId, String modelCheckpoint) {
         Map<String, Object> source = new HashMap<>();
         source.put(FIELD_MODEL, modelCheckpoint);
@@ -85,11 +89,32 @@ public class CheckpointDao {
     }
 
     /**
+     * Puts a model checkpoint in the storage.
+     *
+     * @param modelId id of the model
+     * @param modelCheckpoint checkpoint of the model
+     * @param listener onResponse is called with null when the operation is completed
+     */
+    public void putModelCheckpoint(String modelId, String modelCheckpoint, ActionListener<Void> listener) {
+        Map<String, Object> source = new HashMap<>();
+        source.put(FIELD_MODEL, modelCheckpoint);
+        clientUtil
+            .<IndexRequest, IndexResponse>asyncRequest(
+                new IndexRequest(indexName, DOC_TYPE, modelId).source(source),
+                client::index,
+                ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)
+            );
+    }
+
+    /**
      * Returns the checkpoint for the model.
+     *
+     * @deprecated use getModelCheckpoint with listener instead
      *
      * @param modelId ID of the model
      * @return model checkpoint, or empty if not found
      */
+    @Deprecated
     public Optional<String> getModelCheckpoint(String modelId) {
         return clientUtil
             .<GetRequest, GetResponse>timedRequest(new GetRequest(indexName, DOC_TYPE, modelId), logger, client::get)
@@ -99,11 +124,52 @@ public class CheckpointDao {
     }
 
     /**
+     * Returns to listener the checkpoint for the model.
+     *
+     * @param modelId id of the model
+     * @param listener onResponse is called with the model checkpoint, or empty for no such model
+     */
+    public void getModelCheckpoint(String modelId, ActionListener<Optional<String>> listener) {
+        clientUtil
+            .<GetRequest, GetResponse>asyncRequest(
+                new GetRequest(indexName, DOC_TYPE, modelId),
+                client::get,
+                ActionListener.wrap(response -> listener.onResponse(processModelCheckpoint(response)), listener::onFailure)
+            );
+    }
+
+    private Optional<String> processModelCheckpoint(GetResponse response) {
+        return Optional
+            .ofNullable(response)
+            .filter(GetResponse::isExists)
+            .map(GetResponse::getSource)
+            .map(source -> (String) source.get(FIELD_MODEL));
+    }
+
+    /**
      * Deletes the model checkpoint for the id.
+     *
+     * @deprecated use deleteModelCheckpoint with listener instead
      *
      * @param modelId ID of the model checkpoint
      */
+    @Deprecated
     public void deleteModelCheckpoint(String modelId) {
         clientUtil.<DeleteRequest, DeleteResponse>timedRequest(new DeleteRequest(indexName, DOC_TYPE, modelId), logger, client::delete);
+    }
+
+    /**
+     * Deletes the model checkpoint for the model.
+     *
+     * @param modelId id of the model
+     * @param listener onReponse is called with null when the operation is completed
+     */
+    public void deleteModelCheckpoint(String modelId, ActionListener<Void> listener) {
+        clientUtil
+            .<DeleteRequest, DeleteResponse>asyncRequest(
+                new DeleteRequest(indexName, DOC_TYPE, modelId),
+                client::delete,
+                ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)
+            );
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDaoTests.java
@@ -43,8 +43,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -152,5 +155,104 @@ public class CheckpointDaoTests {
         assertEquals(indexName, deleteRequest.index());
         assertEquals(CheckpointDao.DOC_TYPE, deleteRequest.type());
         assertEquals(modelId, deleteRequest.id());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void putModelCheckpoint_callListener_whenCompleted() {
+        ArgumentCaptor<IndexRequest> requestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(2);
+            listener.onResponse(null);
+            return null;
+        }).when(clientUtil).asyncRequest(requestCaptor.capture(), any(BiConsumer.class), any(ActionListener.class));
+
+        ActionListener<Void> listener = mock(ActionListener.class);
+        checkpointDao.putModelCheckpoint(modelId, model, listener);
+
+        IndexRequest indexRequest = requestCaptor.getValue();
+        assertEquals(indexName, indexRequest.index());
+        assertEquals(CheckpointDao.DOC_TYPE, indexRequest.type());
+        assertEquals(modelId, indexRequest.id());
+        assertEquals(docSource, indexRequest.sourceAsMap());
+
+        ArgumentCaptor<Void> responseCaptor = ArgumentCaptor.forClass(Void.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        Void response = responseCaptor.getValue();
+        assertEquals(null, response);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getModelCheckpoint_returnExpectedToListener() {
+        ArgumentCaptor<GetRequest> requestCaptor = ArgumentCaptor.forClass(GetRequest.class);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(clientUtil).asyncRequest(requestCaptor.capture(), any(BiConsumer.class), any(ActionListener.class));
+        when(getResponse.isExists()).thenReturn(true);
+        when(getResponse.getSource()).thenReturn(docSource);
+
+        ActionListener<Optional<String>> listener = mock(ActionListener.class);
+        checkpointDao.getModelCheckpoint(modelId, listener);
+
+        GetRequest getRequest = requestCaptor.getValue();
+        assertEquals(indexName, getRequest.index());
+        assertEquals(CheckpointDao.DOC_TYPE, getRequest.type());
+        assertEquals(modelId, getRequest.id());
+        ArgumentCaptor<Optional<String>> responseCaptor = ArgumentCaptor.forClass(Optional.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        Optional<String> result = responseCaptor.getValue();
+        assertTrue(result.isPresent());
+        assertEquals(model, result.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getModelCheckpoint_returnEmptyToListener_whenModelNotFound() {
+        ArgumentCaptor<GetRequest> requestCaptor = ArgumentCaptor.forClass(GetRequest.class);
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(2);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(clientUtil).asyncRequest(requestCaptor.capture(), any(BiConsumer.class), any(ActionListener.class));
+        when(getResponse.isExists()).thenReturn(false);
+
+        ActionListener<Optional<String>> listener = mock(ActionListener.class);
+        checkpointDao.getModelCheckpoint(modelId, listener);
+
+        GetRequest getRequest = requestCaptor.getValue();
+        assertEquals(indexName, getRequest.index());
+        assertEquals(CheckpointDao.DOC_TYPE, getRequest.type());
+        assertEquals(modelId, getRequest.id());
+        ArgumentCaptor<Optional<String>> responseCaptor = ArgumentCaptor.forClass(Optional.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        Optional<String> result = responseCaptor.getValue();
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void deleteModelCheckpoint_callListener_whenCompleted() {
+        ArgumentCaptor<DeleteRequest> requestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(2);
+            listener.onResponse(null);
+            return null;
+        }).when(clientUtil).asyncRequest(requestCaptor.capture(), any(BiConsumer.class), any(ActionListener.class));
+
+        ActionListener<Void> listener = mock(ActionListener.class);
+        checkpointDao.deleteModelCheckpoint(modelId, listener);
+
+        DeleteRequest deleteRequest = requestCaptor.getValue();
+        assertEquals(indexName, deleteRequest.index());
+        assertEquals(CheckpointDao.DOC_TYPE, deleteRequest.type());
+        assertEquals(modelId, deleteRequest.id());
+
+        ArgumentCaptor<Void> responseCaptor = ArgumentCaptor.forClass(Void.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        Void response = responseCaptor.getValue();
+        assertEquals(null, response);
     }
 }


### PR DESCRIPTION
This change adds async operations for putting, getting, and deleting checkpoints. In the overall effort of moving towards asynchronous implementation, the new async operations will replace current synchronous operations used for model management.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
