### PR TITLE
Fix that AD job cannot be terminated due to missing training data

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunner.java
@@ -320,7 +320,7 @@ public class AnomalyDetectorJobRunner implements ScheduledJobRunner {
             detectorEndRunExceptionCount.remove(detectorId);
             if (exception instanceof InternalFailure) {
                 // AnomalyResultTransportAction already prints exception stack trace
-                log.error("InternalFailure happened when executed anomaly result action for " + detectorId);
+                log.error("InternalFailure happened when executing anomaly result action for " + detectorId);
             } else {
                 log.error("Failed to execute anomaly result action for " + detectorId, exception);
             }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -781,7 +781,7 @@ public class ModelManager {
         } else {
             throw new LimitExceededException(
                 detectorId,
-                String.format("Exceeded memory limit. New size is %d and max limit is %f", total, heapLimit)
+                String.format("Exceeded memory limit. New size is %d bytes and max limit is %f bytes", total, heapLimit)
             );
         }
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ColdStartRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ColdStartRunner.java
@@ -71,6 +71,9 @@ public class ColdStartRunner {
             if (cause instanceof AnomalyDetectionException) {
                 AnomalyDetectionException adException = (AnomalyDetectionException) cause;
                 currentExceptions.put(adException.getAnomalyDetectorId(), adException);
+                LOG.info("added cause for {}", adException.getAnomalyDetectorId());
+            } else {
+                LOG.error("Get an unexpected exception");
             }
         }
         return Optional.empty();
@@ -79,9 +82,12 @@ public class ColdStartRunner {
     public Optional<AnomalyDetectionException> fetchException(String adID) {
         checkResult();
 
-        if (currentExceptions.containsKey(adID)) {
-            LOG.error("Found matching exception for {}", adID);
+        AnomalyDetectionException ex = currentExceptions.get(adID);
+        if (ex != null) {
+            LOG.error("Found a matching exception for " + adID, ex);
             return Optional.of(currentExceptions.remove(adID));
+        } else {
+            LOG.info("Cannot find a matching exception for {}", adID);
         }
         return Optional.empty();
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We expect an EndRunException to be thrown due to missing training data.  But the exception is not appropriately propagated back to AD job and results in InternalFailure instead.  This PR fixes the bug.

Testing done:
1. Manually reproduced all  possible EndRunExceptions, check AD job is terminated, and check profile API status is correct.
2. Added unit tests to expose the bug.

Profile output for init failures:
[2020-05-02 14:17:31 PDT] [2020-05-02 21:17:31 UTC]
kaituo@dev-dsk-kaituo-2a-74e3f324.us-west-2: ~/code/github/anomaly-detection
% curl -X GET "localhost:9200/_opendistro/_anomaly_detection/detectors/fu8z13EBn03yvIf6cLBm/_profile"
{"state":"DISABLED","error":"Stopped detector as job failed consecutively for more than 3 times: Cannot get training data"}

[2020-05-02 15:13:30 PDT] [2020-05-02 22:13:30 UTC]
kaituo@dev-dsk-kaituo-2a-74e3f324.us-west-2: ~/code/github/anomaly-detection
% curl -X GET "localhost:9200/_opendistro/_anomaly_detection/detectors/cgdm13EBVQAb62q7oAbR/_profile"
{"state":"DISABLED","error":"Stopped detector as job failed consecutively for more than 3 times: Error while cold start"}

[2020-05-02 15:32:04 PDT] [2020-05-02 22:32:04 UTC]
kaituo@dev-dsk-kaituo-2a-74e3f324.us-west-2: ~/code/github/anomaly-detection
% curl -X GET "localhost:9200/_opendistro/_anomaly_detection/detectors/4j1313EBhPlEUyl3nsX-/_profile"
{"state":"DISABLED","error":"Stopped detector: AD models memory usage exceeds our limit."}

[2020-05-02 15:45:50 PDT] [2020-05-02 22:45:50 UTC]
kaituo@dev-dsk-kaituo-2a-74e3f324.us-west-2: ~/code/github/anomaly-detection
% curl -X GET "localhost:9200/_opendistro/_anomaly_detection/detectors/DoOI13EBxc51Fte-eAry/_profile"
{"state":"DISABLED","error":"Stopped detector: limit_exceeded_exception: Exceeded memory limit. New size is 4456448 and max limit is 51897958.400000"

[2020-05-02 15:52:19 PDT] [2020-05-02 22:52:19 UTC]
kaituo@dev-dsk-kaituo-2a-74e3f324.us-west-2: ~/code/github/anomaly-detection
% curl -X GET "localhost:9200/_opendistro/_anomaly_detection/detectors/5z-V13EBskgfiUUv6dRA/_profile"
{"state":"DISABLED","error":"Stopped detector: Having trouble querying data: no such index [server-metrics]"}


[2020-05-02 16:01:09 PDT] [2020-05-02 23:01:09 UTC]
kaituo@dev-dsk-kaituo-2a-74e3f324.us-west-2: ~/code/github/anomaly-detection
% curl -X GET "localhost:9200/_opendistro/_anomaly_detection/detectors/xnuc13EB6HcqWQxXA0ot/_profile"
{"state":"DISABLED","error":"Stopped detector: Having trouble querying data because all of your features have been disabled."}


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
