### PR TITLE
Change setting name so that rpm/deb has the same name as zip

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,4 +13,4 @@
  *   permissions and limitations under the License.
  */
 
-rootProject.name = 'opendistro-anomaly-detector'
+rootProject.name = 'opendistro-anomaly-detection'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, rpm and deb is named as "opendistro-anomaly-detector-1.7.0.0-1.noarch.rpm" and "opendistro-anomaly-detector_1.7.0.0-1_amd64.deb" respectively, whle zip is named as "opendistro-anomaly-detection-1.7.0.0.zip".

After the fix, they are named as:

opendistro-anomaly-detection_1.7.0.0-1_amd64.deb
opendistro-anomaly-detection-1.7.0.0-1.noarch.rpm
opendistro-anomaly-detection-1.7.0.0.zip

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
