### PR TITLE
Use callbacks and bug fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,23 +251,17 @@ List<String> jacocoExclusions = [
         'com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException',
         'com.amazon.opendistroforelasticsearch.ad.util.ClientUtil',
 
-        'com.amazon.opendistroforelasticsearch.ad.ml.*',
-        'com.amazon.opendistroforelasticsearch.ad.feature.*',
-        'com.amazon.opendistroforelasticsearch.ad.dataprocessor.*',
-        'com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorRunner',
-        'com.amazon.opendistroforelasticsearch.ad.resthandler.RestGetAnomalyResultAction',
-        'com.amazon.opendistroforelasticsearch.ad.metrics.MetricFactory',
-        'com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices',
-        'com.amazon.opendistroforelasticsearch.ad.transport.ForwardAction',
-        'com.amazon.opendistroforelasticsearch.ad.transport.ForwardTransportAction',
         'com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorAction',
         'com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorRequest',
         'com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorResponse',
         'com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorTransportAction',
-        'com.amazon.opendistroforelasticsearch.ad.transport.ADStatsAction',
-        'com.amazon.opendistroforelasticsearch.ad.transport.CronRequest',
         'com.amazon.opendistroforelasticsearch.ad.transport.DeleteDetectorAction',
-        'com.amazon.opendistroforelasticsearch.ad.util.ParseUtils'
+        'com.amazon.opendistroforelasticsearch.ad.transport.CronTransportAction',
+        'com.amazon.opendistroforelasticsearch.ad.transport.CronRequest',
+        'com.amazon.opendistroforelasticsearch.ad.transport.ADStatsAction',
+        'com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorRunner',
+        'com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices',
+        'com.amazon.opendistroforelasticsearch.ad.util.ParseUtils',
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -274,7 +274,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             HybridThresholdingModel.class,
             AnomalyDetectorSettings.MIN_PREVIEW_SIZE,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            AnomalyDetectorSettings.HOURLY_MAINTENANCE
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            AnomalyDetectorSettings.SHINGLE_SIZE
         );
 
         HashRing hashRing = new HashRing(clusterService, clock, settings);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -143,6 +143,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
     private ThreadPool threadPool;
     private IndexNameExpressionResolver indexNameExpressionResolver;
     private ADStats adStats;
+    private ClientUtil clientUtil;
 
     static {
         SpecialPermission.check();
@@ -174,6 +175,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         );
         AnomalyDetectorJobRunner jobRunner = AnomalyDetectorJobRunner.getJobRunnerInstance();
         jobRunner.setClient(client);
+        jobRunner.setClientUtil(clientUtil);
         jobRunner.setThreadPool(threadPool);
         jobRunner.setAnomalyResultHandler(anomalyResultHandler);
         jobRunner.setSettings(settings);
@@ -237,7 +239,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         Settings settings = environment.settings();
         Clock clock = Clock.systemUTC();
         Throttler throttler = new Throttler(clock);
-        ClientUtil clientUtil = new ClientUtil(settings, client, throttler, threadPool);
+        this.clientUtil = new ClientUtil(settings, client, throttler, threadPool);
         IndexUtils indexUtils = new IndexUtils(client, clientUtil, clusterService);
         anomalyDetectionIndices = new AnomalyDetectionIndices(client, clusterService, threadPool, settings, clientUtil);
         this.clusterService = clusterService;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
@@ -58,6 +58,7 @@ public final class AnomalyDetectorRunner {
      * @param startTime detection period start time
      * @param endTime   detection period end time
      * @param listener handle anomaly result
+     * @throws IOException - if a user gives wrong query input when defining a detector
      */
     public void executeDetector(AnomalyDetector detector, Instant startTime, Instant endTime, ActionListener<List<AnomalyResult>> listener)
         throws IOException {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -619,6 +619,116 @@ public class ModelManager {
     }
 
     /**
+    * Trains and saves cold-start AD models.
+    *
+    * This implementations splits RCF models and trains them all.
+    * As all model partitions have the same size, the scores from RCF models are merged by averaging.
+    * Since RCF outputs 0 until it is ready, initial 0 scores are meaningless and therefore filtered out.
+    * Filtered (non-zero) RCF scores are the training data for a single thresholding model.
+    * All trained models are serialized and persisted to be hosted.
+    *
+    * @param anomalyDetector the detector for which models are trained
+    * @param dataPoints M, N shape, where M is the number of samples for training and N is the number of features
+    * @param listener onResponse is called with null when this operation is completed
+    *                 onFailure is called IllegalArgumentException when training data is invalid
+    *                 onFailure is called LimitExceededException when a limit for training is exceeded
+    */
+    public void trainModel(AnomalyDetector anomalyDetector, double[][] dataPoints, ActionListener<Void> listener) {
+        if (dataPoints.length == 0 || dataPoints[0].length == 0) {
+            listener.onFailure(new IllegalArgumentException("Data points must not be empty."));
+        } else {
+            int rcfNumFeatures = dataPoints[0].length;
+            // creates partitioned RCF models
+            try {
+                Entry<Integer, Integer> partitionResults = getPartitionedForestSizes(
+                    RandomCutForest
+                        .builder()
+                        .dimensions(rcfNumFeatures)
+                        .sampleSize(rcfNumSamplesInTree)
+                        .numberOfTrees(rcfNumTrees)
+                        .outputAfter(rcfNumSamplesInTree)
+                        .parallelExecutionEnabled(false)
+                        .build(),
+                    anomalyDetector.getDetectorId()
+                );
+                int numForests = partitionResults.getKey();
+                int forestSize = partitionResults.getValue();
+                double[] scores = new double[dataPoints.length];
+                Arrays.fill(scores, 0.);
+                trainModelForStep(anomalyDetector, dataPoints, rcfNumFeatures, numForests, forestSize, scores, 0, listener);
+            } catch (LimitExceededException e) {
+                listener.onFailure(e);
+            }
+        }
+    }
+
+    private void trainModelForStep(
+        AnomalyDetector detector,
+        double[][] dataPoints,
+        int rcfNumFeatures,
+        int numForests,
+        int forestSize,
+        final double[] scores,
+        int step,
+        ActionListener<Void> listener
+    ) {
+        if (step < numForests) {
+            RandomCutForest rcf = RandomCutForest
+                .builder()
+                .dimensions(rcfNumFeatures)
+                .sampleSize(rcfNumSamplesInTree)
+                .numberOfTrees(forestSize)
+                .lambda(rcfTimeDecay)
+                .outputAfter(rcfNumSamplesInTree)
+                .parallelExecutionEnabled(false)
+                .build();
+            for (int j = 0; j < dataPoints.length; j++) {
+                scores[j] += rcf.getAnomalyScore(dataPoints[j]);
+                rcf.update(dataPoints[j]);
+            }
+            String modelId = getRcfModelId(detector.getDetectorId(), step);
+            String checkpoint = AccessController.doPrivileged((PrivilegedAction<String>) () -> rcfSerde.toJson(rcf));
+            checkpointDao
+                .putModelCheckpoint(
+                    modelId,
+                    checkpoint,
+                    ActionListener
+                        .wrap(
+                            r -> trainModelForStep(
+                                detector,
+                                dataPoints,
+                                rcfNumFeatures,
+                                numForests,
+                                forestSize,
+                                scores,
+                                step + 1,
+                                listener
+                            ),
+                            listener::onFailure
+                        )
+                );
+        } else {
+            double[] rcfScores = DoubleStream.of(scores).filter(score -> score > 0).map(score -> score / numForests).toArray();
+
+            // Train thresholding model
+            ThresholdingModel threshold = new HybridThresholdingModel(
+                thresholdMinPvalue,
+                thresholdMaxRankError,
+                thresholdMaxScore,
+                thresholdNumLogNormalQuantiles,
+                thresholdDownsamples,
+                thresholdMaxSamples
+            );
+            threshold.train(rcfScores);
+
+            // Persist thresholding model
+            String modelId = getThresholdModelId(detector.getDetectorId());
+            String checkpoint = AccessController.doPrivileged((PrivilegedAction<String>) () -> gson.toJson(threshold));
+            checkpointDao.putModelCheckpoint(modelId, checkpoint, ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure));
+        }
+    }
+
+    /**
      * Returns the model ID for the RCF model partition.
      *
      * @param detectorId ID of the detector for which the RCF model is trained

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -233,7 +233,7 @@ public class AnomalyDetector implements ToXContentObject {
         List<Feature> features = new ArrayList<>();
         int schemaVersion = 0;
         Map<String, Object> uiMetadata = null;
-        Instant lastUpdateTime = Instant.now();
+        Instant lastUpdateTime = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,10 +30,11 @@ import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectio
 import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
-import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.Client;
@@ -43,8 +43,6 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
-
-import com.amazon.randomcutforest.RandomCutForest;
 
 /**
  * ADStateManager is used by transport layer to manage AnomalyDetector object
@@ -56,7 +54,6 @@ public class ADStateManager {
     private ConcurrentHashMap<String, Entry<AnomalyDetector, Instant>> currentDetectors;
     private ConcurrentHashMap<String, Entry<Integer, Instant>> partitionNumber;
     private Client client;
-    private Random random;
     private ModelManager modelManager;
     private NamedXContentRegistry xContentRegistry;
     private ClientUtil clientUtil;
@@ -77,7 +74,6 @@ public class ADStateManager {
     ) {
         this.currentDetectors = new ConcurrentHashMap<>();
         this.client = client;
-        this.random = new Random();
         this.modelManager = modelManager;
         this.xContentRegistry = xContentRegistry;
         this.partitionNumber = new ConcurrentHashMap<>();
@@ -91,67 +87,63 @@ public class ADStateManager {
     /**
      * Get the number of RCF model's partition number for detector adID
      * @param adID detector id
+     * @param detector object
      * @return the number of RCF model's partition number for adID
      * @throws InterruptedException when we cannot get anomaly detector object for adID before timeout
      * @throws LimitExceededException when there is no sufficient resource available
      */
-    public int getPartitionNumber(String adID) throws InterruptedException {
+    public int getPartitionNumber(String adID, Optional<AnomalyDetector> detector) throws InterruptedException {
         Entry<Integer, Instant> partitonAndTime = partitionNumber.get(adID);
         if (partitonAndTime != null) {
             partitonAndTime.setValue(clock.instant());
             return partitonAndTime.getKey();
         }
 
-        Optional<AnomalyDetector> detector = getAnomalyDetector(adID);
         if (!detector.isPresent()) {
             throw new AnomalyDetectionException(adID, "AnomalyDetector is not found");
         }
 
-        RandomCutForest forest = RandomCutForest
-            .builder()
-            .dimensions(detector.get().getFeatureAttributes().size() * AnomalyDetectorSettings.SHINGLE_SIZE)
-            .sampleSize(AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE)
-            .numberOfTrees(AnomalyDetectorSettings.NUM_TREES)
-            .parallelExecutionEnabled(false)
-            .build();
-        int partitionNum = modelManager.getPartitionedForestSizes(forest, adID).getKey();
+        int partitionNum = modelManager.getPartitionedForestSizes(adID, detector.get().getEnabledFeatureIds().size()).getKey();
         partitionNumber.putIfAbsent(adID, new SimpleEntry<>(partitionNum, clock.instant()));
         return partitionNum;
     }
 
-    public Optional<AnomalyDetector> getAnomalyDetector(String adID) {
+    public void getAnomalyDetector(String adID, ActionListener<Optional<AnomalyDetector>> listener) {
         Entry<AnomalyDetector, Instant> detectorAndTime = currentDetectors.get(adID);
         if (detectorAndTime != null) {
             detectorAndTime.setValue(clock.instant());
-            return Optional.of(detectorAndTime.getKey());
+            listener.onResponse(Optional.of(detectorAndTime.getKey()));
+            return;
         }
 
         GetRequest request = new GetRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX, adID);
 
-        Optional<GetResponse> getResponse = clientUtil.<GetRequest, GetResponse>timedRequest(request, LOG, client::get);
-
-        return onGetResponse(getResponse, adID);
+        clientUtil.<GetRequest, GetResponse>asyncRequest(request, client::get, onGetResponse(adID, listener));
     }
 
-    private Optional<AnomalyDetector> onGetResponse(Optional<GetResponse> asResponse, String adID) {
-        if (!asResponse.isPresent() || !asResponse.get().isExists()) {
-            return Optional.empty();
-        }
+    private ActionListener<GetResponse> onGetResponse(String adID, ActionListener<Optional<AnomalyDetector>> listener) {
+        return ActionListener.wrap(response -> {
+            if (response == null || !response.isExists()) {
+                listener.onResponse(Optional.empty());
+                return;
+            }
 
-        GetResponse response = asResponse.get();
-        String xc = response.getSourceAsString();
-        LOG.debug("Fetched anomaly detector: {}", xc);
+            String xc = response.getSourceAsString();
+            LOG.info("Fetched anomaly detector: {}", xc);
 
-        try (XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, xc)) {
-            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
-            AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId());
-            currentDetectors.put(adID, new SimpleEntry<>(detector, clock.instant()));
-            return Optional.of(detector);
-        } catch (Exception t) {
-            LOG.error("Fail to parse detector {}", adID);
-            LOG.error("Stack trace:", t);
-            return Optional.empty();
-        }
+            try (
+                XContentParser parser = XContentType.JSON.xContent().createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, xc)
+            ) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+                AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId());
+                currentDetectors.put(adID, new SimpleEntry<>(detector, clock.instant()));
+                listener.onResponse(Optional.of(detector));
+            } catch (Exception t) {
+                LOG.error("Fail to parse detector {}", adID);
+                LOG.error("Stack trace:", t);
+                listener.onResponse(Optional.empty());
+            }
+        }, listener::onFailure);
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManager.java
@@ -88,10 +88,9 @@ public class ADStateManager {
      * @param adID detector id
      * @param detector object
      * @return the number of RCF model's partition number for adID
-     * @throws InterruptedException when we cannot get anomaly detector object for adID before timeout
      * @throws LimitExceededException when there is no sufficient resource available
      */
-    public int getPartitionNumber(String adID, AnomalyDetector detector) throws InterruptedException {
+    public int getPartitionNumber(String adID, AnomalyDetector detector) {
         Entry<Integer, Instant> partitonAndTime = partitionNumber.get(adID);
         if (partitonAndTime != null) {
             partitonAndTime.setValue(clock.instant());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/RCFResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/RCFResultTransportAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import com.amazon.opendistroforelasticsearch.ad.breaker.ADCircuitBreakerService;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
-import com.amazon.opendistroforelasticsearch.ad.ml.RcfResult;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -57,8 +57,21 @@ public class RCFResultTransportAction extends HandledTransportAction<RCFResultRe
 
         try {
             LOG.info("Serve rcf request for {}", request.getModelID());
-            RcfResult result = manager.getRcfResult(request.getAdID(), request.getModelID(), request.getFeatures());
-            listener.onResponse(new RCFResultResponse(result.getScore(), result.getConfidence(), result.getForestSize()));
+            manager
+                .getRcfResult(
+                    request.getAdID(),
+                    request.getModelID(),
+                    request.getFeatures(),
+                    ActionListener
+                        .wrap(
+                            result -> listener
+                                .onResponse(new RCFResultResponse(result.getScore(), result.getConfidence(), result.getForestSize())),
+                            exception -> {
+                                LOG.warn(exception);
+                                listener.onFailure(exception);
+                            }
+                        )
+                );
         } catch (Exception e) {
             LOG.error(e);
             listener.onFailure(e);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StopDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StopDetectorTransportAction.java
@@ -15,7 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
-import com.amazon.opendistroforelasticsearch.ad.cluster.DeleteDetector;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.InternalFailure;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,20 +38,17 @@ public class StopDetectorTransportAction extends HandledTransportAction<ActionRe
 
     private final Client client;
     private final ClusterService clusterService;
-    private final DeleteDetector deleteUtil;
 
     @Inject
     public StopDetectorTransportAction(
         TransportService transportService,
         ClusterService clusterService,
         ActionFilters actionFilters,
-        Client client,
-        DeleteDetector deleteUtil
+        Client client
     ) {
         super(StopDetectorAction.NAME, transportService, actionFilters, StopDetectorRequest::new);
         this.client = client;
         this.clusterService = clusterService;
-        this.deleteUtil = deleteUtil;
     }
 
     @Override

--- a/src/main/resources/mappings/anomaly-results.json
+++ b/src/main/resources/mappings/anomaly-results.json
@@ -45,6 +45,9 @@
     "execution_end_time": {
       "type": "date",
       "format": "strict_date_time||epoch_millis"
+    },
+    "error": {
+      "type": "text"
     }
   }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/cluster/ADClusterEventListenerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/cluster/ADClusterEventListenerTests.java
@@ -33,6 +33,7 @@ import static java.util.Collections.emptySet;
 
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
+
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -135,6 +135,7 @@ public class ModelManagerTests {
     private String rcfModelId;
     private String thresholdModelId;
     private String checkpoint;
+    private int shingleSize;
 
     @Before
     public void setup() {
@@ -156,6 +157,7 @@ public class ModelManagerTests {
         minPreviewSize = 500;
         modelTtl = Duration.ofHours(1);
         checkpointInterval = Duration.ofHours(1);
+        shingleSize = 1;
 
         rcf = RandomCutForest.builder().dimensions(numFeatures).sampleSize(numSamples).numberOfTrees(numTrees).build();
 
@@ -185,7 +187,8 @@ public class ModelManagerTests {
                 thresholdingModelClass,
                 minPreviewSize,
                 modelTtl,
-                checkpointInterval
+                checkpointInterval,
+                shingleSize
             )
         );
 
@@ -591,7 +594,7 @@ public class ModelManagerTests {
     public void trainModel_putTrainedModels() {
         double[][] trainData = new Random().doubles().limit(100).mapToObj(d -> new double[] { d }).toArray(double[][]::new);
         doReturn(new SimpleEntry<>(1, 10)).when(modelManager).getPartitionedForestSizes(anyObject(), anyObject());
-
+        doReturn(asList("feature1")).when(anomalyDetector).getEnabledFeatureIds();
         modelManager.trainModel(anomalyDetector, trainData);
 
         verify(checkpointDao).putModelCheckpoint(eq(modelManager.getRcfModelId(anomalyDetector.getDetectorId(), 0)), anyObject());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -94,16 +94,6 @@ public class AnomalyDetectorTests extends ESTestCase {
         assertEquals("Parsing anomaly detector doesn't work", detector, parsedDetector);
     }
 
-    public void testParseAnomalyDetectorWithNullLastUpdateTime() throws IOException {
-        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of(), null);
-        String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
-        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), detector.getDetectorId());
-        assertEquals("Parsing anomaly detector doesn't work", detector, parsedDetector);
-        assertEquals("Parsing anomaly detector doesn't work", detector.getDetectorId(), parsedDetector.getDetectorId());
-        assertNull(detector.getLastUpdateTime());
-        assertNotNull(parsedDetector.getLastUpdateTime());
-    }
-
     public void testNullDetectorName() throws Exception {
         TestHelpers
             .assertFailWith(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManagerTests.java
@@ -94,6 +94,7 @@ public class ADStateManagerTests extends ESTestCase {
             .build();
         clock = mock(Clock.class);
         duration = Duration.ofHours(1);
+        context = TestHelpers.createThreadPool();
         throttler = new Throttler(clock);
 
         stateManager = new ADStateManager(client, xContentRegistry(), modelManager, settings, clientUtil, clock, duration);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStateManagerTests.java
@@ -16,7 +16,6 @@
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
@@ -29,7 +28,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map.Entry;
@@ -84,7 +82,7 @@ public class ADStateManagerTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         modelManager = mock(ModelManager.class);
-        when(modelManager.getPartitionedForestSizes(any(String.class), anyInt())).thenReturn(new SimpleImmutableEntry<>(2, 20));
+        when(modelManager.getPartitionedForestSizes(any(AnomalyDetector.class))).thenReturn(new SimpleImmutableEntry<>(2, 20));
         client = mock(Client.class);
         clientUtil = mock(ClientUtil.class);
         settings = Settings
@@ -157,7 +155,7 @@ public class ADStateManagerTests extends ESTestCase {
     public void testGetPartitionNumber() throws IOException, InterruptedException {
         String detectorId = setupDetector(true);
         int partitionNumber = stateManager
-            .getPartitionNumber(detectorId, Optional.of(TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null)));
+            .getPartitionNumber(detectorId, TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null));
         assertEquals(2, partitionNumber);
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyDouble;
@@ -53,7 +53,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import com.amazon.opendistroforelasticsearch.ad.breaker.ADCircuitBreakerService;
-import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.cluster.HashRing;
@@ -85,7 +84,6 @@ import com.amazon.opendistroforelasticsearch.ad.util.Throttler;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
-import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
@@ -135,7 +133,6 @@ public class AnomalyResultTests extends AbstractADTest {
     private FeatureManager featureQuery;
     private ModelManager normalModelManager;
     private Client client;
-    private AnomalyDetectionIndices anomalyDetectionIndices;
     private AnomalyDetector detector;
     private HashRing hashRing;
     private IndexNameExpressionResolver indexNameResolver;
@@ -171,7 +168,7 @@ public class AnomalyResultTests extends AbstractADTest {
         clusterService = testNodes[0].clusterService;
         stateManager = mock(ADStateManager.class);
         // return 2 RCF partitions
-        when(stateManager.getPartitionNumber(any(String.class))).thenReturn(2);
+        when(stateManager.getPartitionNumber(any(String.class), any(Optional.class))).thenReturn(2);
         when(stateManager.isMuted(any(String.class))).thenReturn(false);
 
         detector = mock(AnomalyDetector.class);
@@ -184,19 +181,35 @@ public class AnomalyResultTests extends AbstractADTest {
         userIndex.add("test*");
         when(detector.getIndices()).thenReturn(userIndex);
         when(detector.getDetectorId()).thenReturn("testDetectorId");
-        when(stateManager.getAnomalyDetector(any(String.class))).thenReturn(Optional.of(detector));
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.of(detector));
+            return null;
+        }).when(stateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
 
         hashRing = mock(HashRing.class);
         when(hashRing.getOwningNode(any(String.class))).thenReturn(Optional.of(clusterService.state().nodes().getLocalNode()));
         when(hashRing.build()).thenReturn(true);
         featureQuery = mock(FeatureManager.class);
-        when(featureQuery.getCurrentFeatures(any(AnomalyDetector.class), anyLong(), anyLong()))
-            .thenReturn(new SinglePointFeatures(Optional.of(new double[] { 0.0d }), Optional.of(new double[] { 0 })));
+
+        doAnswer(invocation -> {
+            ActionListener<SinglePointFeatures> listener = invocation.getArgument(3);
+            listener.onResponse(new SinglePointFeatures(Optional.of(new double[] { 0.0d }), Optional.of(new double[] { 0 })));
+            return null;
+        }).when(featureQuery).getCurrentFeatures(any(AnomalyDetector.class), anyLong(), anyLong(), any(ActionListener.class));
+
         normalModelManager = mock(ModelManager.class);
-        when(normalModelManager.getThresholdingResult(any(String.class), any(String.class), anyDouble()))
-            .thenReturn(new ThresholdingResult(0, 1.0d));
-        when(normalModelManager.getRcfResult(any(String.class), any(String.class), any(double[].class)))
-            .thenReturn(new RcfResult(0.2, 0, 100));
+        doAnswer(invocation -> {
+            ActionListener<ThresholdingResult> listener = invocation.getArgument(3);
+            listener.onResponse(new ThresholdingResult(0, 1.0d));
+            return null;
+        }).when(normalModelManager).getThresholdingResult(any(String.class), any(String.class), anyDouble(), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<RcfResult> listener = invocation.getArgument(3);
+            listener.onResponse(new RcfResult(0.2, 0, 100));
+            return null;
+        }).when(normalModelManager).getRcfResult(any(String.class), any(String.class), any(double[].class), any(ActionListener.class));
         when(normalModelManager.combineRcfResults(any())).thenReturn(new CombinedRcfResult(0, 1.0d));
         adID = "123";
         rcfModelID = "123-rcf-1";
@@ -253,37 +266,6 @@ public class AnomalyResultTests extends AbstractADTest {
         runner = new ColdStartRunner();
     }
 
-    @SuppressWarnings("unchecked")
-    public void setUpSavingAnomalyResultIndex(boolean anomalyResultIndexExists) throws IOException {
-        anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
-        doAnswer(invocation -> {
-            Object[] args = invocation.getArguments();
-            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 1);
-
-            ActionListener<CreateIndexResponse> listener = null;
-
-            if (args[0] instanceof ActionListener) {
-                listener = (ActionListener<CreateIndexResponse>) args[0];
-            }
-
-            assertTrue(listener != null);
-
-            listener.onResponse(new CreateIndexResponse(true, true, AnomalyResult.ANOMALY_RESULT_INDEX) {
-            });
-
-            return null;
-        }).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());
-
-        when(anomalyDetectionIndices.doesAnomalyResultIndexExist()).thenReturn(anomalyResultIndexExists);
-    }
-
-    public void setupInitResultIndexException(Class<? extends Throwable> exceptionType) throws IOException {
-        anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
-        doThrow(exceptionType).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());
-
-        when(anomalyDetectionIndices.doesAnomalyResultIndexExist()).thenReturn(false);
-    }
-
     @Override
     @After
     public final void tearDown() throws Exception {
@@ -293,7 +275,6 @@ public class AnomalyResultTests extends AbstractADTest {
         runner.shutDown();
         runner = null;
         client = null;
-        anomalyDetectionIndices = null;
         super.tearDownLog4jForJUnit();
         super.tearDown();
     }
@@ -309,7 +290,6 @@ public class AnomalyResultTests extends AbstractADTest {
 
     public void testNormal() throws IOException {
 
-        setUpSavingAnomalyResultIndex(false);
         // These constructors register handler in transport service
         new RCFResultTransportAction(
             new ActionFilters(Collections.emptySet()),
@@ -322,17 +302,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -377,17 +354,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             globalRunner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -441,10 +415,13 @@ public class AnomalyResultTests extends AbstractADTest {
         noModelExceptionTemplate(new AnomalyDetectionException(adID, ""), mockRunner, adID, error);
     }
 
+    @SuppressWarnings("unchecked")
     public void testInsufficientCapacityExceptionDuringColdStart() {
 
         ModelManager rcfManager = mock(ModelManager.class);
-        doThrow(ResourceNotFoundException.class).when(rcfManager).getRcfResult(any(String.class), any(String.class), any(double[].class));
+        doThrow(ResourceNotFoundException.class)
+            .when(rcfManager)
+            .getRcfResult(any(String.class), any(String.class), any(double[].class), any(ActionListener.class));
         when(rcfManager.getRcfModelId(any(String.class), anyInt())).thenReturn(rcfModelID);
 
         ColdStartRunner mockRunner = mock(ColdStartRunner.class);
@@ -458,17 +435,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             mockRunner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -480,12 +454,13 @@ public class AnomalyResultTests extends AbstractADTest {
         assertException(listener, LimitExceededException.class);
     }
 
+    @SuppressWarnings("unchecked")
     public void testInsufficientCapacityExceptionDuringRestoringModel() {
 
         ModelManager rcfManager = mock(ModelManager.class);
         doThrow(new NotSerializableExceptionWrapper(new LimitExceededException(adID, CommonErrorMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG)))
             .when(rcfManager)
-            .getRcfResult(any(String.class), any(String.class), any(double[].class));
+            .getRcfResult(any(String.class), any(String.class), any(double[].class), any(ActionListener.class));
 
         // These constructors register handler in transport service
         new RCFResultTransportAction(new ActionFilters(Collections.emptySet()), transportService, rcfManager, adCircuitBreakerService);
@@ -494,17 +469,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -535,17 +507,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -569,17 +538,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             breakerService,
             adStats
         );
@@ -636,17 +602,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             exceptionTransportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             hackedClusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -692,24 +655,26 @@ public class AnomalyResultTests extends AbstractADTest {
         nodeNotConnectedExceptionTemplate(false, true, 1);
     }
 
+    @SuppressWarnings("unchecked")
     public void testMute() {
         ADStateManager muteStateManager = mock(ADStateManager.class);
         when(muteStateManager.isMuted(any(String.class))).thenReturn(true);
-        when(muteStateManager.getAnomalyDetector(any(String.class))).thenReturn(Optional.of(detector));
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.of(detector));
+            return null;
+        }).when(muteStateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             muteStateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -722,7 +687,6 @@ public class AnomalyResultTests extends AbstractADTest {
     }
 
     public void alertingRequestTemplate(boolean anomalyResultIndexExists) throws IOException {
-        setUpSavingAnomalyResultIndex(anomalyResultIndexExists);
         // These constructors register handler in transport service
         new RCFResultTransportAction(
             new ActionFilters(Collections.emptySet()),
@@ -735,17 +699,14 @@ public class AnomalyResultTests extends AbstractADTest {
         new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -890,22 +851,19 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             new ColdStartRunner(),
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
         AnomalyResultTransportAction.RCFActionListener listener = action.new RCFActionListener(
-            null, null, null, null, null, null, null, null, null, 0, 0, 0, new AtomicInteger(), null
+            null, null, null, null, null, null, null, null, null, 0, new AtomicInteger(), null
         );
         listener.onFailure(null);
     }
@@ -915,17 +873,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -943,17 +898,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -968,32 +920,35 @@ public class AnomalyResultTests extends AbstractADTest {
         AD_EXCEPTION
     }
 
+    @SuppressWarnings("unchecked")
     public void featureTestTemplate(FeatureTestMode mode) {
         if (mode == FeatureTestMode.FEATURE_NOT_AVAILABLE) {
-            when(featureQuery.getCurrentFeatures(any(AnomalyDetector.class), anyLong(), anyLong()))
-                .thenReturn(new SinglePointFeatures(Optional.empty(), Optional.empty()));
+            doAnswer(invocation -> {
+                ActionListener<SinglePointFeatures> listener = invocation.getArgument(3);
+                listener.onResponse(new SinglePointFeatures(Optional.empty(), Optional.empty()));
+                return null;
+            }).when(featureQuery).getCurrentFeatures(any(AnomalyDetector.class), anyLong(), anyLong(), any(ActionListener.class));
         } else if (mode == FeatureTestMode.ILLEGAL_STATE) {
-            doThrow(IllegalArgumentException.class).when(featureQuery).getCurrentFeatures(any(AnomalyDetector.class), anyLong(), anyLong());
+            doThrow(IllegalArgumentException.class)
+                .when(featureQuery)
+                .getCurrentFeatures(any(AnomalyDetector.class), anyLong(), anyLong(), any(ActionListener.class));
         } else if (mode == FeatureTestMode.AD_EXCEPTION) {
             doThrow(AnomalyDetectionException.class)
                 .when(featureQuery)
-                .getCurrentFeatures(any(AnomalyDetector.class), anyLong(), anyLong());
+                .getCurrentFeatures(any(AnomalyDetector.class), anyLong(), anyLong(), any(ActionListener.class));
         }
 
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -1069,17 +1024,14 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             hackedClusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
@@ -1116,22 +1068,19 @@ public class AnomalyResultTests extends AbstractADTest {
         AnomalyResultTransportAction action = new AnomalyResultTransportAction(
             new ActionFilters(Collections.emptySet()),
             transportService,
-            client,
             settings,
             stateManager,
             runner,
-            anomalyDetectionIndices,
             featureQuery,
             normalModelManager,
             hashRing,
             clusterService,
             indexNameResolver,
-            threadPool,
             adCircuitBreakerService,
             adStats
         );
         AnomalyResultTransportAction.RCFActionListener listener = action.new RCFActionListener(
-            null, "123-rcf-0", null, "123", null, null, null, null, null, 0, 0, 0, new AtomicInteger(), null
+            null, "123-rcf-0", null, "123", null, null, null, null, null, 0, new AtomicInteger(), null
         );
         listener.onResponse(null);
         assertTrue(testAppender.containsMessage(AnomalyResultTransportAction.NULL_RESPONSE));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportActionTests.java
@@ -27,6 +27,7 @@ import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterName;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportActionTests.java
@@ -30,6 +30,7 @@ import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoun
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
+
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.ActionFilters;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/IndexUtilsTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/IndexUtilsTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import java.time.Clock;
 
 import static org.mockito.Mockito.mock;
@@ -36,8 +37,8 @@ public class IndexUtilsTests extends ESIntegTestCase {
         Client client = client();
         Clock clock = mock(Clock.class);
         Throttler throttler = new Throttler(clock);
-        ThreadPool threadPool = mock(ThreadPool.class);
-        clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, threadPool);
+        ThreadPool context = TestHelpers.createThreadPool();
+        clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, context);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/78

*Description of changes:*
This PR includes the following changes:

1. remove classes that are not needed in jacocoExclusions since we have enough coverage for those classes.
2. Use ClientUtil instead of Elasticsearch’s client in AD job runner
3. Use one function to get the number of partitioned forests. Previously, we have redundant code in both ModelManager and ADStateManager.
4. Change ADStateManager.getAnomalyDetector to use callback.
5. Change AnomalyResultTransportAction to use callback to get features.
6. Add in AnomalyResultTransportAction to handle the case where all features have been disabled, and users' index does not exist.
7. Change get RCF and threshold result methods to use callback and add exception handling of IndexNotFoundException due to the change. Previously, getting RCF and threshold result methods won’t throw IndexNotFoundException.
8. Remove unused fields in StopDetectorTransportAction and AnomalyResultTransportAction
9. Unwrap EsRejectedExecutionException as it can be nested inside RemoteTransportException. Previously, we would not recognize EsRejectedExecutionException and thus miss anomaly results write retrying.
10. Add error in anomaly result schema.
11. Fix broken tests due to my changes.

Testing done:
1. unit/integration tests pass
2. do end-to-end testing and make sure my fix achieves the purpose 
   * timeout issue is gone 
   * when all features have been disabled or index does not exist, we will retry a few more times and disable AD jobs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
