### PR TITLE
Rollover AD result index less frequently

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -86,7 +86,7 @@ public final class AnomalyDetectorSettings {
         .longSetting(
             "opendistro.anomaly_detection.ad_result_history_max_docs",
             // Suppose generally per cluster has 200 detectors and all run with 1 minute interval.
-            // We will get 288,000 AD result docs. So set it as 300k to avoid multiple roll overs
+            // We will get 288,000 AD result docs. So set it as 9000k to avoid multiple roll overs
             // per day.
             9_000_000L,
             0L,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -88,7 +88,7 @@ public final class AnomalyDetectorSettings {
             // Suppose generally per cluster has 200 detectors and all run with 1 minute interval.
             // We will get 288,000 AD result docs. So set it as 300k to avoid multiple roll overs
             // per day.
-            300 * 1000L,
+            9_000_000L,
             0L,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, we roll over the result index every 30 days or every 300000 docs. Assuming each doc has 1 KB and our result index has five shards, each shard takes about 60 MB, which is too small. Small shards are against ES best practice. This PR increases the rollover threshold to 9000000 docs, which increases the max shard size to roughly 1.8 GB. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
