### PR TITLE
fix dynamic setting of max detector/feature limit

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -41,6 +41,8 @@ import java.util.Locale;
 
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DETECTION_INTERVAL;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DETECTION_WINDOW_DELAY;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_DETECTORS;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_FEATURES;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.REQUEST_TIMEOUT;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.DETECTOR_ID;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.IF_PRIMARY_TERM;
@@ -62,6 +64,8 @@ public class RestIndexAnomalyDetectorAction extends BaseRestHandler {
     private volatile TimeValue requestTimeout;
     private volatile TimeValue detectionInterval;
     private volatile TimeValue detectionWindowDelay;
+    private volatile Integer maxAnomalyDetectors;
+    private volatile Integer maxAnomalyFeatures;
 
     public RestIndexAnomalyDetectorAction(
         Settings settings,
@@ -73,12 +77,16 @@ public class RestIndexAnomalyDetectorAction extends BaseRestHandler {
         this.requestTimeout = REQUEST_TIMEOUT.get(settings);
         this.detectionInterval = DETECTION_INTERVAL.get(settings);
         this.detectionWindowDelay = DETECTION_WINDOW_DELAY.get(settings);
+        this.maxAnomalyDetectors = MAX_ANOMALY_DETECTORS.get(settings);
+        this.maxAnomalyFeatures = MAX_ANOMALY_FEATURES.get(settings);
         this.clusterService = clusterService;
         // TODO: will add more cluster setting consumer later
         // TODO: inject ClusterSettings only if clusterService is only used to get ClusterSettings
         clusterService.getClusterSettings().addSettingsUpdateConsumer(REQUEST_TIMEOUT, it -> requestTimeout = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DETECTION_INTERVAL, it -> detectionInterval = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DETECTION_WINDOW_DELAY, it -> detectionWindowDelay = it);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ANOMALY_DETECTORS, newVal -> maxAnomalyDetectors = newVal);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ANOMALY_FEATURES, it -> maxAnomalyFeatures = it);
     }
 
     @Override
@@ -117,7 +125,9 @@ public class RestIndexAnomalyDetectorAction extends BaseRestHandler {
             primaryTerm,
             refreshPolicy,
             detector,
-            requestTimeout
+            requestTimeout,
+            maxAnomalyDetectors,
+            maxAnomalyFeatures
         ).start();
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -85,7 +85,7 @@ public class RestIndexAnomalyDetectorAction extends BaseRestHandler {
         clusterService.getClusterSettings().addSettingsUpdateConsumer(REQUEST_TIMEOUT, it -> requestTimeout = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DETECTION_INTERVAL, it -> detectionInterval = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(DETECTION_WINDOW_DELAY, it -> detectionWindowDelay = it);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ANOMALY_DETECTORS, newVal -> maxAnomalyDetectors = newVal);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ANOMALY_DETECTORS, it -> maxAnomalyDetectors = it);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ANOMALY_FEATURES, it -> maxAnomalyFeatures = it);
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -52,8 +52,6 @@ import java.util.Arrays;
 import java.util.Locale;
 
 import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
-import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_DETECTORS;
-import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_FEATURES;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
 import static org.elasticsearch.common.xcontent.ToXContent.EMPTY_PARAMS;
 
@@ -74,8 +72,8 @@ public class IndexAnomalyDetectorActionHandler extends AbstractActionHandler {
 
     private final Logger logger = LogManager.getLogger(IndexAnomalyDetectorActionHandler.class);
     private final TimeValue requestTimeout;
-    private volatile Integer maxAnomalyDetectors;
-    private volatile Integer maxAnomalyFeatures;
+    private final Integer maxAnomalyDetectors;
+    private final Integer maxAnomalyFeatures;
     private final AnomalyDetectorActionHandler handler = new AnomalyDetectorActionHandler();
 
     /**
@@ -104,7 +102,9 @@ public class IndexAnomalyDetectorActionHandler extends AbstractActionHandler {
         Long primaryTerm,
         WriteRequest.RefreshPolicy refreshPolicy,
         AnomalyDetector anomalyDetector,
-        TimeValue requestTimeout
+        TimeValue requestTimeout,
+        Integer maxAnomalyDetectors,
+        Integer maxAnomalyFeatures
     ) {
         super(client, channel);
         this.clusterService = clusterService;
@@ -115,10 +115,8 @@ public class IndexAnomalyDetectorActionHandler extends AbstractActionHandler {
         this.refreshPolicy = refreshPolicy;
         this.anomalyDetector = anomalyDetector;
         this.requestTimeout = requestTimeout;
-        maxAnomalyDetectors = MAX_ANOMALY_DETECTORS.get(settings);
-        maxAnomalyFeatures = MAX_ANOMALY_FEATURES.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ANOMALY_DETECTORS, it -> maxAnomalyDetectors = it);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_ANOMALY_FEATURES, it -> maxAnomalyFeatures = it);
+        this.maxAnomalyDetectors = maxAnomalyDetectors;
+        this.maxAnomalyFeatures = maxAnomalyFeatures;
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* fix dynamic setting of max detector/feature limit

```
PUT _cluster/settings
{
    "transient" : {
        "opendistro.anomaly_detection.max_anomaly_detectors" : 1
    }
}
```
Create the second detector and will get error:
```
{
    "error": {
        "root_cause": [
            {
                "type": "illegal_argument_exception",
                "reason": "Can't create anomaly detector more than 1"
            }
        ],
        "type": "illegal_argument_exception",
        "reason": "Can't create anomaly detector more than 1"
    },
    "status": 400
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
