### PR TITLE
Add dyanmic setting for memory threshold

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -281,6 +281,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             gson,
             clock,
             AnomalyDetectorSettings.DESIRED_MODEL_SIZE_PERCENTAGE,
+            AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE.get(settings),
             AnomalyDetectorSettings.NUM_TREES,
             AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
             AnomalyDetectorSettings.TIME_DECAY,
@@ -296,7 +297,6 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             AnomalyDetectorSettings.SHINGLE_SIZE,
-            settings,
             clusterService
         );
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -281,7 +281,6 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             gson,
             clock,
             AnomalyDetectorSettings.DESIRED_MODEL_SIZE_PERCENTAGE,
-            AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE,
             AnomalyDetectorSettings.NUM_TREES,
             AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE,
             AnomalyDetectorSettings.TIME_DECAY,
@@ -296,7 +295,9 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             AnomalyDetectorSettings.MIN_PREVIEW_SIZE,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            AnomalyDetectorSettings.SHINGLE_SIZE
+            AnomalyDetectorSettings.SHINGLE_SIZE,
+            settings,
+            clusterService
         );
 
         HashRing hashRing = new HashRing(nodeFilter, clock, settings);
@@ -404,7 +405,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 AnomalyDetectorSettings.BACKOFF_MINUTES,
                 AnomalyDetectorSettings.BACKOFF_INITIAL_DELAY,
                 AnomalyDetectorSettings.MAX_RETRY_FOR_BACKOFF,
-                AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD
+                AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
+                AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE
             );
         return unmodifiableList(Stream.concat(enabledSetting.stream(), systemSetting.stream()).collect(Collectors.toList()));
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -44,7 +44,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.monitor.jvm.JvmService;
 
 import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
@@ -91,7 +90,6 @@ public class ModelManager {
 
     // configuration
     private final double modelDesiredSizePercentage;
-    // percentage of heap for the max size of a model
     private double modelMaxSizePercentage;
     private final int rcfNumTrees;
     private final int rcfNumSamplesInTree;
@@ -132,6 +130,7 @@ public class ModelManager {
      * @param gson thresholding model serialization
      * @param clock clock for system time
      * @param modelDesiredSizePercentage percentage of heap for the desired size of a model
+     * @param modelMaxSizePercentage percentage of heap for the max size of a model
      * @param rcfNumTrees number of trees used in RCF
      * @param rcfNumSamplesInTree number of samples in a RCF tree
      * @param rcfTimeDecay time decay for RCF
@@ -147,6 +146,7 @@ public class ModelManager {
      * @param modelTtl time to live for hosted models
      * @param checkpointInterval interval between checkpoints
      * @param shingleSize required shingle size before RCF emitting anomaly scores
+     * @param clusterService cluster service object
      */
     public ModelManager(
         DiscoveryNodeFilterer nodeFilter,
@@ -156,6 +156,7 @@ public class ModelManager {
         Gson gson,
         Clock clock,
         double modelDesiredSizePercentage,
+        double modelMaxSizePercentage,
         int rcfNumTrees,
         int rcfNumSamplesInTree,
         double rcfTimeDecay,
@@ -171,7 +172,6 @@ public class ModelManager {
         Duration modelTtl,
         Duration checkpointInterval,
         int shingleSize,
-        Settings settings,
         ClusterService clusterService
     ) {
 
@@ -182,6 +182,7 @@ public class ModelManager {
         this.gson = gson;
         this.clock = clock;
         this.modelDesiredSizePercentage = modelDesiredSizePercentage;
+        this.modelMaxSizePercentage = modelMaxSizePercentage;
         this.rcfNumTrees = rcfNumTrees;
         this.rcfNumSamplesInTree = rcfNumSamplesInTree;
         this.rcfTimeDecay = rcfTimeDecay;
@@ -201,8 +202,7 @@ public class ModelManager {
         this.thresholds = new ConcurrentHashMap<>();
         this.shingleSize = shingleSize;
 
-        this.modelMaxSizePercentage = MODEL_MAX_SIZE_PERCENTAGE.get(settings);
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(MODEL_MAX_SIZE_PERCENTAGE, it -> modelMaxSizePercentage = it);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MODEL_MAX_SIZE_PERCENTAGE, it -> this.modelMaxSizePercentage = it);
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.unit.TimeValue;
 
 /**
  * AD plugin settings.
- * TODO: add more settings once detail design done.
  */
 public final class AnomalyDetectorSettings {
 
@@ -164,7 +163,14 @@ public final class AnomalyDetectorSettings {
     public static final double DESIRED_MODEL_SIZE_PERCENTAGE = 0.0002;
 
     public static final Setting<Double> MODEL_MAX_SIZE_PERCENTAGE = Setting
-        .doubleSetting("opendistro.anomaly_detection.model_max_size_percent", 0.1, 0, Setting.Property.NodeScope, Setting.Property.Dynamic);
+        .doubleSetting(
+            "opendistro.anomaly_detection.model_max_size_percent",
+            0.1,
+            0,
+            0.7,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
 
     // Thresholding
     public static final double THRESHOLD_MIN_PVALUE = 0.995;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -163,7 +163,8 @@ public final class AnomalyDetectorSettings {
 
     public static final double DESIRED_MODEL_SIZE_PERCENTAGE = 0.0002;
 
-    public static final double MODEL_MAX_SIZE_PERCENTAGE = 0.1;
+    public static final Setting<Double> MODEL_MAX_SIZE_PERCENTAGE = Setting
+        .doubleSetting("opendistro.anomaly_detection.model_max_size_percent", 0.1, 0, Setting.Property.NodeScope, Setting.Property.Dynamic);
 
     // Thresholding
     public static final double THRESHOLD_MIN_PVALUE = 0.995;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
@@ -51,7 +51,10 @@ import junitparams.Parameters;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.monitor.jvm.JvmService;
 import org.junit.Before;
 import org.junit.Test;
@@ -78,7 +81,7 @@ import com.google.gson.Gson;
 @PowerMockIgnore("javax.management.*")
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(JUnitParamsRunner.class)
-@PrepareForTest({ Gson.class })
+@PrepareForTest({ Gson.class, ClusterSettings.class })
 @SuppressWarnings("unchecked")
 public class ModelManagerTests {
 
@@ -133,6 +136,8 @@ public class ModelManagerTests {
     private String thresholdModelId;
     private String checkpoint;
     private int shingleSize;
+    private Settings settings;
+    private ClusterService clusterService;
 
     @Before
     public void setup() {
@@ -163,6 +168,11 @@ public class ModelManagerTests {
 
         gson = PowerMockito.mock(Gson.class);
 
+        settings = Settings.builder().put("opendistro.anomaly_detection.model_max_size_percent", modelMaxSizePercentage).build();
+        ClusterSettings clusterSettings = PowerMockito.mock(ClusterSettings.class);
+
+        clusterService = new ClusterService(settings, clusterSettings, null);
+
         modelManager = spy(
             new ModelManager(
                 nodeFilter,
@@ -172,7 +182,6 @@ public class ModelManagerTests {
                 gson,
                 clock,
                 modelDesiredSizePercentage,
-                modelMaxSizePercentage,
                 numTrees,
                 numSamples,
                 rcfTimeDecay,
@@ -187,7 +196,9 @@ public class ModelManagerTests {
                 minPreviewSize,
                 modelTtl,
                 checkpointInterval,
-                shingleSize
+                shingleSize,
+                settings,
+                clusterService
             )
         );
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
@@ -182,6 +182,7 @@ public class ModelManagerTests {
                 gson,
                 clock,
                 modelDesiredSizePercentage,
+                modelMaxSizePercentage,
                 numTrees,
                 numSamples,
                 rcfTimeDecay,
@@ -197,7 +198,6 @@ public class ModelManagerTests {
                 modelTtl,
                 checkpointInterval,
                 shingleSize,
-                settings,
                 clusterService
             )
         );


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/170

*Description of changes:*

We have the following two memory threshold:
* a detector's model size per node cannot exceed 10% of heap memory
* the total model size per node cannot exceed 10% of heap memory.

If users use the ES cluster mainly for anomaly detection, they should be able to increase the memory for AD.  This PR makes the threshold dynamically adjustable via the setting opendistro.anomaly_detection.model_max_size_percent.

Testing done:
* Manually verified I can dynamically adjust the memory threshold setting.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
