### PR TITLE
add async stopModel

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -537,10 +537,50 @@ public class ModelManager {
         Optional
             .ofNullable(models.remove(modelId))
             .filter(model -> model.getLastCheckpointTime().plus(checkpointInterval).isBefore(now))
-            .ifPresent(model -> {
-                checkpointDao.putModelCheckpoint(modelId, toCheckpoint.apply(model.getModel()));
-                model.setLastCheckpointTime(now);
-            });
+            .ifPresent(model -> { checkpointDao.putModelCheckpoint(modelId, toCheckpoint.apply(model.getModel())); });
+    }
+
+    /**
+     * Stops hosting the model and creates a checkpoint.
+     *
+     * @param detectorId ID of the detector
+     * @param modelId ID of the model to stop hosting
+     * @param listener onResponse is called with null when the operation is completed
+     */
+    public void stopModel(String detectorId, String modelId, ActionListener<Void> listener) {
+        logger.info(String.format("Stopping detector %s model %s", detectorId, modelId));
+        stopModel(
+            forests,
+            modelId,
+            this::toCheckpoint,
+            ActionListener.wrap(r -> stopModel(thresholds, modelId, this::toCheckpoint, listener), listener::onFailure)
+        );
+    }
+
+    private <T> void stopModel(
+        Map<String, ModelState<T>> models,
+        String modelId,
+        Function<T, String> toCheckpoint,
+        ActionListener<Void> listener
+    ) {
+        Instant now = clock.instant();
+        Optional<ModelState<T>> modelState = Optional
+            .ofNullable(models.remove(modelId))
+            .filter(model -> model.getLastCheckpointTime().plus(checkpointInterval).isBefore(now));
+        if (modelState.isPresent()) {
+            modelState
+                .ifPresent(
+                    model -> checkpointDao
+                        .putModelCheckpoint(
+                            modelId,
+                            toCheckpoint.apply(model.getModel()),
+                            ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)
+                        )
+                );
+        } else {
+            listener.onResponse(null);
+        }
+        ;
     }
 
     /**

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
@@ -563,6 +563,68 @@ public class ModelManagerTests {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    public void stopModel_returnExpectedToListener_whenRcfStop() {
+        RandomCutForest forest = mock(RandomCutForest.class);
+        when(checkpointDao.getModelCheckpoint(rcfModelId)).thenReturn(Optional.of(checkpoint));
+        when(rcfSerde.fromJson(checkpoint)).thenReturn(forest);
+        when(rcfSerde.toJson(forest)).thenReturn(checkpoint);
+        modelManager.getRcfResult(detectorId, rcfModelId, new double[0]);
+        when(clock.instant()).thenReturn(Instant.EPOCH);
+        doAnswer(invocation -> {
+            ActionListener<Void> listener = invocation.getArgument(2);
+            listener.onResponse(null);
+            return null;
+        }).when(checkpointDao).putModelCheckpoint(eq(rcfModelId), eq(checkpoint), any(ActionListener.class));
+
+        ActionListener<Void> listener = mock(ActionListener.class);
+        modelManager.stopModel(detectorId, rcfModelId, listener);
+
+        verify(listener).onResponse(eq(null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void stopModel_returnExpectedToListener_whenThresholdStop() {
+        when(checkpointDao.getModelCheckpoint(thresholdModelId)).thenReturn(Optional.of(checkpoint));
+        PowerMockito.doReturn(hybridThresholdingModel).when(gson).fromJson(checkpoint, thresholdingModelClass);
+        PowerMockito.doReturn(checkpoint).when(gson).toJson(hybridThresholdingModel);
+        modelManager.getThresholdingResult(detectorId, thresholdModelId, 0);
+        when(clock.instant()).thenReturn(Instant.EPOCH);
+        doAnswer(invocation -> {
+            ActionListener<Void> listener = invocation.getArgument(2);
+            listener.onResponse(null);
+            return null;
+        }).when(checkpointDao).putModelCheckpoint(eq(thresholdModelId), eq(checkpoint), any(ActionListener.class));
+
+        ActionListener<Void> listener = mock(ActionListener.class);
+        modelManager.stopModel(detectorId, thresholdModelId, listener);
+
+        verify(listener).onResponse(eq(null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void stopModel_throwToListener_whenCheckpointFail() {
+        RandomCutForest forest = mock(RandomCutForest.class);
+        when(checkpointDao.getModelCheckpoint(rcfModelId)).thenReturn(Optional.of(checkpoint));
+        when(rcfSerde.fromJson(checkpoint)).thenReturn(forest);
+        when(rcfSerde.toJson(forest)).thenReturn(checkpoint);
+        modelManager.getRcfResult(detectorId, rcfModelId, new double[0]);
+        when(clock.instant()).thenReturn(Instant.EPOCH);
+        doAnswer(invocation -> {
+            ActionListener<Void> listener = invocation.getArgument(2);
+            listener.onFailure(new RuntimeException());
+            return null;
+        }).when(checkpointDao).putModelCheckpoint(eq(rcfModelId), eq(checkpoint), any(ActionListener.class));
+
+        ActionListener<Void> listener = mock(ActionListener.class);
+        modelManager.stopModel(detectorId, rcfModelId, listener);
+
+        verify(listener).onFailure(any(Exception.class));
+    }
+
+    @Test
     public void clear_deleteRcfCheckpoint() {
         String checkpoint = "checkpoint";
 


### PR DESCRIPTION
Current stopModel is a synchronous operation for stopping hosting models. As part of migration to asynchronous implementation, this change adds an asynchronous equivalent using the same business logic with one minor change/fix - setting lastCheckpointTime on a stopped and saved model object going into garbage collection is unnecessary and is therefore removed for cleanness.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
