### PR TITLE
preview detector on the fly

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorExecutionInput.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorExecutionInput.java
@@ -35,14 +35,17 @@ public class AnomalyDetectorExecutionInput implements ToXContentObject {
     private static final String DETECTOR_ID_FIELD = "detector_id";
     private static final String PERIOD_START_FIELD = "period_start";
     private static final String PERIOD_END_FIELD = "period_end";
+    private static final String DETECTOR_FIELD = "detector";
     private Instant periodStart;
     private Instant periodEnd;
     private String detectorId;
+    private AnomalyDetector detector;
 
-    public AnomalyDetectorExecutionInput(String detectorId, Instant periodStart, Instant periodEnd) {
+    public AnomalyDetectorExecutionInput(String detectorId, Instant periodStart, Instant periodEnd, AnomalyDetector detector) {
         this.periodStart = periodStart;
         this.periodEnd = periodEnd;
         this.detectorId = detectorId;
+        this.detector = detector;
     }
 
     @Override
@@ -51,14 +54,15 @@ public class AnomalyDetectorExecutionInput implements ToXContentObject {
             .startObject()
             .field(DETECTOR_ID_FIELD, detectorId)
             .field(PERIOD_START_FIELD, periodStart.toEpochMilli())
-            .field(PERIOD_END_FIELD, periodEnd.toEpochMilli());
+            .field(PERIOD_END_FIELD, periodEnd.toEpochMilli())
+            .field(DETECTOR_FIELD, detector);
         return xContentBuilder.endObject();
     }
 
-    public static AnomalyDetectorExecutionInput parse(XContentParser parser) throws IOException {
-        String detectorId = null;
+    public static AnomalyDetectorExecutionInput parse(XContentParser parser, String detectorId) throws IOException {
         Instant periodStart = null;
         Instant periodEnd = null;
+        AnomalyDetector detector = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -66,20 +70,23 @@ public class AnomalyDetectorExecutionInput implements ToXContentObject {
             parser.nextToken();
 
             switch (fieldName) {
-                case DETECTOR_ID_FIELD:
-                    detectorId = parser.text();
-                    break;
                 case PERIOD_START_FIELD:
                     periodStart = ParseUtils.toInstant(parser);
                     break;
                 case PERIOD_END_FIELD:
                     periodEnd = ParseUtils.toInstant(parser);
                     break;
+                case DETECTOR_FIELD:
+                    XContentParser.Token token = parser.currentToken();
+                    if (parser.currentToken().equals(XContentParser.Token.START_OBJECT)) {
+                        detector = AnomalyDetector.parse(parser, detectorId);
+                    }
+                    break;
                 default:
                     break;
             }
         }
-        return new AnomalyDetectorExecutionInput(detectorId, periodStart, periodEnd);
+        return new AnomalyDetectorExecutionInput(detectorId, periodStart, periodEnd, detector);
     }
 
     @Generated
@@ -92,7 +99,8 @@ public class AnomalyDetectorExecutionInput implements ToXContentObject {
         AnomalyDetectorExecutionInput that = (AnomalyDetectorExecutionInput) o;
         return Objects.equal(getPeriodStart(), that.getPeriodStart())
             && Objects.equal(getPeriodEnd(), that.getPeriodEnd())
-            && Objects.equal(getDetectorId(), that.getDetectorId());
+            && Objects.equal(getDetectorId(), that.getDetectorId())
+            && Objects.equal(getDetector(), that.getDetector());
     }
 
     @Generated
@@ -111,6 +119,10 @@ public class AnomalyDetectorExecutionInput implements ToXContentObject {
 
     public String getDetectorId() {
         return detectorId;
+    }
+
+    public AnomalyDetector getDetector() {
+        return detector;
     }
 
     public void setDetectorId(String detectorId) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestExecuteAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestExecuteAnomalyDetectorAction.java
@@ -15,12 +15,12 @@
 
 package com.amazon.opendistroforelasticsearch.ad.rest;
 
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorRunner;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorExecutionInput;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultRequest;
-import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -85,7 +85,7 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
                 this
             );
 
-        // preivew AD
+        // preview detector
         controller
             .registerHandler(
                 RestRequest.Method.POST,
@@ -106,12 +106,27 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
             String rawPath = request.rawPath();
             String error = validateAdExecutionInput(input);
             if (error != null) {
-                channel.sendResponse(new BytesRestResponse(RestStatus.NOT_FOUND, error));
+                channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, error));
                 return;
             }
 
             if (rawPath.endsWith(PREVIEW)) {
-                preivewAnomalyDetector(client, channel, input);
+                if (input.getDetector() != null) {
+                    error = validateDetector(input.getDetector());
+                    if (error != null) {
+                        channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, error));
+                        return;
+                    }
+                    anomalyDetectorRunner
+                        .executeDetector(
+                            input.getDetector(),
+                            input.getPeriodStart(),
+                            input.getPeriodEnd(),
+                            getPreviewDetectorActionListener(channel, input.getDetector())
+                        );
+                } else {
+                    preivewAnomalyDetector(client, channel, input);
+                }
             } else if (rawPath.endsWith(RUN)) {
                 AnomalyResultRequest getRequest = new AnomalyResultRequest(
                     input.getDetectorId(),
@@ -123,6 +138,13 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
         };
     }
 
+    private String validateDetector(AnomalyDetector detector) {
+        if (detector.getFeatureAttributes().isEmpty()) {
+            return "Can't preview detector without feature";
+        }
+        return null;
+    }
+
     private AnomalyDetectorExecutionInput getAnomalyDetectorExecutionInput(RestRequest request) throws IOException {
         String detectorId = null;
         if (request.hasParam(DETECTOR_ID)) {
@@ -131,7 +153,7 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
 
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
-        AnomalyDetectorExecutionInput input = AnomalyDetectorExecutionInput.parse(parser);
+        AnomalyDetectorExecutionInput input = AnomalyDetectorExecutionInput.parse(parser, detectorId);
         if (detectorId != null) {
             input.setDetectorId(detectorId);
         }
@@ -185,24 +207,28 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
                 AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
 
                 anomalyDetectorRunner
-                    .executeDetector(detector, input.getPeriodStart(), input.getPeriodEnd(), ActionListener.wrap(anomalyResult -> {
-                        XContentBuilder builder = channel
-                            .newBuilder()
-                            .startObject()
-                            .field(ANOMALY_RESULT, anomalyResult)
-                            .field(ANOMALY_DETECTOR, detector)
-                            .endObject();
-                        channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
-                    }, exception -> {
-                        logger.error("Unexpected error running anomaly detector " + detector.getDetectorId(), exception);
-                        try {
-                            XContentBuilder builder = channel.newBuilder().startObject().field(ANOMALY_DETECTOR, detector).endObject();
-                            channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, builder));
-                        } catch (IOException e) {
-                            logger.error("Fail to send back exception message" + detector.getDetectorId(), exception);
-                        }
-                    }));
+                    .executeDetector(detector, input.getPeriodStart(), input.getPeriodEnd(), getPreviewDetectorActionListener(channel, detector));
             }
         };
+    }
+
+    private ActionListener getPreviewDetectorActionListener(RestChannel channel, AnomalyDetector detector) {
+        return ActionListener.wrap(anomalyResult -> {
+            XContentBuilder builder = channel
+                .newBuilder()
+                .startObject()
+                .field(ANOMALY_RESULT, anomalyResult)
+                .field(ANOMALY_DETECTOR, detector)
+                .endObject();
+            channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+        }, exception -> {
+            logger.error("Unexpected error running anomaly detector " + detector.getDetectorId(), exception);
+            try {
+                XContentBuilder builder = channel.newBuilder().startObject().field(ANOMALY_DETECTOR, detector).endObject();
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+            } catch (IOException e) {
+                logger.error("Fail to send back exception message" + detector.getDetectorId(), exception);
+            }
+        });
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestExecuteAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestExecuteAnomalyDetectorAction.java
@@ -207,7 +207,12 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
                 AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
 
                 anomalyDetectorRunner
-                    .executeDetector(detector, input.getPeriodStart(), input.getPeriodEnd(), getPreviewDetectorActionListener(channel, detector));
+                    .executeDetector(
+                        detector,
+                        input.getPeriodStart(),
+                        input.getPeriodEnd(),
+                        getPreviewDetectorActionListener(channel, detector)
+                    );
             }
         };
     }
@@ -225,7 +230,7 @@ public class RestExecuteAnomalyDetectorAction extends BaseRestHandler {
             logger.error("Unexpected error running anomaly detector " + detector.getDetectorId(), exception);
             try {
                 XContentBuilder builder = channel.newBuilder().startObject().field(ANOMALY_DETECTOR, detector).endObject();
-                channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+                channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, builder));
             } catch (IOException e) {
                 logger.error("Fail to send back exception message" + detector.getDetectorId(), exception);
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -18,7 +18,6 @@ package com.amazon.opendistroforelasticsearch.ad.rest.handler;
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
-import com.amazon.opendistroforelasticsearch.ad.model.Feature;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -50,10 +49,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
 import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_DETECTORS;
@@ -151,7 +147,7 @@ public class IndexAnomalyDetectorActionHandler extends AbstractActionHandler {
         // 2).If filter will only return one document,
         // 3).If custom expression has specific logic to return one number for some case,
         // but multiple for others, like some if/else branch
-        String error = validateAnomalyDetector(anomalyDetector);
+        String error = RestHandlerUtils.validateAnomalyDetector(anomalyDetector, maxAnomalyFeatures);
         if (StringUtils.isNotBlank(error)) {
             channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, error));
             return;
@@ -161,42 +157,6 @@ public class IndexAnomalyDetectorActionHandler extends AbstractActionHandler {
         } else {
             createAnomalyDetector();
         }
-    }
-
-    private String validateAnomalyDetector(AnomalyDetector anomalyDetector) {
-        if (anomalyDetector.getFeatureAttributes().size() > maxAnomalyFeatures) {
-            return "Can't create anomaly features more than " + maxAnomalyFeatures;
-        }
-        return validateFeatures(anomalyDetector.getFeatureAttributes());
-    }
-
-    public String validateFeatures(List<Feature> features) {
-        final Set<String> duplicateFeatureNames = new HashSet<>();
-        final Set<String> featureNames = new HashSet<>();
-        final Set<String> duplicateFeatureAggNames = new HashSet<>();
-        final Set<String> featureAggNames = new HashSet<>();
-
-        if (features != null) {
-            features.forEach(feature -> {
-                if (!featureNames.add(feature.getName())) {
-                    duplicateFeatureNames.add(feature.getName());
-                }
-                if (!featureAggNames.add(feature.getAggregation().getName())) {
-                    duplicateFeatureAggNames.add(feature.getAggregation().getName());
-                }
-            });
-        }
-
-        StringBuilder errorMsgBuilder = new StringBuilder();
-        if (duplicateFeatureNames.size() > 0) {
-            errorMsgBuilder.append("Detector has duplicate feature names: ");
-            errorMsgBuilder.append(String.join(", ", duplicateFeatureNames)).append("\n");
-        }
-        if (duplicateFeatureAggNames.size() > 0) {
-            errorMsgBuilder.append("Detector has duplicate feature aggregation query names: ");
-            errorMsgBuilder.append(String.join(", ", duplicateFeatureAggNames));
-        }
-        return errorMsgBuilder.toString();
     }
 
     private void updateAnomalyDetector(NodeClient client, String detectorId) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -48,6 +48,7 @@ import org.elasticsearch.rest.action.RestResponseListener;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -268,9 +269,24 @@ public class IndexAnomalyDetectorActionHandler extends AbstractActionHandler {
     }
 
     private void indexAnomalyDetector(String detectorId) throws IOException {
+        AnomalyDetector detector = new AnomalyDetector(
+            anomalyDetector.getDetectorId(),
+            anomalyDetector.getVersion(),
+            anomalyDetector.getName(),
+            anomalyDetector.getDescription(),
+            anomalyDetector.getTimeField(),
+            anomalyDetector.getIndices(),
+            anomalyDetector.getFeatureAttributes(),
+            anomalyDetector.getFilterQuery(),
+            anomalyDetector.getDetectionInterval(),
+            anomalyDetector.getWindowDelay(),
+            anomalyDetector.getUiMetadata(),
+            anomalyDetector.getSchemaVersion(),
+            Instant.now()
+        );
         IndexRequest indexRequest = new IndexRequest(ANOMALY_DETECTORS_INDEX)
             .setRefreshPolicy(refreshPolicy)
-            .source(anomalyDetector.toXContent(channel.newBuilder(), XCONTENT_WITH_TYPE))
+            .source(detector.toXContent(channel.newBuilder(), XCONTENT_WITH_TYPE))
             .setIfSeqNo(seqNo)
             .setIfPrimaryTerm(primaryTerm)
             .timeout(requestTimeout);

--- a/src/main/resources/mappings/anomaly-detectors.json
+++ b/src/main/resources/mappings/anomaly-detectors.json
@@ -93,13 +93,6 @@
         }
       }
     },
-    "enabled": {
-      "type": "boolean"
-    },
-    "enabled_time": {
-      "type": "date",
-      "format": "strict_date_time||epoch_millis"
-    },
     "last_update_time": {
       "type": "date",
       "format": "strict_date_time||epoch_millis"

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -171,6 +171,24 @@ public class TestHelpers {
         );
     }
 
+    public static AnomalyDetector randomAnomalyDetector(List<Feature> features) throws IOException {
+        return new AnomalyDetector(
+            randomAlphaOfLength(10),
+            randomLong(),
+            randomAlphaOfLength(20),
+            randomAlphaOfLength(30),
+            randomAlphaOfLength(5),
+            ImmutableList.of(randomAlphaOfLength(10).toLowerCase()),
+            features,
+            randomQuery(),
+            randomIntervalTimeConfiguration(),
+            randomIntervalTimeConfiguration(),
+            null,
+            randomInt(),
+            Instant.now()
+        );
+    }
+
     public static AnomalyDetector randomAnomalyDetectorWithEmptyFeature() throws IOException {
         return new AnomalyDetector(
             randomAlphaOfLength(10),
@@ -211,7 +229,11 @@ public class TestHelpers {
     }
 
     public static AggregationBuilder randomAggregation() throws IOException {
-        XContentParser parser = parser("{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}");
+        return randomAggregation(randomAlphaOfLength(5));
+    }
+
+    public static AggregationBuilder randomAggregation(String aggregationName) throws IOException {
+        XContentParser parser = parser("{\"" + aggregationName + "\":{\"value_count\":{\"field\":\"ok\"}}}");
 
         AggregatorFactories.Builder parsed = AggregatorFactories.parseAggregators(parser);
         return parsed.getAggregatorFactories().iterator().next();
@@ -234,14 +256,18 @@ public class TestHelpers {
     }
 
     public static Feature randomFeature() {
+        return randomFeature(randomAlphaOfLength(5), randomAlphaOfLength(5));
+    }
+
+    public static Feature randomFeature(String featureName, String aggregationName) {
         AggregationBuilder testAggregation = null;
         try {
-            testAggregation = randomAggregation();
+            testAggregation = randomAggregation(aggregationName);
         } catch (IOException e) {
             logger.error("Fail to generate test aggregation");
             throw new RuntimeException();
         }
-        return new Feature(randomAlphaOfLength(5), randomAlphaOfLength(5), ESRestTestCase.randomBoolean(), testAggregation);
+        return new Feature(randomAlphaOfLength(5), featureName, ESRestTestCase.randomBoolean(), testAggregation);
     }
 
     public static <S, T> void assertFailWith(Class<S> clazz, Callable<T> callable) throws Exception {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -93,7 +93,7 @@ public class TestHelpers {
 
     public static final String AD_BASE_DETECTORS_URI = "/_opendistro/_anomaly_detection/detectors";
     public static final String AD_BASE_RESULT_URI = "/_opendistro/_anomaly_detection/detectors/results";
-    public static final String AD_BASE_PREVIEW_URI = "/_opendistro/_anomaly_detection/detectors/_preview";
+    public static final String AD_BASE_PREVIEW_URI = "/_opendistro/_anomaly_detection/detectors/%s/_preview";
     public static final String AD_BASE_STATS_URI = "/_opendistro/_anomaly_detection/stats";
     private static final Logger logger = LogManager.getLogger(TestHelpers.class);
 
@@ -168,6 +168,24 @@ public class TestHelpers {
             uiMetadata,
             randomInt(),
             lastUpdateTime
+        );
+    }
+
+    public static AnomalyDetector randomAnomalyDetectorWithEmptyFeature() throws IOException {
+        return new AnomalyDetector(
+            randomAlphaOfLength(10),
+            randomLong(),
+            randomAlphaOfLength(20),
+            randomAlphaOfLength(30),
+            randomAlphaOfLength(5),
+            ImmutableList.of(randomAlphaOfLength(10).toLowerCase()),
+            ImmutableList.of(),
+            randomQuery(),
+            randomIntervalTimeConfiguration(),
+            randomIntervalTimeConfiguration(),
+            null,
+            randomInt(),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 
@@ -275,11 +293,12 @@ public class TestHelpers {
         );
     }
 
-    public static AnomalyDetectorExecutionInput randomAnomalyDetectorExecutionInput() {
+    public static AnomalyDetectorExecutionInput randomAnomalyDetectorExecutionInput() throws IOException {
         return new AnomalyDetectorExecutionInput(
             randomAlphaOfLength(5),
             Instant.now().minus(10, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS),
-            Instant.now().truncatedTo(ChronoUnit.SECONDS)
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            randomAnomalyDetector(null, Instant.now().truncatedTo(ChronoUnit.SECONDS))
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorExecutionInputTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorExecutionInputTests.java
@@ -33,7 +33,7 @@ public class AnomalyDetectorExecutionInputTests extends ESTestCase {
         detectInputString = detectInputString
             .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
         AnomalyDetectorExecutionInput parsedAnomalyDetectorExecutionInput = AnomalyDetectorExecutionInput
-            .parse(TestHelpers.parser(detectInputString));
+            .parse(TestHelpers.parser(detectInputString), detectorExecutionInput.getDetectorId());
         assertEquals("Parsing anomaly detect execution input doesn't work", detectorExecutionInput, parsedAnomalyDetectorExecutionInput);
     }
 
@@ -41,7 +41,7 @@ public class AnomalyDetectorExecutionInputTests extends ESTestCase {
         TestHelpers
             .assertFailWith(
                 IllegalArgumentException.class,
-                () -> new AnomalyDetectorExecutionInput(randomAlphaOfLength(5), null, Instant.now())
+                () -> new AnomalyDetectorExecutionInput(randomAlphaOfLength(5), null, Instant.now(), null)
             );
     }
 
@@ -49,7 +49,7 @@ public class AnomalyDetectorExecutionInputTests extends ESTestCase {
         TestHelpers
             .assertFailWith(
                 IllegalArgumentException.class,
-                () -> new AnomalyDetectorExecutionInput(randomAlphaOfLength(5), Instant.now(), null)
+                () -> new AnomalyDetectorExecutionInput(randomAlphaOfLength(5), Instant.now(), null, null)
             );
     }
 
@@ -57,7 +57,12 @@ public class AnomalyDetectorExecutionInputTests extends ESTestCase {
         TestHelpers
             .assertFailWith(
                 IllegalArgumentException.class,
-                () -> new AnomalyDetectorExecutionInput(randomAlphaOfLength(5), Instant.now(), Instant.now().minus(5, ChronoUnit.MINUTES))
+                () -> new AnomalyDetectorExecutionInput(
+                    randomAlphaOfLength(5),
+                    Instant.now(),
+                    Instant.now().minus(5, ChronoUnit.MINUTES),
+                    null
+                )
             );
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -108,7 +108,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         TestHelpers.assertFailWith(ResponseException.class, null, () -> getAnomalyDetector(randomAlphaOfLength(5)));
     }
 
-    public void testUpdateAnomalyDetector() throws IOException {
+    public void testUpdateAnomalyDetectorA() throws IOException {
         AnomalyDetector detector = createRandomAnomalyDetector(true, true);
 
         String newDescription = randomAlphaOfLength(5);
@@ -145,6 +145,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         assertEquals("Version not incremented", (detector.getVersion().intValue() + 1), (int) responseBody.get("_version"));
 
         AnomalyDetector updatedDetector = getAnomalyDetector(detector.getDetectorId());
+        assertNotEquals("Anomaly detector last update time not changed", updatedDetector.getLastUpdateTime(), detector.getLastUpdateTime());
         assertEquals("Anomaly detector description not updated", newDescription, updatedDetector.getDescription());
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -32,11 +32,13 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.junit.Ignore;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.AD_BASE_PREVIEW_URI;
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomAnomalyDetectorWithEmptyFeature;
 
 public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
 
@@ -207,16 +209,23 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         assertEquals("Get stats failed", RestStatus.OK, restStatus(statsResponse));
     }
 
-    @Ignore
     public void testPreviewAnomalyDetector() throws IOException {
         AnomalyDetector detector = createRandomAnomalyDetector(true, false);
         AnomalyDetectorExecutionInput input = new AnomalyDetectorExecutionInput(
             detector.getDetectorId(),
             Instant.now().minusSeconds(60 * 10),
-            Instant.now()
+            Instant.now(),
+            null
         );
         Response response = TestHelpers
-            .makeRequest(client(), "POST", TestHelpers.AD_BASE_PREVIEW_URI, ImmutableMap.of(), toHttpEntity(input), null);
+            .makeRequest(
+                client(),
+                "POST",
+                String.format(AD_BASE_PREVIEW_URI, input.getDetectorId()),
+                ImmutableMap.of(),
+                toHttpEntity(input),
+                null
+            );
         assertEquals("Execute anomaly detector failed", RestStatus.OK, restStatus(response));
     }
 
@@ -225,23 +234,87 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         AnomalyDetectorExecutionInput input = new AnomalyDetectorExecutionInput(
             randomAlphaOfLength(5),
             Instant.now().minusSeconds(60 * 10),
-            Instant.now()
+            Instant.now(),
+            null
         );
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
                 () -> TestHelpers
-                    .makeRequest(client(), "POST", TestHelpers.AD_BASE_PREVIEW_URI, ImmutableMap.of(), toHttpEntity(input), null)
+                    .makeRequest(
+                        client(),
+                        "POST",
+                        String.format(TestHelpers.AD_BASE_PREVIEW_URI, input.getDetectorId()),
+                        ImmutableMap.of(),
+                        toHttpEntity(input),
+                        null
+                    )
             );
     }
 
     public void testExecuteAnomalyDetectorWithNullDetectorId() throws Exception {
-        AnomalyDetectorExecutionInput input = new AnomalyDetectorExecutionInput(null, Instant.now().minusSeconds(60 * 10), Instant.now());
+        AnomalyDetectorExecutionInput input = new AnomalyDetectorExecutionInput(
+            null,
+            Instant.now().minusSeconds(60 * 10),
+            Instant.now(),
+            null
+        );
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
                 () -> TestHelpers
-                    .makeRequest(client(), "POST", TestHelpers.AD_BASE_PREVIEW_URI, ImmutableMap.of(), toHttpEntity(input), null)
+                    .makeRequest(
+                        client(),
+                        "POST",
+                        String.format(TestHelpers.AD_BASE_PREVIEW_URI, input.getDetectorId()),
+                        ImmutableMap.of(),
+                        toHttpEntity(input),
+                        null
+                    )
+            );
+    }
+
+    public void testPreviewAnomalyDetectorWithDetector() throws Exception {
+        AnomalyDetector detector = createRandomAnomalyDetector(true, true);
+        AnomalyDetectorExecutionInput input = new AnomalyDetectorExecutionInput(
+            detector.getDetectorId(),
+            Instant.now().minusSeconds(60 * 10),
+            Instant.now(),
+            detector
+        );
+        Response response = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                String.format(AD_BASE_PREVIEW_URI, input.getDetectorId()),
+                ImmutableMap.of(),
+                toHttpEntity(input),
+                null
+            );
+        assertEquals("Execute anomaly detector failed", RestStatus.OK, restStatus(response));
+    }
+
+    public void testPreviewAnomalyDetectorWithDetectorAndNoFeatures() throws Exception {
+        AnomalyDetector detector = createRandomAnomalyDetector(true, true);
+        AnomalyDetectorExecutionInput input = new AnomalyDetectorExecutionInput(
+            detector.getDetectorId(),
+            Instant.now().minusSeconds(60 * 10),
+            Instant.now(),
+            randomAnomalyDetectorWithEmptyFeature()
+        );
+        TestHelpers
+            .assertFailWith(
+                ResponseException.class,
+                "Can't preview detector without feature",
+                () -> TestHelpers
+                    .makeRequest(
+                        client(),
+                        "POST",
+                        String.format(TestHelpers.AD_BASE_PREVIEW_URI, input.getDetectorId()),
+                        ImmutableMap.of(),
+                        toHttpEntity(input),
+                        null
+                    )
             );
     }
 


### PR DESCRIPTION
*Issue #71

*Description of changes:*

1.Support previewing detector on the fly. If user pass detector in preview API, will preview the detector directly without saving and retrieving it.
2.Remove useless fields in detector index mapping

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
