### PR TITLE
Fix incorrect detector count in stats APIs

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestStatsAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestStatsAnomalyDetectorAction.java
@@ -27,8 +27,7 @@ import com.amazon.opendistroforelasticsearch.ad.util.MultiResponsesDelegateActio
 import com.google.common.collect.ImmutableList;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
-import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -176,11 +175,13 @@ public class RestStatsAnomalyDetectorAction extends BaseRestHandler {
         ADStatsResponse adStatsResponse = new ADStatsResponse();
         if (adStatsRequest.getStatsToBeRetrieved().contains(StatNames.DETECTOR_COUNT.getName())) {
             if (clusterService.state().getRoutingTable().hasIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
-                IndicesStatsRequest indicesStatsRequest = new IndicesStatsRequest().docs(true);
-                client.execute(IndicesStatsAction.INSTANCE, indicesStatsRequest, ActionListener.wrap(indicesStatsResponse -> {
-                    adStats
-                        .getStat(StatNames.DETECTOR_COUNT.getName())
-                        .setValue(indicesStatsResponse.getIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX).getPrimaries().docs.getCount());
+                final SearchRequest request = client
+                    .prepareSearch(AnomalyDetector.ANOMALY_DETECTORS_INDEX)
+                    .setSize(0)
+                    .setTrackTotalHits(true)
+                    .request();
+                client.search(request, ActionListener.wrap(indicesStatsResponse -> {
+                    adStats.getStat(StatNames.DETECTOR_COUNT.getName()).setValue(indicesStatsResponse.getHits().getTotalHits().value);
                     adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
                     listener.onResponse(adStatsResponse);
                 }, e -> listener.onFailure(new RuntimeException("Failed to get AD cluster stats", e))));


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/123

*Description of changes:*

Previously, we use index stats to retrieve doc count. But the stats are emitted by Lucene and include nested doc count.  Since our detector index uses nested type for the feature_attributes field, stats API would overcount the number of docs.

This PR restores to use search all of the index docs and fetch total hits as doc count.

Testing done:
* manually verified by starting a local cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
