### PR TITLE
Added URL for jb_scheduler-plugin_zip instead of local file path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ repositories {
 ext {
     opendistroVersion = '1.4.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-    job_scheduler_plugin_zip = "file://${fileTree("src/test/resources/job-scheduler").getSingleFile().absolutePath}"
+    job_scheduler_plugin_zip = "https://github.com/opendistro-for-elasticsearch/job-scheduler/releases/download/v1.4.0.0/opendistro-job-scheduler-1.4.0.0.zip"
 }
 
 version = "${opendistroVersion}.0"

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,11 @@ repositories {
 ext {
     opendistroVersion = '1.4.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-    job_scheduler_plugin_zip = "https://github.com/opendistro-for-elasticsearch/job-scheduler/releases/download/v1.4.0.0/opendistro-job-scheduler-1.4.0.0.zip"
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+        job_scheduler_plugin_zip = "file:///${fileTree("src/test/resources/job-scheduler").getSingleFile().absolutePath}"
+    } else {
+        job_scheduler_plugin_zip = "file://${fileTree("src/test/resources/job-scheduler").getSingleFile().absolutePath}"
+    }
 }
 
 version = "${opendistroVersion}.0"


### PR DESCRIPTION
*Issue #79 *

*Description of changes:*
The build process failed on Windows because of a UNIX-specific path. During the build, there would be an attempt to download the file from the local file system which would result in an error, as shown in issue #79 . 

The change included adding a remote URL from which the job-scheduler plugin would be downloaded instead of a local file reference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
