### PR TITLE
Fix empty preview result due to insufficient sample

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -229,7 +229,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         SingleFeatureLinearUniformInterpolator singleFeatureLinearUniformInterpolator =
             new IntegerSensitiveSingleFeatureLinearUniformInterpolator();
         Interpolator interpolator = new LinearUniformInterpolator(singleFeatureLinearUniformInterpolator);
-        SearchFeatureDao searchFeatureDao = new SearchFeatureDao(client, scriptService, xContentRegistry, interpolator, clientUtil);
+        SearchFeatureDao searchFeatureDao = new SearchFeatureDao(client, xContentRegistry, interpolator, clientUtil);
 
         JvmService jvmService = new JvmService(environment.settings());
         RandomCutForestSerDe rcfSerde = new RandomCutForestSerDe();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -58,16 +59,8 @@ public final class AnomalyDetectorRunner {
      * @param endTime   detection period end time
      * @param listener handle anomaly result
      */
-    public void run(AnomalyDetector detector, Instant startTime, Instant endTime, ActionListener<List<AnomalyResult>> listener) {
-        executeDetector(detector, startTime, endTime, listener);
-    }
-
-    private void executeDetector(
-        AnomalyDetector detector,
-        Instant startTime,
-        Instant endTime,
-        ActionListener<List<AnomalyResult>> listener
-    ) {
+    public void executeDetector(AnomalyDetector detector, Instant startTime, Instant endTime, ActionListener<List<AnomalyResult>> listener)
+        throws IOException {
         featureManager.getPreviewFeatures(detector, startTime.toEpochMilli(), endTime.toEpochMilli(), ActionListener.wrap(features -> {
             try {
                 List<ThresholdingResult> results = modelManager.getPreviewResults(features.getProcessedFeatures());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.feature;
 
+import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -288,8 +289,10 @@ public class FeatureManager {
      * @param listener onResponse is called with time ranges, unprocessed features,
      *                                      and processed features of the data points from the period
      *                 onFailure is called with IllegalArgumentException when there is no data to preview
+     * @throws IOException if a user gives wrong query input when defining a detector
      */
-    public void getPreviewFeatures(AnomalyDetector detector, long startMilli, long endMilli, ActionListener<Features> listener) {
+    public void getPreviewFeatures(AnomalyDetector detector, long startMilli, long endMilli, ActionListener<Features> listener)
+        throws IOException {
         Entry<List<Entry<Long, Long>>, Integer> sampleRangeResults = getSampleRanges(detector, startMilli, endMilli);
         List<Entry<Long, Long>> sampleRanges = sampleRangeResults.getKey();
         int stride = sampleRangeResults.getValue();
@@ -356,12 +359,13 @@ public class FeatureManager {
      * Gets search results for the sampled time ranges.
      *
      * @param listener handle search results map: key is time ranges, value is corresponding search results
+     * @throws IOException if a user gives wrong query input when defining a detector
      */
     void getSamplesForRanges(
         AnomalyDetector detector,
         List<Entry<Long, Long>> sampleRanges,
         ActionListener<Entry<List<Entry<Long, Long>>, double[][]>> listener
-    ) {
+    ) throws IOException {
         searchFeatureDao.getFeatureSamplesForPeriods(detector, sampleRanges, ActionListener.wrap(featureSamples -> {
             List<Entry<Long, Long>> ranges = new ArrayList<>(featureSamples.size());
             List<double[]> samples = new ArrayList<>(featureSamples.size());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
@@ -197,6 +197,7 @@ public class SearchFeatureDao {
             Aggregations aggs = response.getAggregations();
             if (aggs == null) {
                 listener.onResponse(Collections.emptyList());
+                return;
             }
 
             listener
@@ -307,7 +308,11 @@ public class SearchFeatureDao {
             SearchSourceBuilder searchSourceBuilder = ParseUtils.generateInternalFeatureQuery(detector, startTime, endTime, xContent);
             return new SearchRequest(detector.getIndices().toArray(new String[0]), searchSourceBuilder).preference(preference.orElse(null));
         } catch (IOException e) {
-            logger.warn("Failed to create feature search request for " + detector + " from " + startTime + " to " + endTime, e);
+            logger
+                .warn(
+                    "Failed to create feature search request for " + detector.getDetectorId() + " from " + startTime + " to " + endTime,
+                    e
+                );
             throw new IllegalStateException(e);
         }
     }
@@ -317,7 +322,7 @@ public class SearchFeatureDao {
             SearchSourceBuilder searchSourceBuilder = ParseUtils.generatePreviewQuery(detector, ranges, xContent);
             return new SearchRequest(detector.getIndices().toArray(new String[0]), searchSourceBuilder);
         } catch (IOException e) {
-            logger.warn("Failed to create feature search request for " + detector + " for preview", e);
+            logger.warn("Failed to create feature search request for " + detector.getDetectorId() + " for preview", e);
             throw new IllegalStateException(e);
         }
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
@@ -185,12 +185,13 @@ public class SearchFeatureDao {
      * @param detector info about the indices, documents, feature query
      * @param ranges list of time ranges
      * @param listener handle approximate features for the time ranges
+     * @throws IOException if a user gives wrong query input when defining a detector
      */
     public void getFeatureSamplesForPeriods(
         AnomalyDetector detector,
         List<Entry<Long, Long>> ranges,
         ActionListener<List<Optional<double[]>>> listener
-    ) {
+    ) throws IOException {
         SearchRequest request = createPreviewSearchRequest(detector, ranges);
 
         client.search(request, ActionListener.wrap(response -> {
@@ -317,13 +318,13 @@ public class SearchFeatureDao {
         }
     }
 
-    private SearchRequest createPreviewSearchRequest(AnomalyDetector detector, List<Entry<Long, Long>> ranges) {
+    private SearchRequest createPreviewSearchRequest(AnomalyDetector detector, List<Entry<Long, Long>> ranges) throws IOException {
         try {
             SearchSourceBuilder searchSourceBuilder = ParseUtils.generatePreviewQuery(detector, ranges, xContent);
             return new SearchRequest(detector.getIndices().toArray(new String[0]), searchSourceBuilder);
         } catch (IOException e) {
             logger.warn("Failed to create feature search request for " + detector.getDetectorId() + " for preview", e);
-            throw new IllegalStateException(e);
+            throw e;
         }
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestExecuteAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestExecuteAnomalyDetectorAction.java
@@ -197,7 +197,7 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
                         logger.error("Unexpected error running anomaly detector " + detector.getDetectorId(), exception);
                         try {
                             XContentBuilder builder = channel.newBuilder().startObject().field(ANOMALY_DETECTOR, detector).endObject();
-                            channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+                            channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, builder));
                         } catch (IOException e) {
                             logger.error("Fail to send back exception message" + detector.getDetectorId(), exception);
                         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestExecuteAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestExecuteAnomalyDetectorAction.java
@@ -184,23 +184,24 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
                 AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
 
-                anomalyDetectorRunner.run(detector, input.getPeriodStart(), input.getPeriodEnd(), ActionListener.wrap(anomalyResult -> {
-                    XContentBuilder builder = channel
-                        .newBuilder()
-                        .startObject()
-                        .field(ANOMALY_RESULT, anomalyResult)
-                        .field(ANOMALY_DETECTOR, detector)
-                        .endObject();
-                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
-                }, exception -> {
-                    logger.error("Unexpected error running anomaly detector " + detector.getDetectorId(), exception);
-                    try {
-                        XContentBuilder builder = channel.newBuilder().startObject().field(ANOMALY_DETECTOR, detector).endObject();
+                anomalyDetectorRunner
+                    .executeDetector(detector, input.getPeriodStart(), input.getPeriodEnd(), ActionListener.wrap(anomalyResult -> {
+                        XContentBuilder builder = channel
+                            .newBuilder()
+                            .startObject()
+                            .field(ANOMALY_RESULT, anomalyResult)
+                            .field(ANOMALY_DETECTOR, detector)
+                            .endObject();
                         channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
-                    } catch (IOException e) {
-                        logger.error("Fail to send back exception message" + detector.getDetectorId(), exception);
-                    }
-                }));
+                    }, exception -> {
+                        logger.error("Unexpected error running anomaly detector " + detector.getDetectorId(), exception);
+                        try {
+                            XContentBuilder builder = channel.newBuilder().startObject().field(ANOMALY_DETECTOR, detector).endObject();
+                            channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+                        } catch (IOException e) {
+                            logger.error("Fail to send back exception message" + detector.getDetectorId(), exception);
+                        }
+                    }));
             }
         };
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.feature;
 
+import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -409,7 +410,8 @@ public class FeatureManagerTests {
     }
 
     @SuppressWarnings("unchecked")
-    private void getPreviewFeaturesTemplate(List<Optional<double[]>> samplesResults, boolean querySuccess, boolean previewSuccess) {
+    private void getPreviewFeaturesTemplate(List<Optional<double[]>> samplesResults, boolean querySuccess, boolean previewSuccess)
+        throws IOException {
         long start = 0L;
         long end = 240_000L;
         IntervalTimeConfiguration detectionInterval = new IntervalTimeConfiguration(1, ChronoUnit.MINUTES);
@@ -458,17 +460,17 @@ public class FeatureManagerTests {
     }
 
     @Test
-    public void getPreviewFeatures_returnExpectedToListener() {
+    public void getPreviewFeatures_returnExpectedToListener() throws IOException {
         getPreviewFeaturesTemplate(asList(Optional.of(new double[] { 1 }), Optional.of(new double[] { 3 })), true, true);
     }
 
     @Test
-    public void getPreviewFeatures_returnExceptionToListener_whenNoDataToPreview() {
+    public void getPreviewFeatures_returnExceptionToListener_whenNoDataToPreview() throws IOException {
         getPreviewFeaturesTemplate(asList(), true, false);
     }
 
     @Test
-    public void getPreviewFeatures_returnExceptionToListener_whenQueryFail() {
+    public void getPreviewFeatures_returnExceptionToListener_whenQueryFail() throws IOException {
         getPreviewFeaturesTemplate(asList(Optional.of(new double[] { 1 }), Optional.of(new double[] { 3 })), false, false);
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
@@ -148,7 +148,7 @@ public class SearchFeatureDaoTests {
         PowerMockito.mockStatic(ParseUtils.class);
 
         Interpolator interpolator = new LinearUniformInterpolator(new SingleFeatureLinearUniformInterpolator());
-        searchFeatureDao = spy(new SearchFeatureDao(client, scriptService, xContent, interpolator, clientUtil));
+        searchFeatureDao = spy(new SearchFeatureDao(client, xContent, interpolator, clientUtil));
 
         detectionInterval = new IntervalTimeConfiguration(1, ChronoUnit.MINUTES);
         when(detector.getTimeField()).thenReturn("testTimeField");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
@@ -184,8 +184,7 @@ public class SearchFeatureDaoTests {
             );
 
         multiSearchRequest = new MultiSearchRequest();
-        SearchRequest request = new SearchRequest(detector.getIndices().toArray(new String[0]))
-            .preference(SearchFeatureDao.FEATURE_SAMPLE_PREFERENCE);
+        SearchRequest request = new SearchRequest(detector.getIndices().toArray(new String[0]));
         multiSearchRequest.add(request);
         doReturn(Optional.of(multiSearchResponse))
             .when(clientUtil)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/64

*Description of changes:*
Preview does not use all data in the given time range as it is costly. Previously, we sample data by issuing multiple queries on shard 0 data. The purpose of the shard 0 query restriction is to reduce system costs. The nab_art_daily_jumpsup data set has one doc in each interval, and the doc is spread out in 5 shards. Even though we issue 360 queries, we only get 70~80 samples back by querying shard 0. Together with interpolated data points, the preview run misses significant portions of data required to train models (400 is the minimum) and thus returns empty preview results. This PR fixes the issue by removing the shard 0 search restriction.

Previously, the preview API issues multiple queries encapsulated in a multisearch request (the request can contain 360 search queries at most). The same result could be obtained via a date range query with multiple range buckets. We show a date range query is 2~10 times faster than a multisearch request (https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/63). This PR replaces the multisearch request with a date range query.

This PR also fixes a bug in query generation. We generate aggregation query twice: once with filter query, once separately.  

This PR also removes unused field scriptService in SearchFeatureDao.

Testing done:
- Previous preview unit tests pass.
- Manually verified date range queries results are correctly processed by cross checking intermediate logs.
- Manually verified preview results with multisearch (removing shard 0 search restriction) and date range implementation are the same
- Manually verified preview don't show empty results with the nab_art_daily_jumpsup data set after the fix


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
