### PR TITLE
fix rcf random seed in preview

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -583,6 +583,7 @@ public class ModelManager {
         int rcfNumFeatures = dataPoints[0].length;
         RandomCutForest forest = RandomCutForest
             .builder()
+            .randomSeed(0L)
             .dimensions(rcfNumFeatures)
             .sampleSize(rcfNumSamplesInTree)
             .numberOfTrees(rcfNumTrees)


### PR DESCRIPTION
Current models used output preview results are randomized. To produce more deterministic results in preview, random seeds used in the models are fixed with this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
