### PR TITLE
Install go get outside cli directory

### DIFF
--- a/.github/workflows/esad-cli-test-and-build-workflow.yml
+++ b/.github/workflows/esad-cli-test-and-build-workflow.yml
@@ -41,7 +41,9 @@ jobs:
 
       - name: Format
         run: |
+          cd ..
           go get golang.org/x/tools/cmd/goimports
+          cd cli
           goimports -w .
       - name: Check for modified files
         id: git-check


### PR DESCRIPTION
go get inside cli will update the go.mod, since this is not part of code dependencies,
install goimports outside scope of cli.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
