### PR TITLE
Fix null pointer exception during preview

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -692,7 +691,6 @@ public class ModelManager {
             throw new IllegalArgumentException("Insufficient data for preview results. Minimum required: " + minPreviewSize);
         }
         // Train RCF models and collect non-zero scores
-        Random random = new Random();
         int rcfNumFeatures = dataPoints[0].length;
         RandomCutForest forest = RandomCutForest
             .builder()

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
@@ -88,11 +88,20 @@ public class AnomalyResult implements ToXContentObject {
         XContentBuilder xContentBuilder = builder
             .startObject()
             .field(DETECTOR_ID_FIELD, detectorId)
-            .field(FEATURE_DATA_FIELD, featureData.toArray())
             .field(DATA_START_TIME_FIELD, dataStartTime.toEpochMilli())
-            .field(DATA_END_TIME_FIELD, dataEndTime.toEpochMilli())
-            .field(EXECUTION_START_TIME_FIELD, executionStartTime.toEpochMilli())
-            .field(EXECUTION_END_TIME_FIELD, executionEndTime.toEpochMilli());
+            .field(DATA_END_TIME_FIELD, dataEndTime.toEpochMilli());
+        if (featureData != null) {
+            // can be null during preview
+            xContentBuilder.field(FEATURE_DATA_FIELD, featureData.toArray());
+        }
+        if (executionStartTime != null) {
+            // can be null during preview
+            xContentBuilder.field(EXECUTION_START_TIME_FIELD, executionStartTime.toEpochMilli());
+        }
+        if (executionEndTime != null) {
+            // can be null during preview
+            xContentBuilder.field(EXECUTION_END_TIME_FIELD, executionEndTime.toEpochMilli());
+        }
         if (anomalyScore != null && !anomalyScore.isNaN()) {
             xContentBuilder.field(ANOMALY_SCORE_FIELD, anomalyScore);
         }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/73

*Description of changes:*
Recently, we changed the anomaly result index’s schema and toXContent method by introducing new fields. During the preview, some of the fields in anomaly result index are null. Thus, toXContent fails with a null pointer exception.

This PR fixes the issue by protecting a field’s serialization with a null check.

This PR also removes an unused local variable in ModelManager.

Testing done:
- Manually verified the issue is gone
- gradle build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
