### PR TITLE
Use aggregation's default value if no docs

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
@@ -173,10 +173,7 @@ public class SearchFeatureDao {
     }
 
     private Optional<double[]> parseResponse(SearchResponse response, List<String> featureIds) {
-        return parseAggregations(
-            Optional.ofNullable(response).filter(resp -> response.getHits().getTotalHits().value > 0L).map(resp -> resp.getAggregations()),
-            featureIds
-        );
+        return parseAggregations(Optional.ofNullable(response).map(resp -> resp.getAggregations()), featureIds);
     }
 
     private double parseAggregation(Aggregation aggregation) {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/166

*Description of changes:*
Currently, for sparse data (e.g., we only have docs half an hour every day), the preview/prediction API cannot find aggregated value and thus doesn't work.

This PR mitigates the sparse data issue by using an aggregation's default value if any.

Testing done:
1. Without this PR, preview/prediction cannot find any features to use given sparse data for cardinality aggregation. With this PR, preview/prediction can.
2. Verified no unexpected exceptions are thrown with this PR during prediction or preview.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
