### PR TITLE
threshold model outputs zero grades instead of nan grades

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/HybridThresholdingModel.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/HybridThresholdingModel.java
@@ -307,7 +307,8 @@ public class HybridThresholdingModel implements ThresholdingModel {
     public double grade(double anomalyScore) {
         final double scale = 1.0 / (1.0 - minPvalueThreshold);
         final double pvalue = quantileSketch.getRank((float) anomalyScore);
-        final double anomalyGrade = scale * (pvalue - minPvalueThreshold);
+        double anomalyGrade = scale * (pvalue - minPvalueThreshold);
+        anomalyGrade = Double.isNaN(anomalyGrade) ? 0. : anomalyGrade;
         return Math.max(0.0, anomalyGrade);
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/HybridThresholdingModelTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/HybridThresholdingModelTests.java
@@ -155,7 +155,12 @@ public class HybridThresholdingModelTests {
                 model,
                 trainingAnomalyScores,
                 new double[] { 0.0, Math.exp(mu), Math.exp(mu + sigma), maxScore },
-                new double[] { 0.0, 0.5, 0.84134, 1.0 }, }, };
+                new double[] { 0.0, 0.5, 0.84134, 1.0 }, },
+            new Object[] {
+                new HybridThresholdingModel(1e-8, 1e-5, maxScore, 10_000, 2, 5_000_000),
+                new double[0],
+                new double[] { 1.0 },
+                new double[] { 0.0 }, } };
     }
 
     @Test


### PR DESCRIPTION
Current thresholding model outputs anomaly grade nan when it has not been updated any data. This change makes the output grade zero to make results clearer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
