### PR TITLE
change AD result index rollover setting

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -77,7 +77,7 @@ public final class AnomalyDetectorSettings {
     public static final Setting<TimeValue> AD_RESULT_HISTORY_INDEX_MAX_AGE = Setting
         .positiveTimeSetting(
             "opendistro.anomaly_detection.ad_result_history_max_age",
-            TimeValue.timeValueHours(24),
+            TimeValue.timeValueHours(24 * 30),
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
@@ -85,7 +85,10 @@ public final class AnomalyDetectorSettings {
     public static final Setting<Long> AD_RESULT_HISTORY_MAX_DOCS = Setting
         .longSetting(
             "opendistro.anomaly_detection.ad_result_history_max_docs",
-            10000L,
+                // Suppose generally per cluster has 200 detectors and all run with 1 minute interval.
+                // We will get 288,000 AD result docs. So set it as 300k to avoid multiple roll overs
+                // per day.
+            300 * 1000L,
             0L,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Change AD result index  rollover setting
1. Roll over AD result index every 30 days, or
2. Roll over AD result index if doc count exceeds 300k. 
> Suppose generally per cluster has 200 detectors and all run with 1 minute interval. We will get 288,000 AD result docs. So set it as 300k to avoid multiple roll overs per day.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
