### PR TITLE
add anomaly feature attribution to model output

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -226,7 +226,7 @@ public class ModelManager {
                 double confidence = rcfResults.stream().mapToDouble(r -> r.getConfidence() * r.getForestSize()).sum() / Math
                     .max(rcfNumTrees, totalForestSize);
                 double[] attribution = combineAttribution(rcfResults, numFeatures, totalForestSize);
-                combinedResult = new CombinedRcfResult(score, confidence, combineAttribution(rcfResults, numFeatures, totalForestSize));
+                combinedResult = new CombinedRcfResult(score, confidence, attribution);
             }
         }
         return combinedResult;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -53,6 +53,7 @@ import com.amazon.opendistroforelasticsearch.ad.ml.rcf.CombinedRcfResult;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import com.amazon.randomcutforest.RandomCutForest;
+import com.amazon.randomcutforest.returntypes.DiVector;
 import com.amazon.randomcutforest.serialize.RandomCutForestSerDe;
 import com.google.gson.Gson;
 
@@ -206,26 +207,46 @@ public class ModelManager {
      *
      * Final RCF score is calculated by averaging scores weighted by model size (number of trees).
      * Confidence is the weighted average of confidence with confidence for missing models being 0.
+     * Attribution is normalized weighted average for the most recent feature dimensions.
      *
      * @param rcfResults RCF results from partitioned models
+     * @param numFeatures number of features for attribution
      * @return combined RCF result
      */
-    public CombinedRcfResult combineRcfResults(List<RcfResult> rcfResults) {
+    public CombinedRcfResult combineRcfResults(List<RcfResult> rcfResults, int numFeatures) {
         CombinedRcfResult combinedResult = null;
         if (rcfResults.isEmpty()) {
-            combinedResult = new CombinedRcfResult(0, 0);
+            combinedResult = new CombinedRcfResult(0, 0, new double[0]);
         } else {
             int totalForestSize = rcfResults.stream().mapToInt(RcfResult::getForestSize).sum();
             if (totalForestSize == 0) {
-                combinedResult = new CombinedRcfResult(0, 0);
+                combinedResult = new CombinedRcfResult(0, 0, new double[0]);
             } else {
                 double score = rcfResults.stream().mapToDouble(r -> r.getScore() * r.getForestSize()).sum() / totalForestSize;
                 double confidence = rcfResults.stream().mapToDouble(r -> r.getConfidence() * r.getForestSize()).sum() / Math
                     .max(rcfNumTrees, totalForestSize);
-                combinedResult = new CombinedRcfResult(score, confidence);
+                double[] attribution = combineAttribution(rcfResults, numFeatures, totalForestSize);
+                combinedResult = new CombinedRcfResult(score, confidence, combineAttribution(rcfResults, numFeatures, totalForestSize));
             }
         }
         return combinedResult;
+    }
+
+    private double[] combineAttribution(List<RcfResult> rcfResults, int numFeatures, int totalForestSize) {
+        double[] combined = new double[numFeatures];
+        double sum = 0;
+        for (RcfResult result : rcfResults) {
+            double[] attribution = result.getAttribution();
+            for (int i = 0; i < numFeatures; i++) {
+                double attr = attribution[attribution.length - numFeatures + i] * result.getForestSize() / totalForestSize;
+                combined[i] += attr;
+                sum += attr;
+            }
+        }
+        for (int i = 0; i < numFeatures; i++) {
+            combined[i] /= sum;
+        }
+        return combined;
     }
 
     /**
@@ -349,13 +370,25 @@ public class ModelManager {
     }
 
     private void getRcfResult(ModelState<RandomCutForest> modelState, double[] point, ActionListener<RcfResult> listener) {
+        modelState.setLastUsedTime(clock.instant());
+
         RandomCutForest rcf = modelState.getModel();
         double score = rcf.getAnomalyScore(point);
         double confidence = computeRcfConfidence(rcf);
         int forestSize = rcf.getNumberOfTrees();
+        double[] attribution = getAnomalyAttribution(rcf, point);
         rcf.update(point);
-        modelState.setLastUsedTime(clock.instant());
-        listener.onResponse(new RcfResult(score, confidence, forestSize));
+        listener.onResponse(new RcfResult(score, confidence, forestSize, attribution));
+    }
+
+    private double[] getAnomalyAttribution(RandomCutForest rcf, double[] point) {
+        DiVector vec = rcf.getAnomalyAttribution(point);
+        vec.renormalize(1d);
+        double[] attribution = new double[vec.getDimensions()];
+        for (int i = 0; i < attribution.length; i++) {
+            attribution[i] = vec.getHighLowSum(i);
+        }
+        return attribution;
     }
 
     private Optional<ModelState<RandomCutForest>> restoreCheckpoint(Optional<String> rcfCheckpoint, String modelId, String detectorId) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/RcfResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/RcfResult.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.ml;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -25,6 +26,7 @@ public class RcfResult {
     private final double score;
     private final double confidence;
     private final int forestSize;
+    private final double[] attribution;
 
     /**
      * Constructor with all arguments.
@@ -32,11 +34,13 @@ public class RcfResult {
      * @param score RCF score
      * @param confidence RCF confidence
      * @param forestSize number of RCF trees used for the score
+     * @param attribution anomaly score attribution
      */
-    public RcfResult(double score, double confidence, int forestSize) {
+    public RcfResult(double score, double confidence, int forestSize, double[] attribution) {
         this.score = score;
         this.confidence = confidence;
         this.forestSize = forestSize;
+        this.attribution = attribution;
     }
 
     /**
@@ -66,6 +70,15 @@ public class RcfResult {
         return forestSize;
     }
 
+    /**
+     * Returns anomaly score attribution.
+     *
+     * @return anomaly score attribution
+     */
+    public double[] getAttribution() {
+        return attribution;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -75,11 +88,12 @@ public class RcfResult {
         RcfResult that = (RcfResult) o;
         return Objects.equals(this.score, that.score)
             && Objects.equals(this.confidence, that.confidence)
-            && Objects.equals(this.forestSize, that.forestSize);
+            && Objects.equals(this.forestSize, that.forestSize)
+            && Arrays.equals(this.attribution, that.attribution);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(score, confidence, forestSize);
+        return Objects.hash(score, confidence, forestSize, attribution);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/rcf/CombinedRcfResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/rcf/CombinedRcfResult.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.ml.rcf;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -24,16 +25,19 @@ public class CombinedRcfResult {
 
     private final double score;
     private final double confidence;
+    private final double[] attribution;
 
     /**
      * Constructor with all arguments.
      *
      * @param score combined RCF score
      * @param confidence confidence of the score
+     * @param attribution score attribution normalized to 1
      */
-    public CombinedRcfResult(double score, double confidence) {
+    public CombinedRcfResult(double score, double confidence, double[] attribution) {
         this.score = score;
         this.confidence = confidence;
+        this.attribution = attribution;
     }
 
     /**
@@ -54,6 +58,15 @@ public class CombinedRcfResult {
         return confidence;
     }
 
+    /**
+     * Return score attribution normalized to 1.
+     *
+     * @return score attribution normalized to 1
+     */
+    public double[] getAttribution() {
+        return attribution;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -61,11 +74,13 @@ public class CombinedRcfResult {
         if (o == null || getClass() != o.getClass())
             return false;
         CombinedRcfResult that = (CombinedRcfResult) o;
-        return Objects.equals(this.score, that.score) && Objects.equals(this.confidence, that.confidence);
+        return Objects.equals(this.score, that.score)
+            && Objects.equals(this.confidence, that.confidence)
+            && Arrays.equals(this.attribution, that.attribution);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(score, confidence);
+        return Objects.hash(score, confidence, attribution);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/RCFResultResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/RCFResultResponse.java
@@ -27,14 +27,17 @@ public class RCFResultResponse extends ActionResponse implements ToXContentObjec
     public static final String RCF_SCORE_JSON_KEY = "rcfScore";
     public static final String CONFIDENCE_JSON_KEY = "confidence";
     public static final String FOREST_SIZE_JSON_KEY = "forestSize";
+    public static final String ATTRIBUTION_JSON_KEY = "attribution";
     private double rcfScore;
     private double confidence;
     private int forestSize;
+    private double[] attribution;
 
-    public RCFResultResponse(double rcfScore, double confidence, int forestSize) {
+    public RCFResultResponse(double rcfScore, double confidence, int forestSize, double[] attribution) {
         this.rcfScore = rcfScore;
         this.confidence = confidence;
         this.forestSize = forestSize;
+        this.attribution = attribution;
     }
 
     public RCFResultResponse(StreamInput in) throws IOException {
@@ -42,6 +45,7 @@ public class RCFResultResponse extends ActionResponse implements ToXContentObjec
         rcfScore = in.readDouble();
         confidence = in.readDouble();
         forestSize = in.readVInt();
+        attribution = in.readDoubleArray();
     }
 
     public double getRCFScore() {
@@ -56,11 +60,21 @@ public class RCFResultResponse extends ActionResponse implements ToXContentObjec
         return forestSize;
     }
 
+    /**
+     * Returns RCF score attribution.
+     *
+     * @return RCF score attribution.
+     */
+    public double[] getAttribution() {
+        return attribution;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeDouble(rcfScore);
         out.writeDouble(confidence);
         out.writeVInt(forestSize);
+        out.writeDoubleArray(attribution);
     }
 
     @Override
@@ -69,6 +83,7 @@ public class RCFResultResponse extends ActionResponse implements ToXContentObjec
         builder.field(RCF_SCORE_JSON_KEY, rcfScore);
         builder.field(CONFIDENCE_JSON_KEY, confidence);
         builder.field(FOREST_SIZE_JSON_KEY, forestSize);
+        builder.field(ATTRIBUTION_JSON_KEY, attribution);
         builder.endObject();
         return builder;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/RCFResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/RCFResultTransportAction.java
@@ -65,7 +65,14 @@ public class RCFResultTransportAction extends HandledTransportAction<RCFResultRe
                     ActionListener
                         .wrap(
                             result -> listener
-                                .onResponse(new RCFResultResponse(result.getScore(), result.getConfidence(), result.getForestSize())),
+                                .onResponse(
+                                    new RCFResultResponse(
+                                        result.getScore(),
+                                        result.getConfidence(),
+                                        result.getForestSize(),
+                                        result.getAttribution()
+                                    )
+                                ),
                             exception -> {
                                 LOG.warn(exception);
                                 listener.onFailure(exception);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/RcfResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/RcfResultTests.java
@@ -16,6 +16,9 @@
 package com.amazon.opendistroforelasticsearch.ad.ml;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -29,12 +32,14 @@ public class RcfResultTests {
     private double score = 1.;
     private double confidence = 0;
     private int forestSize = 10;
-    private RcfResult rcfResult = new RcfResult(score, confidence, forestSize);
+    private double[] attribution = new double[] { 1. };
+    private RcfResult rcfResult = new RcfResult(score, confidence, forestSize, attribution);
 
     @Test
     public void getters_returnExcepted() {
         assertEquals(score, rcfResult.getScore(), 1e-8);
         assertEquals(forestSize, rcfResult.getForestSize());
+        assertTrue(Arrays.equals(attribution, rcfResult.getAttribution()));
     }
 
     private Object[] equalsData() {
@@ -42,11 +47,12 @@ public class RcfResultTests {
             new Object[] { rcfResult, null, false },
             new Object[] { rcfResult, rcfResult, true },
             new Object[] { rcfResult, 1, false },
-            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize), true },
-            new Object[] { rcfResult, new RcfResult(score + 1, confidence, forestSize), false },
-            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize + 1), false },
-            new Object[] { rcfResult, new RcfResult(score + 1, confidence, forestSize + 1), false },
-            new Object[] { rcfResult, new RcfResult(score, confidence + 1, forestSize), false }, };
+            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize, attribution), true },
+            new Object[] { rcfResult, new RcfResult(score + 1, confidence, forestSize, attribution), false },
+            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize + 1, attribution), false },
+            new Object[] { rcfResult, new RcfResult(score + 1, confidence, forestSize + 1, attribution), false },
+            new Object[] { rcfResult, new RcfResult(score, confidence + 1, forestSize, attribution), false },
+            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize, new double[] { 2. }), false }, };
     }
 
     @Test
@@ -57,10 +63,11 @@ public class RcfResultTests {
 
     private Object[] hashCodeData() {
         return new Object[] {
-            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize), true },
-            new Object[] { rcfResult, new RcfResult(score + 1, confidence, forestSize), false },
-            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize + 1), false },
-            new Object[] { rcfResult, new RcfResult(score + 1, confidence, forestSize + 1), false }, };
+            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize, attribution), true },
+            new Object[] { rcfResult, new RcfResult(score + 1, confidence, forestSize, attribution), false },
+            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize + 1, attribution), false },
+            new Object[] { rcfResult, new RcfResult(score + 1, confidence, forestSize + 1, attribution), false },
+            new Object[] { rcfResult, new RcfResult(score, confidence, forestSize, new double[] { 2. }), false }, };
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/rcf/CombinedRcfResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/rcf/CombinedRcfResultTests.java
@@ -16,6 +16,9 @@
 package com.amazon.opendistroforelasticsearch.ad.ml.rcf;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -28,12 +31,14 @@ public class CombinedRcfResultTests {
 
     private double score = 1.;
     private double confidence = .5;
-    private CombinedRcfResult rcfResult = new CombinedRcfResult(score, confidence);
+    private double[] attribution = new double[] { 1. };
+    private CombinedRcfResult rcfResult = new CombinedRcfResult(score, confidence, attribution);
 
     @Test
     public void getters_returnExcepted() {
         assertEquals(score, rcfResult.getScore(), 1e-8);
         assertEquals(confidence, rcfResult.getConfidence(), 1e-8);
+        assertTrue(Arrays.equals(attribution, rcfResult.getAttribution()));
     }
 
     private Object[] equalsData() {
@@ -41,10 +46,11 @@ public class CombinedRcfResultTests {
             new Object[] { rcfResult, null, false },
             new Object[] { rcfResult, rcfResult, true },
             new Object[] { rcfResult, 1, false },
-            new Object[] { rcfResult, new CombinedRcfResult(score, confidence), true },
-            new Object[] { rcfResult, new CombinedRcfResult(score + 1, confidence), false },
-            new Object[] { rcfResult, new CombinedRcfResult(score, confidence + 1), false },
-            new Object[] { rcfResult, new CombinedRcfResult(score + 1, confidence + 1), false }, };
+            new Object[] { rcfResult, new CombinedRcfResult(score, confidence, attribution), true },
+            new Object[] { rcfResult, new CombinedRcfResult(score + 1, confidence, attribution), false },
+            new Object[] { rcfResult, new CombinedRcfResult(score, confidence + 1, attribution), false },
+            new Object[] { rcfResult, new CombinedRcfResult(score + 1, confidence + 1, attribution), false },
+            new Object[] { rcfResult, new CombinedRcfResult(score, confidence, new double[] { 0. }), false }, };
     }
 
     @Test
@@ -55,10 +61,11 @@ public class CombinedRcfResultTests {
 
     private Object[] hashCodeData() {
         return new Object[] {
-            new Object[] { rcfResult, new CombinedRcfResult(score, confidence), true },
-            new Object[] { rcfResult, new CombinedRcfResult(score + 1, confidence), false },
-            new Object[] { rcfResult, new CombinedRcfResult(score, confidence + 1), false },
-            new Object[] { rcfResult, new CombinedRcfResult(score + 1, confidence + 1), false }, };
+            new Object[] { rcfResult, new CombinedRcfResult(score, confidence, attribution), true },
+            new Object[] { rcfResult, new CombinedRcfResult(score + 1, confidence, attribution), false },
+            new Object[] { rcfResult, new CombinedRcfResult(score, confidence + 1, attribution), false },
+            new Object[] { rcfResult, new CombinedRcfResult(score + 1, confidence + 1, attribution), false },
+            new Object[] { rcfResult, new CombinedRcfResult(score, confidence, new double[] { 0. }), false }, };
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
@@ -218,10 +218,10 @@ public class AnomalyResultTests extends AbstractADTest {
 
         doAnswer(invocation -> {
             ActionListener<RcfResult> listener = invocation.getArgument(3);
-            listener.onResponse(new RcfResult(0.2, 0, 100));
+            listener.onResponse(new RcfResult(0.2, 0, 100, new double[] { 1 }));
             return null;
         }).when(normalModelManager).getRcfResult(any(String.class), any(String.class), any(double[].class), any(ActionListener.class));
-        when(normalModelManager.combineRcfResults(any())).thenReturn(new CombinedRcfResult(0, 1.0d));
+        when(normalModelManager.combineRcfResults(any(), anyInt())).thenReturn(new CombinedRcfResult(0, 1.0d, new double[] { 1 }));
 
         rcfModelID = "123-rcf-1";
         when(normalModelManager.getRcfModelId(any(String.class), anyInt())).thenReturn(rcfModelID);
@@ -564,7 +564,7 @@ public class AnomalyResultTests extends AbstractADTest {
             @Override
             @SuppressWarnings("unchecked")
             public void handleResponse(T response) {
-                handler.handleResponse((T) new RCFResultResponse(1, 1, 100));
+                handler.handleResponse((T) new RCFResultResponse(1, 1, 100, new double[0]));
             }
 
             @Override
@@ -992,7 +992,7 @@ public class AnomalyResultTests extends AbstractADTest {
             threadPool
         );
         AnomalyResultTransportAction.RCFActionListener listener = action.new RCFActionListener(
-            null, null, null, null, null, null, null, null, null, 0, new AtomicInteger(), null
+            null, null, null, null, null, null, null, null, null, 0, new AtomicInteger(), null, 1
         );
         listener.onFailure(null);
     }
@@ -1341,7 +1341,7 @@ public class AnomalyResultTests extends AbstractADTest {
             threadPool
         );
         AnomalyResultTransportAction.RCFActionListener listener = action.new RCFActionListener(
-            null, "123-rcf-0", null, "123", null, null, null, null, null, 0, new AtomicInteger(), null
+            null, "123-rcf-0", null, "123", null, null, null, null, null, 0, new AtomicInteger(), null, 1
         );
         listener.onResponse(null);
         assertTrue(testAppender.containsMessage(AnomalyResultTransportAction.NULL_RESPONSE));


### PR DESCRIPTION
*Description of changes:* This pr adds normalized anomaly score attribution to anomaly detection model output. Anomaly score is attributed to each feature dimension of a current single data point and normalized to 1 for easier consumption. Further changes to external API and persistence is not included in this pr.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
