### PR TITLE
Queries data from the index when insufficient data in buffer to form a full shingle

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
@@ -922,7 +922,7 @@ public class AnomalyResultTests extends AbstractADTest {
     }
 
     @SuppressWarnings("unchecked")
-    public void featureTestTemplate(FeatureTestMode mode) {
+    public void featureTestTemplate(FeatureTestMode mode) throws IOException {
         if (mode == FeatureTestMode.FEATURE_NOT_AVAILABLE) {
             doAnswer(invocation -> {
                 ActionListener<SinglePointFeatures> listener = invocation.getArgument(3);
@@ -969,15 +969,15 @@ public class AnomalyResultTests extends AbstractADTest {
         }
     }
 
-    public void testFeatureNotAvailable() {
+    public void testFeatureNotAvailable() throws IOException {
         featureTestTemplate(FeatureTestMode.FEATURE_NOT_AVAILABLE);
     }
 
-    public void testFeatureIllegalState() {
+    public void testFeatureIllegalState() throws IOException {
         featureTestTemplate(FeatureTestMode.ILLEGAL_STATE);
     }
 
-    public void testFeatureAnomalyException() {
+    public void testFeatureAnomalyException() throws IOException {
         featureTestTemplate(FeatureTestMode.AD_EXCEPTION);
     }
 
@@ -1088,9 +1088,7 @@ public class AnomalyResultTests extends AbstractADTest {
     }
 
     @SuppressWarnings("unchecked")
-    public void testAllFeaturesDisabled() {
-        // doThrow(IllegalArgumentException.class).when(featureQuery)
-        // .getCurrentFeatures(any(AnomalyDetector.class), anyLong(), anyLong(), any(ActionListener.class));
+    public void testAllFeaturesDisabled() throws IOException {
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
             ActionListener<SinglePointFeatures> listener = (ActionListener<SinglePointFeatures>) args[3];


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When running an AD on an interval, data points from past consecutive intervals are required in the shingling process. Currently, the AD only checks data points from a buffer which only contains data points for intervals which were previously run. This means for the first several intervals which the AD runs on, or if there were previously missed intervals (for example, due to restarts), the AD is unable to form a shingle and will output no results, even if the data points for the missed intervals are in the data index. This change will query the index if there are any missing data points from the buffer so that a full shingle can be formed as long as the data points exist in the index. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
