### PR TITLE
Change the default value of lastUpdateTime

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -230,7 +230,7 @@ public class AnomalyDetector implements ToXContentObject {
         List<Feature> features = new ArrayList<>();
         int schemaVersion = 0;
         Map<String, Object> uiMetadata = null;
-        Instant lastUpdateTime = Instant.now();
+        Instant lastUpdateTime = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -93,16 +93,6 @@ public class AnomalyDetectorTests extends ESTestCase {
         assertEquals("Parsing anomaly detector doesn't work", detector, parsedDetector);
     }
 
-    public void testParseAnomalyDetectorWithNullLastUpdateTime() throws IOException {
-        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of(), null);
-        String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
-        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), detector.getDetectorId());
-        assertEquals("Parsing anomaly detector doesn't work", detector, parsedDetector);
-        assertEquals("Parsing anomaly detector doesn't work", detector.getDetectorId(), parsedDetector.getDetectorId());
-        assertNull(detector.getLastUpdateTime());
-        assertNotNull(parsedDetector.getLastUpdateTime());
-    }
-
     public void testNullDetectorName() throws Exception {
         TestHelpers
             .assertFailWith(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManagerTests.java
@@ -92,6 +92,7 @@ public class ADStateManagerTests extends ESTestCase {
             .build();
         clock = mock(Clock.class);
         duration = Duration.ofHours(1);
+        context = TestHelpers.createThreadPool();
         throttler = new Throttler(clock);
 
         stateManager = new ADStateManager(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/IndexUtilsTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/IndexUtilsTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import java.time.Clock;
 
 import static org.mockito.Mockito.mock;
@@ -36,8 +37,8 @@ public class IndexUtilsTests extends ESIntegTestCase {
         Client client = client();
         Clock clock = mock(Clock.class);
         Throttler throttler = new Throttler(clock);
-        ThreadPool threadPool = mock(ThreadPool.class);
-        clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, threadPool);
+        ThreadPool context = TestHelpers.createThreadPool();
+        clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, context);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The PR does the following:

1. Change the default value of lastUpdateTime from the current timestamp to null. Before the change, creating a detector returns one lastUpdateTime, while getting a detector returns a different lastUpdateTime. The difference is confusing to the user, and they may wonder what has happened between the creating and getting detector calls. After the change, creating a detector returns no last update time, while getting a detector returns a last update time.
2. Replace the mocked threadpool in 2 tests with a real threadpool object.

Testing done:
1. verified lastUpdateTime change in a cluster
2. gradle build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
