### PR TITLE
fix job index mapping

### DIFF
--- a/src/main/resources/mappings/anomaly-detector-jobs.json
+++ b/src/main/resources/mappings/anomaly-detector-jobs.json
@@ -7,11 +7,18 @@
     "schema_version": {
       "type": "integer"
     },
+    "name": {
+      "type": "keyword"
+    },
     "schedule": {
       "properties": {
-        "period": {
+        "interval": {
           "properties": {
-            "interval": {
+            "start_time": {
+              "type": "date",
+              "format": "strict_date_time||epoch_millis"
+            },
+            "period": {
               "type": "integer"
             },
             "unit": {
@@ -39,6 +46,10 @@
       "type": "boolean"
     },
     "enabled_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "disabled_time": {
       "type": "date",
       "format": "strict_date_time||epoch_millis"
     },


### PR DESCRIPTION
## Description of changes:

Current job index mapping can't match the [model class](https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/master/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorJob.java). AD job can run successfully. This PR fixes the job index mapping to match the model class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
