### PR TITLE
Use goimports instead of gofmt

### DIFF
--- a/.github/workflows/esad-cli-test-and-build-workflow.yml
+++ b/.github/workflows/esad-cli-test-and-build-workflow.yml
@@ -39,8 +39,10 @@ jobs:
       - name: Check out AD CLI
         uses: actions/checkout@v2
 
-      - name: gofmt
-        run: gofmt -s -w .
+      - name: Format
+        run: |
+          go get golang.org/x/tools/cmd/goimports
+          goimports -w .
       - name: Check for modified files
         id: git-check
         run: |
@@ -48,9 +50,9 @@ jobs:
       - name: Display unformated changes
         if: steps.git-check.outputs.modified == 'true'
         run: |
-          echo "Failed to format using go-fmt".
+          echo "Failed to format using goimports".
           git diff
-
+          exit 1
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v1

--- a/cli/cmd/cat.go
+++ b/cli/cmd/cat.go
@@ -17,6 +17,7 @@ import (
 	entity "esad/internal/entity/ad"
 	"esad/internal/handler/ad"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -15,6 +15,7 @@ package cmd
 import (
 	handler "esad/internal/handler/ad"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/delete.go
+++ b/cli/cmd/delete.go
@@ -15,6 +15,7 @@ package cmd
 import (
 	handler "esad/internal/handler/ad"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cli/cmd/profile.go
+++ b/cli/cmd/profile.go
@@ -17,13 +17,14 @@ import (
 	"esad/internal/client"
 	entity "esad/internal/entity/ad"
 	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh/terminal"
-	"os"
-	"strings"
-	"text/tabwriter"
 )
 
 const (

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -21,11 +21,12 @@ import (
 	handler "esad/internal/handler/ad"
 	"esad/pkg"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"path/filepath"
 )
 
 const (

--- a/cli/cmd/start_stop.go
+++ b/cli/cmd/start_stop.go
@@ -16,6 +16,7 @@ import (
 	"esad/internal/client"
 	"esad/internal/handler/ad"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -22,6 +22,6 @@ require (
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
 	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6 // indirect
+	golang.org/x/tools v0.0.0-20200820180210-c8f393745106 // indirect
 	gopkg.in/ini.v1 v1.57.0 // indirect
 )

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -356,6 +356,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6 h1:nULzSsKgihxFGLnQFv2T7lE5vIhOtg8ZPpJHapEt7o0=
 golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200820180210-c8f393745106 h1:42Zs/g7pjhSIE/wiAuKcp8zp20zv7W2diNU6arpshOA=
+golang.org/x/tools v0.0.0-20200820180210-c8f393745106/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/cli/internal/client/request.go
+++ b/cli/internal/client/request.go
@@ -14,8 +14,9 @@ package client
 
 import (
 	"crypto/tls"
-	"github.com/hashicorp/go-retryablehttp"
 	"net/http"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 //Client is an Abstraction for actual client

--- a/cli/internal/controller/ad/ad.go
+++ b/cli/internal/controller/ad/ad.go
@@ -22,10 +22,11 @@ import (
 	cmapper "esad/internal/mapper"
 	mapper "esad/internal/mapper/ad"
 	"fmt"
-	"github.com/cheggaaa/pb/v3"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/cheggaaa/pb/v3"
 )
 
 //go:generate mockgen -destination=mocks/mock_ad.go -package=mocks . Controller

--- a/cli/internal/controller/ad/ad_test.go
+++ b/cli/internal/controller/ad/ad_test.go
@@ -22,12 +22,13 @@ import (
 	adgateway "esad/internal/gateway/ad/mocks"
 	mapper2 "esad/internal/mapper"
 	"fmt"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 )
 
 const mockDetectorID = "m4ccEnIBTXsGi3mvMt9p"

--- a/cli/internal/controller/ad/mocks/mock_ad.go
+++ b/cli/internal/controller/ad/mocks/mock_ad.go
@@ -7,8 +7,9 @@ package mocks
 import (
 	context "context"
 	ad "esad/internal/entity/ad"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockController is a mock of Controller interface

--- a/cli/internal/controller/es/es.go
+++ b/cli/internal/controller/es/es.go
@@ -15,7 +15,7 @@ package es
 import (
 	"context"
 	"encoding/json"
-	"esad/internal/entity/es"
+	elasticsearch "esad/internal/entity/es"
 	"esad/internal/gateway/es"
 	"fmt"
 )

--- a/cli/internal/controller/es/es_test.go
+++ b/cli/internal/controller/es/es_test.go
@@ -16,11 +16,12 @@ import (
 	"context"
 	"errors"
 	gateway "esad/internal/gateway/es/mocks"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 )
 
 func helperLoadBytes(t *testing.T, name string) []byte {

--- a/cli/internal/controller/es/mocks/mock_es.go
+++ b/cli/internal/controller/es/mocks/mock_es.go
@@ -6,8 +6,9 @@ package mocks
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockController is a mock of Controller interface

--- a/cli/internal/entity/ad/ad_test.go
+++ b/cli/internal/entity/ad/ad_test.go
@@ -15,9 +15,10 @@ package ad
 import (
 	"encoding/json"
 	"esad/internal/mapper"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func getRawFilter() []byte {

--- a/cli/internal/entity/es/es.go
+++ b/cli/internal/entity/es/es.go
@@ -10,7 +10,7 @@
  * permissions and limitations under the License.
  */
 
-package elasticsearch
+package es
 
 //Terms contains fields
 type Terms struct {

--- a/cli/internal/gateway/ad/ad_test.go
+++ b/cli/internal/gateway/ad/ad_test.go
@@ -19,11 +19,12 @@ import (
 	"esad/internal/client"
 	"esad/internal/client/mocks"
 	"esad/internal/entity/ad"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func helperLoadBytes(t *testing.T, name string) []byte {

--- a/cli/internal/gateway/ad/mocks/mock_ad.go
+++ b/cli/internal/gateway/ad/mocks/mock_ad.go
@@ -6,8 +6,9 @@ package mocks
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockGateway is a mock of Gateway interface

--- a/cli/internal/gateway/es/es_test.go
+++ b/cli/internal/gateway/es/es_test.go
@@ -19,11 +19,12 @@ import (
 	"esad/internal/client"
 	"esad/internal/client/mocks"
 	elasticsearch "esad/internal/entity/es"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func helperLoadBytes(t *testing.T, name string) []byte {

--- a/cli/internal/gateway/es/mocks/mock_es.go
+++ b/cli/internal/gateway/es/mocks/mock_es.go
@@ -6,8 +6,9 @@ package mocks
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockGateway is a mock of Gateway interface

--- a/cli/internal/gateway/gateway.go
+++ b/cli/internal/gateway/gateway.go
@@ -18,9 +18,10 @@ import (
 	"encoding/json"
 	"esad/internal/client"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
 	"io/ioutil"
 	"net/url"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 //HTTPGateway type for gateway client

--- a/cli/internal/handler/ad/ad_test.go
+++ b/cli/internal/handler/ad/ad_test.go
@@ -19,9 +19,10 @@ import (
 	"esad/internal/controller/ad/mocks"
 	"esad/internal/entity/ad"
 	"esad/internal/mapper"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func getRawFilter() []byte {

--- a/cli/internal/mapper/ad/ad_test.go
+++ b/cli/internal/mapper/ad/ad_test.go
@@ -15,10 +15,11 @@ package ad
 import (
 	"esad/internal/entity/ad"
 	"esad/internal/mapper"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func helperLoadBytes(t *testing.T, name string) []byte {


### PR DESCRIPTION
goimports fixes imports order and also formats like gofmt.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
