### PR TITLE
CLI: Download Detector Configuration as File

### DIFF
--- a/cli/cmd/cat.go
+++ b/cli/cmd/cat.go
@@ -43,7 +43,7 @@ var catCmd = &cobra.Command{
 	},
 }
 
-type Display func(*entity.DetectorOutput) error
+type Display func(*cobra.Command, *entity.DetectorOutput) error
 
 //printDetectors print detectors
 func printDetectors(display Display, cmd *cobra.Command, detectors []string) error {
@@ -61,7 +61,7 @@ func printDetectors(display Display, cmd *cobra.Command, detectors []string) err
 	if err != nil {
 		return err
 	}
-	return print(display, results)
+	return print(cmd, display, results)
 }
 
 func getDetectors(
@@ -89,12 +89,12 @@ func getDetectorsByID(commandHandler *ad.Handler, ID string) ([]*entity.Detector
 }
 
 //print displays the list of output.
-func print(display Display, results []*entity.DetectorOutput) error {
+func print(cmd *cobra.Command, display Display, results []*entity.DetectorOutput) error {
 	if results == nil {
 		return nil
 	}
 	for _, d := range results {
-		if err := display(d); err != nil {
+		if err := display(cmd, d); err != nil {
 			return err
 		}
 	}
@@ -113,7 +113,7 @@ func FPrint(writer io.Writer, d *entity.DetectorOutput) error {
 }
 
 //Println prints detector configuration on stdout
-func Println(d *entity.DetectorOutput) error {
+func Println(cmd *cobra.Command, d *entity.DetectorOutput) error {
 	return FPrint(os.Stdout, d)
 }
 

--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -39,17 +39,12 @@ var createCmd = &cobra.Command{
 		}
 		//If no args, display usage
 		if len(args) < 1 {
-			if err := cmd.Usage(); err != nil {
-				fmt.Println(err)
-			}
+			displayError(cmd.Usage(), commandCreate)
 			return
 		}
 		status, _ := cmd.Flags().GetBool(interactive)
 		err := createDetectors(args, status)
-		if err != nil {
-			fmt.Println(commandCreate, "command failed")
-			fmt.Println("Reason:", err)
-		}
+		displayError(err, commandCreate)
 	},
 }
 

--- a/cli/cmd/delete.go
+++ b/cli/cmd/delete.go
@@ -14,7 +14,6 @@ package cmd
 
 import (
 	handler "esad/internal/handler/ad"
-	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -30,9 +29,7 @@ var deleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		//If no args, display usage
 		if len(args) < 1 {
-			if err := cmd.Usage(); err != nil {
-				fmt.Println(err)
-			}
+			displayError(cmd.Usage(), commandDelete)
 			return
 		}
 		force, _ := cmd.Flags().GetBool("force")
@@ -42,10 +39,7 @@ var deleteCmd = &cobra.Command{
 			action = handler.DeleteAnomalyDetectorByID
 		}
 		err := deleteDetectors(args, force, action)
-		if err != nil {
-			fmt.Println(commandDelete, "command failed")
-			fmt.Println("Reason:", err)
-		}
+		displayError(err, commandDelete)
 	},
 }
 

--- a/cli/cmd/download.go
+++ b/cli/cmd/download.go
@@ -25,6 +25,7 @@ import (
 const (
 	commandDownload   = "download"
 	flagInteractive   = "interactive"
+	flagOutput        = "output"
 	fileExtensionJSON = "json"
 )
 
@@ -50,11 +51,11 @@ var downloadCmd = &cobra.Command{
 //file will be created inside current working directory,
 //with detector name as file name
 func WriteInFile(cmd *cobra.Command, d *entity.DetectorOutput) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
+	output, _ := cmd.Flags().GetString(flagOutput)
+	if _, err := os.Stat(output); os.IsNotExist(err) {
+		return fmt.Errorf("output directory [%s] does not exists", output)
 	}
-	filePath := filepath.Join(cwd, fmt.Sprintf("%s.%s", d.Name, fileExtensionJSON))
+	filePath := filepath.Join(output, fmt.Sprintf("%s.%s", d.Name, fileExtensionJSON))
 	interactive, _ := cmd.Flags().GetBool(flagInteractive)
 	if ok := isCreateFileAllowed(filePath, interactive); !ok {
 		return nil
@@ -104,4 +105,9 @@ func init() {
 	downloadCmd.Flags().BoolP("name", "", true, "input is name or pattern")
 	downloadCmd.Flags().BoolP("id", "", false, "input is id")
 	downloadCmd.Flags().BoolP(flagInteractive, "i", false, "write a prompt before downloading a file that would overwrite an existing file.")
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Println("failed to find current working directory due to ", err)
+	}
+	downloadCmd.Flags().StringP(flagOutput, "o", cwd, "downloads detectors inside this folder path")
 }

--- a/cli/cmd/download.go
+++ b/cli/cmd/download.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package cmd
+
+import (
+	entity "esad/internal/entity/ad"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+const commandDownload = "download"
+
+//downloadCmd downloads detectors configuration on current working directory
+//based on detector id or name patter
+var downloadCmd = &cobra.Command{
+	Use:   commandDownload + " [flags] [list of detectors]",
+	Short: "Downloads detectors configurations based on id or name pattern",
+	Long: fmt.Sprintf("Description:\n  " +
+		`Downloads detectors configurations based on id or name pattern, use "" to make sure the name is not matched with pwd lists'`),
+	Run: func(cmd *cobra.Command, args []string) {
+		//If no args, display usage
+		if len(args) < 1 {
+			displayError(cmd.Usage(), commandDownload)
+			return
+		}
+		err := printDetectors(WriteInFile, cmd, args)
+		displayError(err, commandDownload)
+	},
+}
+
+//WriteInFile writes detector's configuration on file
+//file will be created inside current working directory,
+//with detector name as file name
+func WriteInFile(d *entity.DetectorOutput) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	filePath := filepath.Join(cwd, d.Name)
+	f, err := os.Create(filePath)
+	defer func() {
+		f.Close()
+	}()
+	if err != nil {
+		return err
+	}
+	return FPrint(f, d)
+}
+
+func init() {
+	esadCmd.AddCommand(downloadCmd)
+	downloadCmd.Flags().BoolP("name", "", true, "input is name or pattern")
+	downloadCmd.Flags().BoolP("id", "", false, "input is id")
+}

--- a/cli/cmd/download.go
+++ b/cli/cmd/download.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	commandDownload   = "download"
-	flagInteractive   = "interactive"
 	flagOutput        = "output"
 	fileExtensionJSON = "json"
 )
@@ -56,8 +55,7 @@ func WriteInFile(cmd *cobra.Command, d *entity.DetectorOutput) error {
 		return fmt.Errorf("output directory [%s] does not exists", output)
 	}
 	filePath := filepath.Join(output, fmt.Sprintf("%s.%s", d.Name, fileExtensionJSON))
-	interactive, _ := cmd.Flags().GetBool(flagInteractive)
-	if ok := isCreateFileAllowed(filePath, interactive); !ok {
+	if ok := isCreateFileAllowed(filePath); !ok {
 		return nil
 	}
 	f, err := os.Create(filePath)
@@ -70,10 +68,7 @@ func WriteInFile(cmd *cobra.Command, d *entity.DetectorOutput) error {
 	return FPrint(f, d)
 }
 
-func isCreateFileAllowed(path string, interactive bool) bool {
-	if !interactive {
-		return true
-	}
+func isCreateFileAllowed(path string) bool {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return true
 	}
@@ -104,7 +99,6 @@ func init() {
 	esadCmd.AddCommand(downloadCmd)
 	downloadCmd.Flags().BoolP("name", "", true, "input is name or pattern")
 	downloadCmd.Flags().BoolP("id", "", false, "input is id")
-	downloadCmd.Flags().BoolP(flagInteractive, "i", false, "write a prompt before downloading a file that would overwrite an existing file.")
 	cwd, err := os.Getwd()
 	if err != nil {
 		fmt.Println("failed to find current working directory due to ", err)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -111,3 +111,10 @@ func GetHandler(c *client.Client, u *client.UserConfig) *handler.Handler {
 	ctr := controller.New(os.Stdin, esc, g)
 	return handler.New(ctr)
 }
+
+func displayError(err error, cmdName string) {
+	if err != nil {
+		fmt.Println(cmdName, "command failed")
+		fmt.Println("Reason: ", err)
+	}
+}

--- a/cli/cmd/start_stop.go
+++ b/cli/cmd/start_stop.go
@@ -15,7 +15,6 @@ package cmd
 import (
 	"esad/internal/client"
 	"esad/internal/handler/ad"
-	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -32,16 +31,17 @@ var startCmd = &cobra.Command{
 	Short: "Start detectors based on an ID or name pattern",
 	Long:  `Start detectors based on a pattern. Use "" to make sure the name does not match with pwd lists'`,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) < 1 {
+			displayError(cmd.Usage(), commandStop)
+			return
+		}
 		idStatus, _ := cmd.Flags().GetBool("id")
 		action := ad.StartAnomalyDetectorByNamePattern
 		if idStatus {
 			action = ad.StartAnomalyDetectorByID
 		}
 		err := execute(action, args)
-		if err != nil {
-			fmt.Println(commandStart, "command failed")
-			fmt.Println("Reason:", err)
-		}
+		displayError(err, commandStart)
 	},
 }
 
@@ -54,9 +54,7 @@ var stopCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		//If no args, display usage
 		if len(args) < 1 {
-			if err := cmd.Usage(); err != nil {
-				fmt.Println(err)
-			}
+			displayError(cmd.Usage(), commandStop)
 			return
 		}
 		idStatus, _ := cmd.Flags().GetBool("id")
@@ -65,10 +63,7 @@ var stopCmd = &cobra.Command{
 			action = ad.StopAnomalyDetectorByID
 		}
 		err := execute(action, args)
-		if err != nil {
-			fmt.Println(commandStop, "command failed")
-			fmt.Println("Reason:", err)
-		}
+		displayError(err, commandStop)
 	},
 }
 


### PR DESCRIPTION
Download configuration as files helps users to save it in source code control and maintains it.
This will also let users to share detector configuration across users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
