### PR TITLE
not update threshold with zero scores

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -473,7 +473,9 @@ public class ModelManager {
         ThresholdingModel threshold = modelState.getModel();
         double grade = threshold.grade(score);
         double confidence = threshold.confidence();
-        threshold.update(score);
+        if (score > 0) {
+            threshold.update(score);
+        }
         modelState.setLastUsedTime(clock.instant());
         listener.onResponse(new ThresholdingResult(grade, confidence));
     }


### PR DESCRIPTION
The current system updates thresholding models with any scores, including zero anomaly scores. Zero scores lower the threshold and result into more false positives later on when the scores become non-zero. This change skips zero scores for updating thresholding models.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.