### PR TITLE
Can't start AD job if detector has no feature

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -155,11 +155,14 @@ public class AnomalyDetector implements ToXContentObject {
             .field(DESCRIPTION_FIELD, description)
             .field(TIMEFIELD_FIELD, timeField)
             .field(INDICES_FIELD, indices.toArray())
-            .field(FEATURE_ATTRIBUTES_FIELD, featureAttributes.toArray())
             .field(FILTER_QUERY_FIELD, filterQuery)
             .field(DETECTION_INTERVAL_FIELD, detectionInterval)
             .field(WINDOW_DELAY_FIELD, windowDelay)
             .field(SCHEMA_VERSION_FIELD, schemaVersion);
+
+        if (featureAttributes != null) {
+            xContentBuilder.field(FEATURE_ATTRIBUTES_FIELD, featureAttributes.toArray());
+        }
 
         if (uiMetadata != null && !uiMetadata.isEmpty()) {
             xContentBuilder.field(UI_METADATA_FIELD, uiMetadata);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
@@ -154,6 +154,11 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
             AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
 
+            if (detector.getFeatureAttributes().size() == 0) {
+                channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "Can't start detector job as no features configured"));
+                return;
+            }
+
             IntervalTimeConfiguration interval = (IntervalTimeConfiguration) detector.getDetectionInterval();
             Schedule schedule = new IntervalSchedule(Instant.now(), (int) interval.getInterval(), interval.getUnit());
             Duration duration = Duration.of(interval.getInterval(), interval.getUnit());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -154,6 +154,11 @@ public class TestHelpers {
     }
 
     public static AnomalyDetector randomAnomalyDetector(Map<String, Object> uiMetadata, Instant lastUpdateTime) throws IOException {
+        return randomAnomalyDetector(ImmutableList.of(randomFeature()), uiMetadata, lastUpdateTime);
+    }
+
+    public static AnomalyDetector randomAnomalyDetector(List<Feature> features, Map<String, Object> uiMetadata, Instant lastUpdateTime)
+        throws IOException {
         return new AnomalyDetector(
             randomAlphaOfLength(10),
             randomLong(),
@@ -161,7 +166,7 @@ public class TestHelpers {
             randomAlphaOfLength(30),
             randomAlphaOfLength(5),
             ImmutableList.of(randomAlphaOfLength(10).toLowerCase()),
-            ImmutableList.of(randomFeature()),
+            features,
             randomQuery(),
             randomIntervalTimeConfiguration(),
             randomIntervalTimeConfiguration(),
@@ -343,5 +348,17 @@ public class TestHelpers {
         ThreadPool pool = mock(ThreadPool.class);
         when(pool.getThreadContext()).thenReturn(createThreadContext());
         return pool;
+    }
+
+    public static void createIndex(RestClient client, String indexName, HttpEntity data) throws IOException {
+        TestHelpers
+            .makeRequest(
+                client,
+                "POST",
+                "/" + indexName + "/_doc/" + randomAlphaOfLength(5) + "?refresh=true",
+                ImmutableMap.of(),
+                data,
+                null
+            );
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Locale;
 
 public class AnomalyDetectorTests extends ESTestCase {
@@ -233,5 +234,20 @@ public class AnomalyDetectorTests extends ESTestCase {
                     Instant.now()
                 )
             );
+    }
+
+    public void testNullFeatures() throws IOException {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(null, null, Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(0, parsedDetector.getFeatureAttributes().size());
+    }
+
+    public void testEmptyFeatures() throws IOException {
+        AnomalyDetector detector = TestHelpers
+            .randomAnomalyDetector(ImmutableList.of(), null, Instant.now().truncatedTo(ChronoUnit.SECONDS));
+        String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals(0, parsedDetector.getFeatureAttributes().size());
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -22,6 +22,7 @@ import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorExecutionInput;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
@@ -75,15 +76,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
     public void testCreateAnomalyDetector() throws IOException {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null);
         String indexName = detector.getIndices().get(0);
-        TestHelpers
-            .makeRequest(
-                client(),
-                "POST",
-                "/" + indexName + "/_doc/" + randomAlphaOfLength(5) + "?refresh=true",
-                ImmutableMap.of(),
-                toHttpEntity("{\"name\": \"test\"}"),
-                null
-            );
+        TestHelpers.createIndex(client(), indexName, toHttpEntity("{\"name\": \"test\"}"));
 
         Response response = TestHelpers
             .makeRequest(client(), "POST", TestHelpers.AD_BASE_DETECTORS_URI, ImmutableMap.of(), toHttpEntity(detector), null);
@@ -615,4 +608,45 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         assertEquals("Fail to start AD job", RestStatus.OK, restStatus(startAdJobResponse));
     }
 
+    public void testStartAdjobWithNullFeatures() throws Exception {
+        AnomalyDetector detectorWithoutFeature = TestHelpers.randomAnomalyDetector(null, null, Instant.now());
+        String indexName = detectorWithoutFeature.getIndices().get(0);
+        TestHelpers.createIndex(client(), indexName, toHttpEntity("{\"name\": \"test\"}"));
+        AnomalyDetector detector = createAnomalyDetector(detectorWithoutFeature, true);
+        TestHelpers
+            .assertFailWith(
+                ResponseException.class,
+                "Can't start detector job as no features configured",
+                () -> TestHelpers
+                    .makeRequest(
+                        client(),
+                        "POST",
+                        TestHelpers.AD_BASE_DETECTORS_URI + "/" + detector.getDetectorId() + "/_start",
+                        ImmutableMap.of(),
+                        "",
+                        null
+                    )
+            );
+    }
+
+    public void testStartAdjobWithEmptyFeatures() throws Exception {
+        AnomalyDetector detectorWithoutFeature = TestHelpers.randomAnomalyDetector(ImmutableList.of(), null, Instant.now());
+        String indexName = detectorWithoutFeature.getIndices().get(0);
+        TestHelpers.createIndex(client(), indexName, toHttpEntity("{\"name\": \"test\"}"));
+        AnomalyDetector detector = createAnomalyDetector(detectorWithoutFeature, true);
+        TestHelpers
+            .assertFailWith(
+                ResponseException.class,
+                "Can't start detector job as no features configured",
+                () -> TestHelpers
+                    .makeRequest(
+                        client(),
+                        "POST",
+                        TestHelpers.AD_BASE_DETECTORS_URI + "/" + detector.getDetectorId() + "/_start",
+                        ImmutableMap.of(),
+                        "",
+                        null
+                    )
+            );
+    }
 }


### PR DESCRIPTION
*Issue #75

*Description of changes:*

1.Check if feature list is null or not when convert `AnomalyDetector` to `XContentBuilder`
2.Will not start AD job if detector has no features.
