### PR TITLE
Allows window size to be set per detector.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -329,6 +329,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             AnomalyDetectorSettings.MAX_SAMPLE_STRIDE,
             AnomalyDetectorSettings.TRAIN_SAMPLE_TIME_RANGE_IN_HOURS,
             AnomalyDetectorSettings.MIN_TRAIN_SAMPLES,
+            AnomalyDetectorSettings.MAX_SHINGLE_PROPORTION_MISSING,
+            AnomalyDetectorSettings.MAX_IMPUTATION_NEIGHBOR_DISTANCE,
             AnomalyDetectorSettings.PREVIEW_SAMPLE_RATE,
             AnomalyDetectorSettings.MAX_PREVIEW_SAMPLES,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -307,7 +307,6 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             AnomalyDetectorSettings.MIN_PREVIEW_SIZE,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
-            AnomalyDetectorSettings.SHINGLE_SIZE,
             clusterService
         );
 
@@ -330,9 +329,6 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             AnomalyDetectorSettings.MAX_SAMPLE_STRIDE,
             AnomalyDetectorSettings.TRAIN_SAMPLE_TIME_RANGE_IN_HOURS,
             AnomalyDetectorSettings.MIN_TRAIN_SAMPLES,
-            AnomalyDetectorSettings.SHINGLE_SIZE,
-            AnomalyDetectorSettings.MAX_MISSING_POINTS,
-            AnomalyDetectorSettings.MAX_NEIGHBOR_DISTANCE,
             AnomalyDetectorSettings.PREVIEW_SAMPLE_RATE,
             AnomalyDetectorSettings.MAX_PREVIEW_SAMPLES,
             AnomalyDetectorSettings.HOURLY_MAINTENANCE

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -67,9 +67,6 @@ public class FeatureManager {
     private final int maxSampleStride;
     private final int trainSampleTimeRangeInHours;
     private final int minTrainSamples;
-    private final int shingleSize;
-    private final int maxMissingPoints;
-    private final int maxNeighborDistance;
     private final double previewSampleRate;
     private final int maxPreviewSamples;
     private final Duration featureBufferTtl;
@@ -84,9 +81,6 @@ public class FeatureManager {
      * @param maxSampleStride max stride between uninterpolated train samples
      * @param trainSampleTimeRangeInHours time range in hours for collect train samples
      * @param minTrainSamples min number of train samples
-     * @param shingleSize size of feature shingles
-     * @param maxMissingPoints max number of missing points allowed to generate a shingle
-     * @param maxNeighborDistance max distance (number of intervals) between a missing point and a replacement neighbor
      * @param previewSampleRate number of samples to number of all the data points in the preview time range
      * @param maxPreviewSamples max number of samples from search for preview features
      * @param featureBufferTtl time to live for stale feature buffers
@@ -99,9 +93,6 @@ public class FeatureManager {
         int maxSampleStride,
         int trainSampleTimeRangeInHours,
         int minTrainSamples,
-        int shingleSize,
-        int maxMissingPoints,
-        int maxNeighborDistance,
         double previewSampleRate,
         int maxPreviewSamples,
         Duration featureBufferTtl
@@ -113,9 +104,6 @@ public class FeatureManager {
         this.maxSampleStride = maxSampleStride;
         this.trainSampleTimeRangeInHours = trainSampleTimeRangeInHours;
         this.minTrainSamples = minTrainSamples;
-        this.shingleSize = shingleSize;
-        this.maxMissingPoints = maxMissingPoints;
-        this.maxNeighborDistance = maxNeighborDistance;
         this.previewSampleRate = previewSampleRate;
         this.maxPreviewSamples = maxPreviewSamples;
         this.featureBufferTtl = featureBufferTtl;
@@ -140,6 +128,7 @@ public class FeatureManager {
      */
     public void getCurrentFeatures(AnomalyDetector detector, long startTime, long endTime, ActionListener<SinglePointFeatures> listener) {
 
+        int shingleSize = detector.getWindowSize();
         Deque<Entry<Long, Optional<double[]>>> shingle = detectorIdsToTimeShingles
             .computeIfAbsent(detector.getDetectorId(), id -> new ArrayDeque<>(shingleSize));
 
@@ -174,8 +163,8 @@ public class FeatureManager {
         long endTime
     ) {
         long intervalMilli = getDetectorIntervalInMilliseconds(detector);
-
-        return getFullShingleEndTimes(endTime, intervalMilli)
+        int shingleSize = detector.getWindowSize();
+        return getFullShingleEndTimes(endTime, intervalMilli, shingleSize)
             .filter(time -> !featuresMap.containsKey(time))
             .mapToObj(time -> new SimpleImmutableEntry<>(time - intervalMilli, time))
             .collect(Collectors.toList());
@@ -208,7 +197,7 @@ public class FeatureManager {
         ActionListener<SinglePointFeatures> listener
     ) {
         shingle.clear();
-        getFullShingleEndTimes(endTime, getDetectorIntervalInMilliseconds(detector))
+        getFullShingleEndTimes(endTime, getDetectorIntervalInMilliseconds(detector), detector.getWindowSize())
             .mapToObj(time -> featuresMap.getOrDefault(time, new SimpleImmutableEntry<>(time, Optional.empty())))
             .forEach(e -> shingle.add(e));
 
@@ -221,6 +210,7 @@ public class FeatureManager {
         long endTime,
         ActionListener<SinglePointFeatures> listener
     ) {
+        int shingleSize = detector.getWindowSize();
         Optional<double[]> currentPoint = shingle.peekLast().getValue();
         listener
             .onResponse(
@@ -234,13 +224,15 @@ public class FeatureManager {
     }
 
     private double[][] filterAndFill(Deque<Entry<Long, Optional<double[]>>> shingle, long endTime, AnomalyDetector detector) {
+        int shingleSize = detector.getWindowSize();
         Deque<Entry<Long, Optional<double[]>>> filteredShingle = shingle
             .stream()
             .filter(e -> e.getValue().isPresent())
             .collect(Collectors.toCollection(ArrayDeque::new));
         double[][] result = null;
-        if (filteredShingle.size() >= shingleSize - maxMissingPoints) {
+        if (filteredShingle.size() >= shingleSize - getMaxMissingPoints(shingleSize)) {
             // Imputes missing data points with the values of neighboring data points.
+            int maxNeighborDistance = getMaxNeighborDistance(shingleSize);
             long maxMillisecondsDifference = maxNeighborDistance * getDetectorIntervalInMilliseconds(detector);
             result = getNearbyPointsForShingle(detector, filteredShingle, endTime, maxMillisecondsDifference)
                 .map(e -> e.getValue().getValue().orElse(null))
@@ -271,10 +263,11 @@ public class FeatureManager {
         long maxMillisecondsDifference
     ) {
         long intervalMilli = getDetectorIntervalInMilliseconds(detector);
+        int shingleSize = detector.getWindowSize();
         TreeMap<Long, Optional<double[]>> search = new TreeMap<>(
             shingle.stream().collect(Collectors.toMap(Entry::getKey, Entry::getValue))
         );
-        return getFullShingleEndTimes(endTime, intervalMilli).mapToObj(t -> {
+        return getFullShingleEndTimes(endTime, intervalMilli, shingleSize).mapToObj(t -> {
             Optional<Entry<Long, Optional<double[]>>> after = Optional.ofNullable(search.ceilingEntry(t));
             Optional<Entry<Long, Optional<double[]>>> before = Optional.ofNullable(search.floorEntry(t));
             return after
@@ -290,7 +283,7 @@ public class FeatureManager {
         return ((IntervalTimeConfiguration) detector.getDetectionInterval()).toDuration().toMillis();
     }
 
-    private LongStream getFullShingleEndTimes(long endTime, long intervalMilli) {
+    private LongStream getFullShingleEndTimes(long endTime, long intervalMilli, int shingleSize) {
         return LongStream.rangeClosed(1, shingleSize).map(i -> endTime - (shingleSize - i) * intervalMilli);
     }
 
@@ -308,6 +301,7 @@ public class FeatureManager {
      */
     @Deprecated
     public Optional<double[][]> getColdStartData(AnomalyDetector detector) {
+        int shingleSize = detector.getWindowSize();
         return searchFeatureDao
             .getLatestDataTime(detector)
             .flatMap(latest -> searchFeatureDao.getFeaturesForSampledPeriods(detector, maxTrainSamples, maxSampleStride, latest))
@@ -338,6 +332,7 @@ public class FeatureManager {
     }
 
     private void getColdStartSamples(Optional<Long> latest, AnomalyDetector detector, ActionListener<Optional<double[][]>> listener) {
+        int shingleSize = detector.getWindowSize();
         if (latest.isPresent()) {
             List<Entry<Long, Long>> sampleRanges = getColdStartSampleRanges(detector, latest.get());
             try {
@@ -345,7 +340,7 @@ public class FeatureManager {
                     .getFeatureSamplesForPeriods(
                         detector,
                         sampleRanges,
-                        ActionListener.wrap(samples -> processColdStartSamples(samples, listener), listener::onFailure)
+                        ActionListener.wrap(samples -> processColdStartSamples(samples, shingleSize, listener), listener::onFailure)
                     );
             } catch (IOException e) {
                 listener.onFailure(new EndRunException(detector.getDetectorId(), CommonErrorMessages.INVALID_SEARCH_QUERY_MSG, e, true));
@@ -355,13 +350,13 @@ public class FeatureManager {
         }
     }
 
-    private void processColdStartSamples(List<Optional<double[]>> samples, ActionListener<Optional<double[][]>> listener) {
+    private void processColdStartSamples(List<Optional<double[]>> samples, int shingleSize, ActionListener<Optional<double[][]>> listener) {
         List<double[]> shingles = new ArrayList<>();
         LinkedList<Optional<double[]>> currentShingle = new LinkedList<>();
         for (Optional<double[]> sample : samples) {
             currentShingle.addLast(sample);
-            if (currentShingle.size() == this.shingleSize) {
-                sample.ifPresent(s -> fillAndShingle(currentShingle, this.shingleSize).ifPresent(shingles::add));
+            if (currentShingle.size() == shingleSize) {
+                sample.ifPresent(s -> fillAndShingle(currentShingle, shingleSize).ifPresent(shingles::add));
                 currentShingle.remove();
             }
         }
@@ -370,7 +365,7 @@ public class FeatureManager {
 
     private Optional<double[]> fillAndShingle(LinkedList<Optional<double[]>> shingle, int shingleSize) {
         Optional<double[]> result = null;
-        if (shingle.stream().filter(s -> s.isPresent()).count() >= shingleSize - this.maxMissingPoints) {
+        if (shingle.stream().filter(s -> s.isPresent()).count() >= shingleSize - getMaxMissingPoints(shingleSize)) {
             TreeMap<Integer, double[]> search = new TreeMap<>(
                 IntStream
                     .range(0, shingleSize)
@@ -385,7 +380,7 @@ public class FeatureManager {
                     .filter(a -> Math.abs(i - a.getKey()) <= before.map(b -> Math.abs(i - b.getKey())).orElse(Integer.MAX_VALUE))
                     .map(Optional::of)
                     .orElse(before)
-                    .filter(e -> Math.abs(i - e.getKey()) <= maxNeighborDistance)
+                    .filter(e -> Math.abs(i - e.getKey()) <= getMaxNeighborDistance(shingleSize))
                     .map(Entry::getValue)
                     .orElse(null);
             }).filter(d -> d != null).toArray(double[][]::new))
@@ -484,6 +479,7 @@ public class FeatureManager {
         Entry<List<Entry<Long, Long>>, Integer> sampleRangeResults = getSampleRanges(detector, startMilli, endMilli);
         List<Entry<Long, Long>> sampleRanges = sampleRangeResults.getKey();
         int stride = sampleRangeResults.getValue();
+        int shingleSize = detector.getWindowSize();
 
         getSamplesForRanges(detector, sampleRanges, ActionListener.wrap(samples -> {
             List<Entry<Long, Long>> searchTimeRange = samples.getKey();
@@ -493,8 +489,8 @@ public class FeatureManager {
             }
             double[][] sampleFeatures = samples.getValue();
 
-            List<Entry<Long, Long>> previewRanges = getPreviewRanges(searchTimeRange, stride);
-            Entry<double[][], double[][]> previewFeatures = getPreviewFeatures(sampleFeatures, stride);
+            List<Entry<Long, Long>> previewRanges = getPreviewRanges(searchTimeRange, stride, shingleSize);
+            Entry<double[][], double[][]> previewFeatures = getPreviewFeatures(sampleFeatures, stride, shingleSize);
             listener.onResponse(new Features(previewRanges, previewFeatures.getKey(), previewFeatures.getValue()));
         }, listener::onFailure));
     }
@@ -555,9 +551,10 @@ public class FeatureManager {
      *
      * @param ranges time ranges of samples
      * @param stride the number of data points between samples
+     * @param shingleSize the size of a shingle
      * @return time ranges for all data points
      */
-    private List<Entry<Long, Long>> getPreviewRanges(List<Entry<Long, Long>> ranges, int stride) {
+    private List<Entry<Long, Long>> getPreviewRanges(List<Entry<Long, Long>> ranges, int stride, int shingleSize) {
         double[] rangeStarts = ranges.stream().mapToDouble(Entry::getKey).toArray();
         double[] rangeEnds = ranges.stream().mapToDouble(Entry::getValue).toArray();
         double[] previewRangeStarts = interpolator.interpolate(new double[][] { rangeStarts }, stride * (ranges.size() - 1) + 1)[0];
@@ -576,9 +573,9 @@ public class FeatureManager {
      * sample query results. Unprocessed features are interpolated query results.
      * Processed features are inputs to models, transformed (such as shingle) from unprocessed features.
      *
-     * @return unprocessed and procesed features
+     * @return unprocessed and processed features
      */
-    private Entry<double[][], double[][]> getPreviewFeatures(double[][] samples, int stride) {
+    private Entry<double[][], double[][]> getPreviewFeatures(double[][] samples, int stride, int shingleSize) {
         Entry<double[][], double[][]> unprocessedAndProcessed = Optional
             .of(samples)
             .map(m -> transpose(m))
@@ -595,6 +592,20 @@ public class FeatureManager {
 
     private long truncateToMinute(long epochMillis) {
         return Instant.ofEpochMilli(epochMillis).truncatedTo(ChronoUnit.MINUTES).toEpochMilli();
+    }
+
+    /**
+     * @return max number of missing points allowed to generate a shingle
+     */
+    private int getMaxMissingPoints(int shingleSize) {
+        return Math.max(Math.min(2, shingleSize), (int) Math.floor(shingleSize * 0.25));
+    }
+
+    /**
+     * @return max distance (number of intervals) between a missing point and a replacement neighbor
+     */
+    private int getMaxNeighborDistance(int shingleSize) {
+        return Math.min(2, shingleSize);
     }
 
     public int getShingleSize(String detectorId) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -298,7 +298,7 @@ public class ModelManager {
      * @throws LimitExceededException when there is no sufficient resouce available
      */
     public Entry<Integer, Integer> getPartitionedForestSizes(AnomalyDetector detector) {
-        int shingleSize = detector.getWindowSize();
+        int shingleSize = detector.getShingleSize();
         String detectorId = detector.getDetectorId();
         int rcfNumFeatures = detector.getEnabledFeatureIds().size() * shingleSize;
         return getPartitionedForestSizes(
@@ -678,7 +678,7 @@ public class ModelManager {
      */
     @Deprecated
     public void trainModel(AnomalyDetector anomalyDetector, double[][] dataPoints) {
-        int shingleSize = anomalyDetector.getWindowSize();
+        int shingleSize = anomalyDetector.getShingleSize();
         if (dataPoints.length == 0 || dataPoints[0].length == 0) {
             throw new IllegalArgumentException("Data points must not be empty.");
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -113,7 +113,6 @@ public class ModelManager {
     private final CheckpointDao checkpointDao;
     private final Gson gson;
     private final Clock clock;
-    private final int shingleSize;
 
     // A tree of N samples has 2N nodes, with one bounding box for each node.
     private static final long BOUNDING_BOXES = 2L;
@@ -145,7 +144,6 @@ public class ModelManager {
      * @param minPreviewSize minimum number of data points for preview
      * @param modelTtl time to live for hosted models
      * @param checkpointInterval interval between checkpoints
-     * @param shingleSize required shingle size before RCF emitting anomaly scores
      * @param clusterService cluster service object
      */
     public ModelManager(
@@ -171,7 +169,6 @@ public class ModelManager {
         int minPreviewSize,
         Duration modelTtl,
         Duration checkpointInterval,
-        int shingleSize,
         ClusterService clusterService
     ) {
 
@@ -200,7 +197,6 @@ public class ModelManager {
 
         this.forests = new ConcurrentHashMap<>();
         this.thresholds = new ConcurrentHashMap<>();
-        this.shingleSize = shingleSize;
 
         clusterService.getClusterSettings().addSettingsUpdateConsumer(MODEL_MAX_SIZE_PERCENTAGE, it -> this.modelMaxSizePercentage = it);
     }
@@ -302,6 +298,7 @@ public class ModelManager {
      * @throws LimitExceededException when there is no sufficient resouce available
      */
     public Entry<Integer, Integer> getPartitionedForestSizes(AnomalyDetector detector) {
+        int shingleSize = detector.getWindowSize();
         String detectorId = detector.getDetectorId();
         int rcfNumFeatures = detector.getEnabledFeatureIds().size() * shingleSize;
         return getPartitionedForestSizes(
@@ -681,6 +678,7 @@ public class ModelManager {
      */
     @Deprecated
     public void trainModel(AnomalyDetector anomalyDetector, double[][] dataPoints) {
+        int shingleSize = anomalyDetector.getWindowSize();
         if (dataPoints.length == 0 || dataPoints[0].length == 0) {
             throw new IllegalArgumentException("Data points must not be empty.");
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.model;
 
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 
@@ -427,7 +428,7 @@ public class AnomalyDetector implements ToXContentObject {
     }
 
     public Integer getShingleSize() {
-        return shingleSize;
+        return shingleSize == null ? DEFAULT_SHINGLE_SIZE : shingleSize;
     }
 
     public Map<String, Object> getUiMetadata() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.rest;
 
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DETECTION_INTERVAL;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DETECTION_WINDOW_DELAY;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_DETECTORS;
@@ -106,7 +107,8 @@ public class RestIndexAnomalyDetectorAction extends BaseRestHandler {
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
         // TODO: check detection interval < modelTTL
-        AnomalyDetector detector = AnomalyDetector.parse(parser, detectorId, null, detectionInterval, detectionWindowDelay);
+        AnomalyDetector detector = AnomalyDetector
+            .parse(parser, detectorId, null, detectionInterval, detectionWindowDelay, DEFAULT_SHINGLE_SIZE);
 
         long seqNo = request.paramAsLong(IF_SEQ_NO, SequenceNumbers.UNASSIGNED_SEQ_NO);
         long primaryTerm = request.paramAsLong(IF_PRIMARY_TERM, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -279,6 +279,7 @@ public class IndexAnomalyDetectorActionHandler extends AbstractActionHandler {
             anomalyDetector.getFilterQuery(),
             anomalyDetector.getDetectionInterval(),
             anomalyDetector.getWindowDelay(),
+            anomalyDetector.getWindowSize(),
             anomalyDetector.getUiMetadata(),
             anomalyDetector.getSchemaVersion(),
             Instant.now()

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -279,7 +279,7 @@ public class IndexAnomalyDetectorActionHandler extends AbstractActionHandler {
             anomalyDetector.getFilterQuery(),
             anomalyDetector.getDetectionInterval(),
             anomalyDetector.getWindowDelay(),
-            anomalyDetector.getWindowSize(),
+            anomalyDetector.getShingleSize(),
             anomalyDetector.getUiMetadata(),
             anomalyDetector.getSchemaVersion(),
             Instant.now()

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -197,11 +197,7 @@ public final class AnomalyDetectorSettings {
 
     public static final int MIN_TRAIN_SAMPLES = 512;
 
-    public static final int SHINGLE_SIZE = 8;
-
-    public static final int MAX_MISSING_POINTS = Math.min(2, SHINGLE_SIZE);
-
-    public static final int MAX_NEIGHBOR_DISTANCE = Math.min(2, SHINGLE_SIZE);
+    public static final int DEFAULT_SHINGLE_SIZE = 8;
 
     public static final double PREVIEW_SAMPLE_RATE = 0.25; // ok to adjust, higher for more data, lower for lower latency
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -199,6 +199,10 @@ public final class AnomalyDetectorSettings {
 
     public static final int DEFAULT_SHINGLE_SIZE = 8;
 
+    public static final int MAX_IMPUTATION_NEIGHBOR_DISTANCE = 2;
+
+    public static final double MAX_SHINGLE_PROPORTION_MISSING = 0.25;
+
     public static final double PREVIEW_SAMPLE_RATE = 0.25; // ok to adjust, higher for more data, lower for lower latency
 
     public static final int MAX_PREVIEW_SAMPLES = 300; // ok to adjust, higher for more data, lower for lower latency

--- a/src/main/resources/mappings/anomaly-detectors.json
+++ b/src/main/resources/mappings/anomaly-detectors.json
@@ -93,6 +93,9 @@
         }
       }
     },
+    "window_size": {
+      "type": "integer"
+    },
     "last_update_time": {
       "type": "date",
       "format": "strict_date_time||epoch_millis"

--- a/src/main/resources/mappings/anomaly-detectors.json
+++ b/src/main/resources/mappings/anomaly-detectors.json
@@ -93,7 +93,7 @@
         }
       }
     },
-    "window_size": {
+    "shingle_size": {
       "type": "integer"
     },
     "last_update_time": {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
@@ -103,6 +103,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
+            detector.getWindowSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             detector.getLastUpdateTime()
@@ -172,6 +173,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                 detector.getFilterQuery(),
                 detector.getDetectionInterval(),
                 detector.getWindowDelay(),
+                detector.getWindowSize(),
                 detector.getUiMetadata(),
                 detector.getSchemaVersion(),
                 detector.getLastUpdateTime()

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
@@ -103,7 +103,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
-            detector.getWindowSize(),
+            detector.getShingleSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             detector.getLastUpdateTime()
@@ -173,7 +173,7 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                 detector.getFilterQuery(),
                 detector.getDetectionInterval(),
                 detector.getWindowDelay(),
-                detector.getWindowSize(),
+                detector.getShingleSize(),
                 detector.getUiMetadata(),
                 detector.getSchemaVersion(),
                 detector.getLastUpdateTime()

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -189,6 +189,7 @@ public class TestHelpers {
             randomQuery(),
             randomIntervalTimeConfiguration(),
             randomIntervalTimeConfiguration(),
+            randomInt(),
             uiMetadata,
             randomInt(),
             lastUpdateTime
@@ -207,6 +208,7 @@ public class TestHelpers {
             randomQuery(),
             randomIntervalTimeConfiguration(),
             randomIntervalTimeConfiguration(),
+            randomInt(),
             null,
             randomInt(),
             Instant.now()
@@ -225,6 +227,7 @@ public class TestHelpers {
             randomQuery(),
             randomIntervalTimeConfiguration(),
             randomIntervalTimeConfiguration(),
+            randomInt(),
             null,
             randomInt(),
             Instant.now().truncatedTo(ChronoUnit.SECONDS)
@@ -243,6 +246,7 @@ public class TestHelpers {
             randomQuery(),
             interval,
             randomIntervalTimeConfiguration(),
+            randomInt(),
             null,
             randomInt(),
             Instant.now().truncatedTo(ChronoUnit.SECONDS)

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -21,6 +21,7 @@ import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomDouble;
 import static org.elasticsearch.test.ESTestCase.randomInt;
+import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.elasticsearch.test.ESTestCase.randomLong;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -189,7 +190,7 @@ public class TestHelpers {
             randomQuery(),
             randomIntervalTimeConfiguration(),
             randomIntervalTimeConfiguration(),
-            randomInt(),
+            randomIntBetween(1, 2000),
             uiMetadata,
             randomInt(),
             lastUpdateTime
@@ -208,7 +209,7 @@ public class TestHelpers {
             randomQuery(),
             randomIntervalTimeConfiguration(),
             randomIntervalTimeConfiguration(),
-            randomInt(),
+            randomIntBetween(1, 2000),
             null,
             randomInt(),
             Instant.now()
@@ -227,7 +228,7 @@ public class TestHelpers {
             randomQuery(),
             randomIntervalTimeConfiguration(),
             randomIntervalTimeConfiguration(),
-            randomInt(),
+            randomIntBetween(1, 2000),
             null,
             randomInt(),
             Instant.now().truncatedTo(ChronoUnit.SECONDS)
@@ -246,7 +247,7 @@ public class TestHelpers {
             randomQuery(),
             interval,
             randomIntervalTimeConfiguration(),
-            randomInt(),
+            randomIntBetween(1, 2000),
             null,
             randomInt(),
             Instant.now().truncatedTo(ChronoUnit.SECONDS)

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
@@ -166,7 +166,7 @@ public class ModelManagerTests {
 
         when(jvmService.info().getMem().getHeapMax().getBytes()).thenReturn(10_000_000_000L);
 
-        when(anomalyDetector.getWindowSize()).thenReturn(shingleSize);
+        when(anomalyDetector.getShingleSize()).thenReturn(shingleSize);
 
         gson = PowerMockito.mock(Gson.class);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
@@ -166,6 +166,8 @@ public class ModelManagerTests {
 
         when(jvmService.info().getMem().getHeapMax().getBytes()).thenReturn(10_000_000_000L);
 
+        when(anomalyDetector.getWindowSize()).thenReturn(shingleSize);
+
         gson = PowerMockito.mock(Gson.class);
 
         settings = Settings.builder().put("opendistro.anomaly_detection.model_max_size_percent", modelMaxSizePercentage).build();
@@ -197,7 +199,6 @@ public class ModelManagerTests {
                 minPreviewSize,
                 modelTtl,
                 checkpointInterval,
-                shingleSize,
                 clusterService
             )
         );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -316,4 +316,24 @@ public class AnomalyDetectorTests extends ESTestCase {
         );
         assertEquals((int) anomalyDetector.getShingleSize(), 5);
     }
+
+    public void testGetShingleSizeReturnsDefaultValue() throws IOException {
+        AnomalyDetector anomalyDetector = new AnomalyDetector(
+            randomAlphaOfLength(5),
+            randomLong(),
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            ImmutableList.of(randomAlphaOfLength(5)),
+            ImmutableList.of(TestHelpers.randomFeature()),
+            TestHelpers.randomQuery(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            null,
+            null,
+            1,
+            Instant.now()
+        );
+        assertEquals((int) anomalyDetector.getShingleSize(), AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE);
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.test.ESTestCase;
 
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -46,7 +47,7 @@ public class AnomalyDetectorTests extends ESTestCase {
             + "\"feature_attributes\":[{\"feature_id\":\"lxYRN\",\"feature_name\":\"eqSeU\",\"feature_enabled\""
             + ":true,\"aggregation_query\":{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}}],\"detection_interval\":"
             + "{\"period\":{\"interval\":425,\"unit\":\"Minutes\"}},\"window_delay\":{\"period\":{\"interval\":973,"
-            + "\"unit\":\"Minutes\"}},\"schema_version\":-1203962153,\"ui_metadata\":{\"JbAaV\":{\"feature_id\":"
+            + "\"unit\":\"Minutes\"}},\"window_size\":4,\"schema_version\":-1203962153,\"ui_metadata\":{\"JbAaV\":{\"feature_id\":"
             + "\"rIFjS\",\"feature_name\":\"QXCmS\",\"feature_enabled\":false,\"aggregation_query\":{\"aa\":"
             + "{\"value_count\":{\"field\":\"ok\"}}}}},\"last_update_time\":1568396089028}";
         AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
@@ -59,7 +60,7 @@ public class AnomalyDetectorTests extends ESTestCase {
             + "\"feature_attributes\":[{\"feature_id\":\"lxYRN\",\"feature_name\":\"eqSeU\",\"feature_enabled\":"
             + "true,\"aggregation_query\":{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}}],\"filter_query\":{},"
             + "\"detection_interval\":{\"period\":{\"interval\":425,\"unit\":\"Minutes\"}},\"window_delay\":"
-            + "{\"period\":{\"interval\":973,\"unit\":\"Minutes\"}},\"schema_version\":-1203962153,\"ui_metadata\":"
+            + "{\"period\":{\"interval\":973,\"unit\":\"Minutes\"}},\"window_size\":4,\"schema_version\":-1203962153,\"ui_metadata\":"
             + "{\"JbAaV\":{\"feature_id\":\"rIFjS\",\"feature_name\":\"QXCmS\",\"feature_enabled\":false,"
             + "\"aggregation_query\":{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}}},"
             + "\"last_update_time\":1568396089028}";
@@ -73,11 +74,24 @@ public class AnomalyDetectorTests extends ESTestCase {
             + "\"feature_attributes\":[{\"feature_id\":\"lxYRN\",\"feature_name\":\"eqSeU\",\"feature_enabled\":"
             + "true,\"aggregation_query\":{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}}],\"filter_query\":"
             + "{\"aa\":\"bb\"},\"detection_interval\":{\"period\":{\"interval\":425,\"unit\":\"Minutes\"}},"
-            + "\"window_delay\":{\"period\":{\"interval\":973,\"unit\":\"Minutes\"}},\"schema_version\":"
+            + "\"window_delay\":{\"period\":{\"interval\":973,\"unit\":\"Minutes\"}},\"window_size\":4,\"schema_version\":"
             + "-1203962153,\"ui_metadata\":{\"JbAaV\":{\"feature_id\":\"rIFjS\",\"feature_name\":\"QXCmS\","
             + "\"feature_enabled\":false,\"aggregation_query\":{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}}},"
             + "\"last_update_time\":1568396089028}";
         TestHelpers.assertFailWith(ParsingException.class, () -> AnomalyDetector.parse(TestHelpers.parser(detectorString)));
+    }
+
+    public void testParseAnomalyDetectorWithoutOptionalParams() throws IOException {
+        String detectorString = "{\"name\":\"todagtCMkwpcaedpyYUM\",\"description\":"
+            + "\"ClrcaMpuLfeDSlVduRcKlqPZyqWDBf\",\"time_field\":\"dJRwh\",\"indices\":[\"eIrgWMqAED\"],"
+            + "\"feature_attributes\":[{\"feature_id\":\"lxYRN\",\"feature_name\":\"eqSeU\",\"feature_enabled\""
+            + ":true,\"aggregation_query\":{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}}],\"detection_interval\":"
+            + "{\"period\":{\"interval\":425,\"unit\":\"Minutes\"}},\"schema_version\":-1203962153,\"ui_metadata\":"
+            + "{\"JbAaV\":{\"feature_id\":\"rIFjS\",\"feature_name\":\"QXCmS\",\"feature_enabled\":false,"
+            + "\"aggregation_query\":{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}}},\"last_update_time\":1568396089028}";
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertTrue(parsedDetector.getFilterQuery() instanceof MatchAllQueryBuilder);
+        assertEquals((long) parsedDetector.getWindowSize(), (long) AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE);
     }
 
     public void testParseAnomalyDetectorWithNullUiMetadata() throws IOException {
@@ -110,6 +124,7 @@ public class AnomalyDetectorTests extends ESTestCase {
                     TestHelpers.randomQuery(),
                     TestHelpers.randomIntervalTimeConfiguration(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
                     Instant.now()
@@ -132,6 +147,7 @@ public class AnomalyDetectorTests extends ESTestCase {
                     TestHelpers.randomQuery(),
                     TestHelpers.randomIntervalTimeConfiguration(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
                     Instant.now()
@@ -154,6 +170,7 @@ public class AnomalyDetectorTests extends ESTestCase {
                     TestHelpers.randomQuery(),
                     TestHelpers.randomIntervalTimeConfiguration(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
                     Instant.now()
@@ -176,6 +193,7 @@ public class AnomalyDetectorTests extends ESTestCase {
                     TestHelpers.randomQuery(),
                     TestHelpers.randomIntervalTimeConfiguration(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
                     Instant.now()
@@ -198,6 +216,7 @@ public class AnomalyDetectorTests extends ESTestCase {
                     TestHelpers.randomQuery(),
                     TestHelpers.randomIntervalTimeConfiguration(),
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
                     Instant.now()
@@ -220,6 +239,7 @@ public class AnomalyDetectorTests extends ESTestCase {
                     TestHelpers.randomQuery(),
                     null,
                     TestHelpers.randomIntervalTimeConfiguration(),
+                    AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
                     Instant.now()
@@ -240,5 +260,25 @@ public class AnomalyDetectorTests extends ESTestCase {
         String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
         AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
         assertEquals(0, parsedDetector.getFeatureAttributes().size());
+    }
+
+    public void testGetWindowSize() throws IOException {
+        AnomalyDetector anomalyDetector = new AnomalyDetector(
+            randomAlphaOfLength(5),
+            randomLong(),
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            ImmutableList.of(randomAlphaOfLength(5)),
+            ImmutableList.of(TestHelpers.randomFeature()),
+            TestHelpers.randomQuery(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            5,
+            null,
+            1,
+            Instant.now()
+        );
+        assertEquals((int) anomalyDetector.getWindowSize(), 5);
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -97,7 +97,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomQuery(),
             randomIntervalTimeConfiguration(),
             randomIntervalTimeConfiguration(),
-            randomInt(),
+            randomIntBetween(1, 2000),
             randomUiMetadata(),
             randomInt(),
             null
@@ -179,7 +179,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
-            detector.getWindowSize(),
+            detector.getShingleSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             detector.getLastUpdateTime()
@@ -239,7 +239,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector1.getFilterQuery(),
             detector1.getDetectionInterval(),
             detector1.getWindowDelay(),
-            detector1.getWindowSize(),
+            detector1.getShingleSize(),
             detector1.getUiMetadata(),
             detector1.getSchemaVersion(),
             detector1.getLastUpdateTime()
@@ -275,7 +275,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
-            detector.getWindowSize(),
+            detector.getShingleSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             Instant.now()
@@ -317,7 +317,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
-            detector.getWindowSize(),
+            detector.getShingleSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             detector.getLastUpdateTime()
@@ -699,7 +699,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
-            detector.getWindowSize(),
+            detector.getShingleSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             detector.getLastUpdateTime()

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -97,6 +97,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomQuery(),
             randomIntervalTimeConfiguration(),
             randomIntervalTimeConfiguration(),
+            randomInt(),
             randomUiMetadata(),
             randomInt(),
             null
@@ -178,6 +179,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
+            detector.getWindowSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             detector.getLastUpdateTime()
@@ -237,6 +239,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector1.getFilterQuery(),
             detector1.getDetectionInterval(),
             detector1.getWindowDelay(),
+            detector1.getWindowSize(),
             detector1.getUiMetadata(),
             detector1.getSchemaVersion(),
             detector1.getLastUpdateTime()
@@ -272,6 +275,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
+            detector.getWindowSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             Instant.now()
@@ -313,6 +317,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
+            detector.getWindowSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             detector.getLastUpdateTime()
@@ -694,6 +699,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getFilterQuery(),
             detector.getDetectionInterval(),
             detector.getWindowDelay(),
+            detector.getWindowSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
             detector.getLastUpdateTime()


### PR DESCRIPTION
*Description of changes:*

- This change adds a new `windowSize` instance variable to the AnomalyDetector class along with a public getter for this variable, which the model uses to determine the shingle size. 
- The Create Detector and Update Detector APIs allow `window_size` to be set per detector. If no `window_size` param is provided, the default is set to 8.
- The Get Detector, Preview Detector, and Search Detector APIs will also reflect the `window_size` value in the API response.
- The FeatureManager and ModelManager classes have `shingleSize` removed as instance variables, and instead gets the shingle size from the anomaly detector that is passed to their methods.
- The `maxMissingPoints` (that determines how many data points can be missing and still form a valid shingle) is set to be at most 25% of the shingle size. The floor is still set to the same as before: `max(2, shingleSize)`. The `maxNeighborDistance` (max number of intervals away that a data point value can be imputed to a missing data point) is the same as before: `max(2, shingleSize)`.
- 6 new unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
