### PR TITLE
delete deprecated getFeatureSamplesForPeriods getPreviewFeatures

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
@@ -19,7 +19,6 @@ import static java.util.Arrays.asList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -434,34 +433,6 @@ public class FeatureManagerTests {
         when(clock.instant()).thenThrow(new RuntimeException());
 
         featureManager.maintenance();
-    }
-
-    @Test
-    public void getPreviewFeatures_returnExpected() {
-        long start = 0L;
-        long end = 240_000L;
-        IntervalTimeConfiguration detectionInterval = new IntervalTimeConfiguration(1, ChronoUnit.MINUTES);
-        when(detector.getDetectionInterval()).thenReturn(detectionInterval);
-
-        List<Entry<Long, Long>> sampleRanges = Arrays.asList(new SimpleEntry<>(0L, 60_000L), new SimpleEntry<>(120_000L, 180_000L));
-        List<Optional<double[]>> samplesResults = Arrays.asList(Optional.of(new double[] { 1 }), Optional.of(new double[] { 3 }));
-        when(searchFeatureDao.getFeatureSamplesForPeriods(detector, sampleRanges)).thenReturn(samplesResults);
-
-        when(interpolator.interpolate(argThat(new ArrayEqMatcher<>(new double[][] { { 1, 3 } })), eq(3)))
-            .thenReturn(new double[][] { { 1, 2, 3 } });
-        when(interpolator.interpolate(argThat(new ArrayEqMatcher<>(new double[][] { { 0, 120000 } })), eq(3)))
-            .thenReturn(new double[][] { { 0, 60000, 120000 } });
-        when(interpolator.interpolate(argThat(new ArrayEqMatcher<>(new double[][] { { 60000, 180000 } })), eq(3)))
-            .thenReturn(new double[][] { { 60000, 120000, 180000 } });
-
-        Features previewFeatures = featureManager.getPreviewFeatures(detector, start, end);
-
-        Features expected = new Features(
-            asList(new SimpleEntry<>(120_000L, 180_000L)),
-            new double[][] { { 3 } },
-            new double[][] { { 1, 2, 3 } }
-        );
-        assertEquals(expected, previewFeatures);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
@@ -418,47 +418,6 @@ public class SearchFeatureDaoTests {
         verify(listener).onFailure(any(Exception.class));
     }
 
-    private Object[] getFeatureSamplesForPeriodsData() {
-        String maxName = "max";
-        double maxValue = 2;
-        Max max = mock(Max.class);
-        when(max.value()).thenReturn(maxValue);
-        when(max.getName()).thenReturn(maxName);
-
-        String missingName = "mising";
-        Max missing = mock(Max.class);
-        when(missing.value()).thenReturn(Double.NaN);
-        when(missing.getName()).thenReturn(missingName);
-
-        return new Object[] {
-            new Object[] { asList(max), asList(maxName), asList(Optional.of(new double[] { maxValue })) },
-            new Object[] { asList(missing), asList(missingName), asList(Optional.empty()) }, };
-    }
-
-    @Test
-    @Parameters(method = "getFeatureSamplesForPeriodsData")
-    public void getFeatureSamplesForPeriods_returnExpected(
-        List<Aggregation> aggs,
-        List<String> featureIds,
-        List<Optional<double[]>> expected
-    ) throws Exception {
-
-        long start = 1L;
-        long end = 2L;
-
-        // pre-conditions
-        when(ParseUtils.generateInternalFeatureQuery(eq(detector), eq(start), eq(end), eq(xContent))).thenReturn(searchSourceBuilder);
-        when(searchResponse.getAggregations()).thenReturn(new Aggregations(aggs));
-        when(detector.getEnabledFeatureIds()).thenReturn(featureIds);
-
-        List<Optional<double[]>> results = searchFeatureDao.getFeatureSamplesForPeriods(detector, asList(pair(start, end)));
-
-        assertEquals(expected.size(), results.size());
-        for (int i = 0; i < expected.size(); i++) {
-            assertTrue(Arrays.equals(expected.get(i).orElse(null), results.get(i).orElse(null)));
-        }
-    }
-
     @Test
     public void test_getFeaturesForPeriod_returnEmpty_givenNoData() throws Exception {
         long start = 100L;


### PR DESCRIPTION
This pr deletes deprecated code for getFeatureSamplesForPeriods and getPreviewFeatures methods.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
