### PR TITLE
Adding RestActions support for AD Search Rest API's

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -113,6 +113,10 @@ import com.amazon.opendistroforelasticsearch.ad.transport.RCFPollingAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.RCFPollingTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.RCFResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.RCFResultTransportAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorTransportAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ThresholdResultAction;
@@ -460,7 +464,9 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ActionHandler<>(CronAction.INSTANCE, CronTransportAction.class),
                 new ActionHandler<>(ADStatsNodesAction.INSTANCE, ADStatsNodesTransportAction.class),
                 new ActionHandler<>(ProfileAction.INSTANCE, ProfileTransportAction.class),
-                new ActionHandler<>(RCFPollingAction.INSTANCE, RCFPollingTransportAction.class)
+                new ActionHandler<>(RCFPollingAction.INSTANCE, RCFPollingTransportAction.class),
+                new ActionHandler<>(SearchAnomalyDetectorAction.INSTANCE, SearchAnomalyDetectorTransportAction.class),
+                new ActionHandler<>(SearchAnomalyResultAction.INSTANCE, SearchAnomalyResultTransportAction.class)
             );
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestSearchAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestSearchAnomalyDetectorAction.java
@@ -19,6 +19,7 @@ import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANO
 
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorAction;
 
 /**
  * This class consists of the REST handler to search anomaly detectors.
@@ -29,7 +30,7 @@ public class RestSearchAnomalyDetectorAction extends AbstractSearchAction<Anomal
     private final String SEARCH_ANOMALY_DETECTOR_ACTION = "search_anomaly_detector";
 
     public RestSearchAnomalyDetectorAction() {
-        super(URL_PATH, ANOMALY_DETECTORS_INDEX, AnomalyDetector.class);
+        super(URL_PATH, ANOMALY_DETECTORS_INDEX, AnomalyDetector.class, SearchAnomalyDetectorAction.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestSearchAnomalyResultAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestSearchAnomalyResultAction.java
@@ -19,6 +19,8 @@ import static com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionI
 
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultAction;
+
 
 /**
  * This class consists of the REST handler to search anomaly results.
@@ -29,7 +31,7 @@ public class RestSearchAnomalyResultAction extends AbstractSearchAction<AnomalyR
     private final String SEARCH_ANOMALY_DETECTOR_ACTION = "search_anomaly_result";
 
     public RestSearchAnomalyResultAction() {
-        super(URL_PATH, ALL_AD_RESULTS_INDEX_PATTERN, AnomalyResult.class);
+        super(URL_PATH, ALL_AD_RESULTS_INDEX_PATTERN, AnomalyResult.class, SearchAnomalyResultAction.INSTANCE);
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestSearchAnomalyResultAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestSearchAnomalyResultAction.java
@@ -21,7 +21,6 @@ import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultAction;
 
-
 /**
  * This class consists of the REST handler to search anomaly results.
  */

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorAction.java
@@ -20,7 +20,7 @@ import org.elasticsearch.action.search.SearchResponse;
 
 public class SearchAnomalyDetectorAction extends ActionType<SearchResponse> {
     public static final SearchAnomalyDetectorAction INSTANCE = new SearchAnomalyDetectorAction();
-    public static final String NAME = "cluster:admin/ad/search/detector";
+    public static final String NAME = "cluster:admin/opendistro/ad/detector/search";
 
     private SearchAnomalyDetectorAction() {
         super(NAME, SearchResponse::new);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorAction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.search.SearchResponse;
+
+public class SearchAnomalyDetectorAction extends ActionType<SearchResponse> {
+    public static final SearchAnomalyDetectorAction INSTANCE = new SearchAnomalyDetectorAction();
+    public static final String NAME = "cluster:admin/ad/search/detector";
+
+    private SearchAnomalyDetectorAction() {
+        super(NAME, SearchResponse::new);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorTransportAction.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+
+public class SearchAnomalyDetectorTransportAction extends HandledTransportAction<SearchRequest, SearchResponse> {
+
+    private final Client client;
+
+    @Inject
+    public SearchAnomalyDetectorTransportAction(
+            TransportService transportService,
+            ActionFilters actionFilters,
+            Client client
+    ) {
+        super(SearchAnomalyDetectorAction.NAME, transportService, actionFilters, SearchRequest::new);
+        this.client = client;
+    }
+
+    @Override
+    protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
+        client.search(request, new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse searchResponse) {
+                listener.onResponse(searchResponse);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorTransportAction.java
@@ -25,17 +25,12 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
-
 public class SearchAnomalyDetectorTransportAction extends HandledTransportAction<SearchRequest, SearchResponse> {
 
     private final Client client;
 
     @Inject
-    public SearchAnomalyDetectorTransportAction(
-            TransportService transportService,
-            ActionFilters actionFilters,
-            Client client
-    ) {
+    public SearchAnomalyDetectorTransportAction(TransportService transportService, ActionFilters actionFilters, Client client) {
         super(SearchAnomalyDetectorAction.NAME, transportService, actionFilters, SearchRequest::new);
         this.client = client;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultAction.java
@@ -20,7 +20,7 @@ import org.elasticsearch.action.search.SearchResponse;
 
 public class SearchAnomalyResultAction extends ActionType<SearchResponse> {
     public static final SearchAnomalyResultAction INSTANCE = new SearchAnomalyResultAction();
-    public static final String NAME = "cluster:admin/ad/search/result";
+    public static final String NAME = "cluster:admin/opendistro/ad/result/search";
 
     private SearchAnomalyResultAction() {
         super(NAME, SearchResponse::new);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultAction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.search.SearchResponse;
+
+public class SearchAnomalyResultAction extends ActionType<SearchResponse> {
+    public static final SearchAnomalyResultAction INSTANCE = new SearchAnomalyResultAction();
+    public static final String NAME = "cluster:admin/ad/search/result";
+
+    private SearchAnomalyResultAction() {
+        super(NAME, SearchResponse::new);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultTransportAction.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+
+public class SearchAnomalyResultTransportAction extends HandledTransportAction<SearchRequest, SearchResponse> {
+
+    private final Client client;
+
+    @Inject
+    public SearchAnomalyResultTransportAction(
+            TransportService transportService,
+            ActionFilters actionFilters,
+            Client client
+    ) {
+        super(SearchAnomalyResultAction.NAME, transportService, actionFilters, SearchRequest::new);
+        this.client = client;
+    }
+
+    @Override
+    protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
+        client.search(request, new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse searchResponse) {
+                listener.onResponse(searchResponse);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultTransportAction.java
@@ -25,17 +25,12 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
-
 public class SearchAnomalyResultTransportAction extends HandledTransportAction<SearchRequest, SearchResponse> {
 
     private final Client client;
 
     @Inject
-    public SearchAnomalyResultTransportAction(
-            TransportService transportService,
-            ActionFilters actionFilters,
-            Client client
-    ) {
+    public SearchAnomalyResultTransportAction(TransportService transportService, ActionFilters actionFilters, Client client) {
         super(SearchAnomalyResultAction.NAME, transportService, actionFilters, SearchRequest::new);
         this.client = client;
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorActionTests.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.apache.lucene.index.IndexNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class SearchAnomalyDetectorActionTests extends ESIntegTestCase {
+    private SearchAnomalyDetectorTransportAction action;
+    private Task task;
+    private ActionListener<SearchResponse> response;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        action = new SearchAnomalyDetectorTransportAction(
+                mock(TransportService.class),
+                mock(ActionFilters.class),
+                client()
+        );
+        task = mock(Task.class);
+        response = new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse searchResponse) {
+                Assert.assertEquals(searchResponse.getSuccessfulShards(), 5);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Assert.assertFalse(IndexNotFoundException.class == e.getClass());
+            }
+        };
+    }
+
+    @Test
+    public void testSearchResponse() {
+        // Will call response.onResponse as Index exists
+        Settings indexSettings = Settings.builder()
+                .put("number_of_shards", 5)
+                .put("number_of_replicas", 1)
+                .build();
+        CreateIndexRequest indexRequest = new CreateIndexRequest("my-test-index", indexSettings);
+        client().admin().indices().create(indexRequest).actionGet();
+        SearchRequest searchRequest = new SearchRequest("my-test-index");
+        action.doExecute(task, searchRequest, response);
+    }
+
+    @Test
+    public void testSearchDetectorAction() {
+        Assert.assertNotNull(SearchAnomalyDetectorAction.INSTANCE.name());
+        Assert.assertEquals(SearchAnomalyDetectorAction.INSTANCE.name(), SearchAnomalyDetectorAction.NAME);
+    }
+
+    @Test
+    public void testNoIndex() {
+        // No Index, will call response.onFailure
+        SearchRequest searchRequest = new SearchRequest("my-test-index");
+        action.doExecute(task, searchRequest, response);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorActionTests.java
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 public class SearchAnomalyDetectorActionTests extends ESIntegTestCase {
     private SearchAnomalyDetectorTransportAction action;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorActionTests.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static org.mockito.Mockito.mock;
+
 import org.apache.lucene.index.IndexNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -29,8 +31,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.mock;
-
 public class SearchAnomalyDetectorActionTests extends ESIntegTestCase {
     private SearchAnomalyDetectorTransportAction action;
     private Task task;
@@ -41,11 +41,7 @@ public class SearchAnomalyDetectorActionTests extends ESIntegTestCase {
     public void setUp() throws Exception {
         super.setUp();
 
-        action = new SearchAnomalyDetectorTransportAction(
-                mock(TransportService.class),
-                mock(ActionFilters.class),
-                client()
-        );
+        action = new SearchAnomalyDetectorTransportAction(mock(TransportService.class), mock(ActionFilters.class), client());
         task = mock(Task.class);
         response = new ActionListener<SearchResponse>() {
             @Override
@@ -63,10 +59,7 @@ public class SearchAnomalyDetectorActionTests extends ESIntegTestCase {
     @Test
     public void testSearchResponse() {
         // Will call response.onResponse as Index exists
-        Settings indexSettings = Settings.builder()
-                .put("number_of_shards", 5)
-                .put("number_of_replicas", 1)
-                .build();
+        Settings indexSettings = Settings.builder().put("number_of_shards", 5).put("number_of_replicas", 1).build();
         CreateIndexRequest indexRequest = new CreateIndexRequest("my-test-index", indexSettings);
         client().admin().indices().create(indexRequest).actionGet();
         SearchRequest searchRequest = new SearchRequest("my-test-index");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
 
 public class SearchAnomalyResultActionTests extends ESIntegTestCase {
     private SearchAnomalyResultTransportAction action;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.apache.lucene.index.IndexNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class SearchAnomalyResultActionTests extends ESIntegTestCase {
+    private SearchAnomalyResultTransportAction action;
+    private Task task;
+    private ActionListener<SearchResponse> response;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        action = new SearchAnomalyResultTransportAction(
+                mock(TransportService.class),
+                mock(ActionFilters.class),
+                client()
+        );
+        task = mock(Task.class);
+        response = new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse searchResponse) {
+                Assert.assertEquals(searchResponse.getSuccessfulShards(), 5);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Assert.assertFalse(IndexNotFoundException.class == e.getClass());
+            }
+        };
+    }
+
+    @Test
+    public void testSearchResponse() {
+        // Will call response.onResponse as Index exists
+        Settings indexSettings = Settings.builder()
+                .put("number_of_shards", 5)
+                .put("number_of_replicas", 1)
+                .build();
+        CreateIndexRequest indexRequest = new CreateIndexRequest("my-test-index", indexSettings);
+        client().admin().indices().create(indexRequest).actionGet();
+        SearchRequest searchRequest = new SearchRequest("my-test-index");
+        action.doExecute(task, searchRequest, response);
+    }
+
+    @Test
+    public void testSearchResultAction() {
+        Assert.assertNotNull(SearchAnomalyDetectorAction.INSTANCE.name());
+        Assert.assertEquals(SearchAnomalyDetectorAction.INSTANCE.name(), SearchAnomalyDetectorAction.NAME);
+    }
+
+    @Test
+    public void testNoIndex() {
+        // No Index, will call response.onFailure
+        SearchRequest searchRequest = new SearchRequest("my-test-index");
+        action.doExecute(task, searchRequest, response);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -74,8 +74,8 @@ public class SearchAnomalyResultActionTests extends ESIntegTestCase {
 
     @Test
     public void testSearchResultAction() {
-        Assert.assertNotNull(SearchAnomalyDetectorAction.INSTANCE.name());
-        Assert.assertEquals(SearchAnomalyDetectorAction.INSTANCE.name(), SearchAnomalyDetectorAction.NAME);
+        Assert.assertNotNull(SearchAnomalyResultAction.INSTANCE.name());
+        Assert.assertEquals(SearchAnomalyResultAction.INSTANCE.name(), SearchAnomalyResultAction.NAME);
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static org.mockito.Mockito.mock;
+
 import org.apache.lucene.index.IndexNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -29,8 +31,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.Mockito.mock;
-
 public class SearchAnomalyResultActionTests extends ESIntegTestCase {
     private SearchAnomalyResultTransportAction action;
     private Task task;
@@ -40,11 +40,7 @@ public class SearchAnomalyResultActionTests extends ESIntegTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        action = new SearchAnomalyResultTransportAction(
-                mock(TransportService.class),
-                mock(ActionFilters.class),
-                client()
-        );
+        action = new SearchAnomalyResultTransportAction(mock(TransportService.class), mock(ActionFilters.class), client());
         task = mock(Task.class);
         response = new ActionListener<SearchResponse>() {
             @Override
@@ -62,10 +58,7 @@ public class SearchAnomalyResultActionTests extends ESIntegTestCase {
     @Test
     public void testSearchResponse() {
         // Will call response.onResponse as Index exists
-        Settings indexSettings = Settings.builder()
-                .put("number_of_shards", 5)
-                .put("number_of_replicas", 1)
-                .build();
+        Settings indexSettings = Settings.builder().put("number_of_shards", 5).put("number_of_replicas", 1).build();
         CreateIndexRequest indexRequest = new CreateIndexRequest("my-test-index", indexSettings);
         client().admin().indices().create(indexRequest).actionGet();
         SearchRequest searchRequest = new SearchRequest("my-test-index");


### PR DESCRIPTION
Adding RestActions support for Search Rest API's.

- This is needed to integrate with Security plugin as it applies permissions based on Rest Actions.
- This is the first of the API's and work in progress for other APIs. Tests will be added soon.
*Issue #195 *


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
