### PR TITLE
add timestamp to async putModelCheckpoint

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDao.java
@@ -98,6 +98,7 @@ public class CheckpointDao {
     public void putModelCheckpoint(String modelId, String modelCheckpoint, ActionListener<Void> listener) {
         Map<String, Object> source = new HashMap<>();
         source.put(FIELD_MODEL, modelCheckpoint);
+        source.put(TIMESTAMP, ZonedDateTime.now(ZoneOffset.UTC));
         clientUtil
             .<IndexRequest, IndexResponse>asyncRequest(
                 new IndexRequest(indexName, DOC_TYPE, modelId).source(source),

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDaoTests.java
@@ -15,9 +15,12 @@
 
 package com.amazon.opendistroforelasticsearch.ad.ml;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiConsumer;
 
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
@@ -41,6 +44,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import static org.mockito.Matchers.any;
@@ -102,7 +106,10 @@ public class CheckpointDaoTests {
         assertEquals(indexName, indexRequest.index());
         assertEquals(CheckpointDao.DOC_TYPE, indexRequest.type());
         assertEquals(modelId, indexRequest.id());
+        Set<String> expectedSourceKeys = new HashSet<String>(Arrays.asList(CheckpointDao.FIELD_MODEL, CheckpointDao.TIMESTAMP));
+        assertEquals(expectedSourceKeys, indexRequest.sourceAsMap().keySet());
         assertEquals(model, indexRequest.sourceAsMap().get(CheckpointDao.FIELD_MODEL));
+        assertNotNull(indexRequest.sourceAsMap().get(CheckpointDao.TIMESTAMP));
     }
 
     @Test
@@ -174,7 +181,10 @@ public class CheckpointDaoTests {
         assertEquals(indexName, indexRequest.index());
         assertEquals(CheckpointDao.DOC_TYPE, indexRequest.type());
         assertEquals(modelId, indexRequest.id());
-        assertEquals(docSource, indexRequest.sourceAsMap());
+        Set<String> expectedSourceKeys = new HashSet<String>(Arrays.asList(CheckpointDao.FIELD_MODEL, CheckpointDao.TIMESTAMP));
+        assertEquals(expectedSourceKeys, indexRequest.sourceAsMap().keySet());
+        assertEquals(model, indexRequest.sourceAsMap().get(CheckpointDao.FIELD_MODEL));
+        assertNotNull(indexRequest.sourceAsMap().get(CheckpointDao.TIMESTAMP));
 
         ArgumentCaptor<Void> responseCaptor = ArgumentCaptor.forClass(Void.class);
         verify(listener).onResponse(responseCaptor.capture());


### PR DESCRIPTION
Current asynchronous putModelCheckpoint implementation does not include timestamp. This change adds to checkpoint data the timestamp at which it is made for cleanup.

Below is an example of mode checkpoint data.
`
{'model' : '...',
'timestamp': '2020-04-28T16:40:18.096676Z'}
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
