### PR TITLE
Adding RestActions support for Detector Stats API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,6 +249,7 @@ List<String> jacocoExclusions = [
         'com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorRunner',
         'com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices',
         'com.amazon.opendistroforelasticsearch.ad.util.ParseUtils',
+        'com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorTransportAction'
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -29,8 +29,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorAction;
-import com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorTransportAction;
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -119,6 +117,8 @@ import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorA
 import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultTransportAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ThresholdResultAction;
@@ -223,10 +223,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             clusterService,
             anomalyDetectorRunner
         );
-        RestStatsAnomalyDetectorAction statsAnomalyDetectorAction = new RestStatsAnomalyDetectorAction(
-            adStats,
-            this.nodeFilter
-        );
+        RestStatsAnomalyDetectorAction statsAnomalyDetectorAction = new RestStatsAnomalyDetectorAction(adStats, this.nodeFilter);
         RestAnomalyDetectorJobAction anomalyDetectorJobAction = new RestAnomalyDetectorJobAction(
             settings,
             clusterService,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -29,6 +29,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorTransportAction;
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -223,8 +225,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         );
         RestStatsAnomalyDetectorAction statsAnomalyDetectorAction = new RestStatsAnomalyDetectorAction(
             adStats,
-            this.nodeFilter,
-            this.clusterService
+            this.nodeFilter
         );
         RestAnomalyDetectorJobAction anomalyDetectorJobAction = new RestAnomalyDetectorJobAction(
             settings,
@@ -466,7 +467,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ActionHandler<>(ProfileAction.INSTANCE, ProfileTransportAction.class),
                 new ActionHandler<>(RCFPollingAction.INSTANCE, RCFPollingTransportAction.class),
                 new ActionHandler<>(SearchAnomalyDetectorAction.INSTANCE, SearchAnomalyDetectorTransportAction.class),
-                new ActionHandler<>(SearchAnomalyResultAction.INSTANCE, SearchAnomalyResultTransportAction.class)
+                new ActionHandler<>(SearchAnomalyResultAction.INSTANCE, SearchAnomalyResultTransportAction.class),
+                new ActionHandler<>(StatsAnomalyDetectorAction.INSTANCE, StatsAnomalyDetectorTransportAction.class)
             );
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestStatsAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestStatsAnomalyDetectorAction.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorAction;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Client;
@@ -49,6 +50,7 @@ import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsRequest;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import com.amazon.opendistroforelasticsearch.ad.util.MultiResponsesDelegateActionListener;
 import com.google.common.collect.ImmutableList;
+import org.elasticsearch.rest.action.RestToXContentListener;
 
 /**
  * RestStatsAnomalyDetectorAction consists of the REST handler to get the stats from the anomaly detector plugin.
@@ -65,12 +67,10 @@ public class RestStatsAnomalyDetectorAction extends BaseRestHandler {
      *
      * @param adStats ADStats object
      * @param nodeFilter util class to get eligible data nodes
-     * @param clusterService ClusterService
      */
-    public RestStatsAnomalyDetectorAction(ADStats adStats, DiscoveryNodeFilterer nodeFilter, ClusterService clusterService) {
+    public RestStatsAnomalyDetectorAction(ADStats adStats, DiscoveryNodeFilterer nodeFilter) {
         this.adStats = adStats;
         this.nodeFilter = nodeFilter;
-        this.clusterService = clusterService;
     }
 
     @Override
@@ -84,7 +84,7 @@ public class RestStatsAnomalyDetectorAction extends BaseRestHandler {
             throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
         }
         ADStatsRequest adStatsRequest = getRequest(request);
-        return channel -> getStats(client, channel, adStatsRequest);
+        return channel -> client.execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest, new RestToXContentListener<>(channel));
     }
 
     /**
@@ -141,115 +141,6 @@ public class RestStatsAnomalyDetectorAction extends BaseRestHandler {
         return adStatsRequest;
     }
 
-    /**
-     * Make the 2 requests to get the node and cluster statistics
-     *
-     * @param client Client
-     * @param channel Channel to send response
-     * @param adStatsRequest Request containing stats to be retrieved
-     */
-    private void getStats(Client client, RestChannel channel, ADStatsRequest adStatsRequest) {
-        // Use MultiResponsesDelegateActionListener to execute 2 async requests and create the response once they finish
-        MultiResponsesDelegateActionListener<ADStatsResponse> delegateListener = new MultiResponsesDelegateActionListener<>(
-            getRestStatsListener(channel),
-            2,
-            "Unable to return AD Stats"
-        );
-
-        getClusterStats(client, delegateListener, adStatsRequest);
-        getNodeStats(client, delegateListener, adStatsRequest);
-    }
-
-    /**
-     * Make async request to get the number of detectors in AnomalyDetector.ANOMALY_DETECTORS_INDEX if necessary
-     * and, onResponse, gather the cluster statistics
-     *
-     * @param client Client
-     * @param listener MultiResponsesDelegateActionListener to be used once both requests complete
-     * @param adStatsRequest Request containing stats to be retrieved
-     */
-    private void getClusterStats(
-        Client client,
-        MultiResponsesDelegateActionListener<ADStatsResponse> listener,
-        ADStatsRequest adStatsRequest
-    ) {
-        ADStatsResponse adStatsResponse = new ADStatsResponse();
-        if (adStatsRequest.getStatsToBeRetrieved().contains(StatNames.DETECTOR_COUNT.getName())) {
-            if (clusterService.state().getRoutingTable().hasIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
-                final SearchRequest request = client
-                    .prepareSearch(AnomalyDetector.ANOMALY_DETECTORS_INDEX)
-                    .setSize(0)
-                    .setTrackTotalHits(true)
-                    .request();
-                client.search(request, ActionListener.wrap(indicesStatsResponse -> {
-                    adStats.getStat(StatNames.DETECTOR_COUNT.getName()).setValue(indicesStatsResponse.getHits().getTotalHits().value);
-                    adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
-                    listener.onResponse(adStatsResponse);
-                }, e -> listener.onFailure(new RuntimeException("Failed to get AD cluster stats", e))));
-            } else {
-                adStats.getStat(StatNames.DETECTOR_COUNT.getName()).setValue(0L);
-                adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
-                listener.onResponse(adStatsResponse);
-            }
-        } else {
-            adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
-            listener.onResponse(adStatsResponse);
-        }
-    }
-
-    /**
-     * Make async request to get the Anomaly Detection statistics from each node and, onResponse, set the
-     * ADStatsNodesResponse field of ADStatsResponse
-     *
-     * @param client Client
-     * @param listener MultiResponsesDelegateActionListener to be used once both requests complete
-     * @param adStatsRequest Request containing stats to be retrieved
-     */
-    private void getNodeStats(
-        Client client,
-        MultiResponsesDelegateActionListener<ADStatsResponse> listener,
-        ADStatsRequest adStatsRequest
-    ) {
-        client.execute(ADStatsNodesAction.INSTANCE, adStatsRequest, ActionListener.wrap(adStatsResponse -> {
-            ADStatsResponse restADStatsResponse = new ADStatsResponse();
-            restADStatsResponse.setADStatsNodesResponse(adStatsResponse);
-            listener.onResponse(restADStatsResponse);
-        }, listener::onFailure));
-    }
-
-    /**
-     * Collect Cluster Stats into map to be retrieved
-     *
-     * @param adStatsRequest Request containing stats to be retrieved
-     * @return Map containing Cluster Stats
-     */
-    private Map<String, Object> getClusterStatsMap(ADStatsRequest adStatsRequest) {
-        Map<String, Object> clusterStats = new HashMap<>();
-        Set<String> statsToBeRetrieved = adStatsRequest.getStatsToBeRetrieved();
-        adStats
-            .getClusterStats()
-            .entrySet()
-            .stream()
-            .filter(s -> statsToBeRetrieved.contains(s.getKey()))
-            .forEach(s -> clusterStats.put(s.getKey(), s.getValue().getValue()));
-        return clusterStats;
-    }
-
-    /**
-     * Listener sends response once Node Stats and Cluster Stats are gathered
-     *
-     * @param channel Channel
-     * @return ActionListener for ADStatsResponse
-     */
-    private ActionListener<ADStatsResponse> getRestStatsListener(RestChannel channel) {
-        return ActionListener
-            .wrap(
-                adStatsResponse -> {
-                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, adStatsResponse.toXContent(channel.newBuilder())));
-                },
-                exception -> channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, exception.getMessage()))
-            );
-    }
 
     @Override
     public List<Route> routes() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestStatsAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestStatsAnomalyDetectorAction.java
@@ -18,39 +18,26 @@ package com.amazon.opendistroforelasticsearch.ad.rest;
 import static com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin.AD_BASE_URI;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorAction;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.client.Client;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.BytesRestResponse;
-import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestToXContentListener;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
-import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.settings.EnabledSetting;
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStats;
-import com.amazon.opendistroforelasticsearch.ad.stats.ADStatsResponse;
-import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
-import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsNodesAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsRequest;
+import com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorAction;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
-import com.amazon.opendistroforelasticsearch.ad.util.MultiResponsesDelegateActionListener;
 import com.google.common.collect.ImmutableList;
-import org.elasticsearch.rest.action.RestToXContentListener;
 
 /**
  * RestStatsAnomalyDetectorAction consists of the REST handler to get the stats from the anomaly detector plugin.
@@ -140,7 +127,6 @@ public class RestStatsAnomalyDetectorAction extends BaseRestHandler {
         }
         return adStatsRequest;
     }
-
 
     @Override
     public List<Route> routes() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/ADStatsResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/ADStatsResponse.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -80,6 +82,18 @@ public class ADStatsResponse implements ToXContentObject, Mergeable {
      */
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
         return toXContent(builder, ToXContent.EMPTY_PARAMS);
+    }
+
+    public ADStatsResponse() {}
+
+    public ADStatsResponse(StreamInput in) throws IOException {
+        adStatsNodesResponse = new ADStatsNodesResponse(in);
+        clusterStats = in.readMap();
+    }
+
+    public void writeTo(StreamOutput out) throws IOException {
+        adStatsNodesResponse.writeTo(out);
+        out.writeMap(clusterStats);
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorAction.java
@@ -20,7 +20,7 @@ import org.elasticsearch.action.search.SearchResponse;
 
 public class SearchAnomalyDetectorAction extends ActionType<SearchResponse> {
     public static final SearchAnomalyDetectorAction INSTANCE = new SearchAnomalyDetectorAction();
-    public static final String NAME = "cluster:admin/ad/search/detector";
+    public static final String NAME = "cluster:admin/opendistro/ad/detector/search";
 
     private SearchAnomalyDetectorAction() {
         super(NAME, SearchResponse::new);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorAction.java
@@ -16,13 +16,13 @@
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.search.SearchResponse;
 
-public class SearchAnomalyDetectorAction extends ActionType<SearchResponse> {
-    public static final SearchAnomalyDetectorAction INSTANCE = new SearchAnomalyDetectorAction();
-    public static final String NAME = "cluster:admin/ad/search/detector";
+public class StatsAnomalyDetectorAction extends ActionType<StatsAnomalyDetectorResponse> {
+    public static final StatsAnomalyDetectorAction INSTANCE = new StatsAnomalyDetectorAction();
+    public static final String NAME = "cluster:admin/opendistro/ad/detector/stats";
 
-    private SearchAnomalyDetectorAction() {
-        super(NAME, SearchResponse::new);
+    private StatsAnomalyDetectorAction() {
+        super(NAME, StatsAnomalyDetectorResponse::new);
     }
+
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorResponse.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.model.*;
+import com.amazon.opendistroforelasticsearch.ad.stats.ADStatsResponse;
+import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.rest.RestStatus;
+
+public class StatsAnomalyDetectorResponse extends ActionResponse implements ToXContentObject {
+    private ADStatsResponse adStatsResponse;
+
+    public StatsAnomalyDetectorResponse(StreamInput in) throws IOException {
+        super(in);
+        adStatsResponse = new ADStatsResponse(in);
+    }
+
+    public StatsAnomalyDetectorResponse(ADStatsResponse adStatsResponse) {
+        this.adStatsResponse = adStatsResponse;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        adStatsResponse.writeTo(out);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        adStatsResponse.toXContent(builder, params);
+        return builder;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorResponse.java
@@ -17,17 +17,13 @@ package com.amazon.opendistroforelasticsearch.ad.transport;
 
 import java.io.IOException;
 
-import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
-import com.amazon.opendistroforelasticsearch.ad.model.*;
-import com.amazon.opendistroforelasticsearch.ad.stats.ADStatsResponse;
-import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.rest.RestStatus;
+
+import com.amazon.opendistroforelasticsearch.ad.stats.ADStatsResponse;
 
 public class StatsAnomalyDetectorResponse extends ActionResponse implements ToXContentObject {
     private ADStatsResponse adStatsResponse;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportAction.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.stats.ADStats;
+import com.amazon.opendistroforelasticsearch.ad.stats.ADStatsResponse;
+import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
+import com.amazon.opendistroforelasticsearch.ad.util.MultiResponsesDelegateActionListener;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+
+public class StatsAnomalyDetectorTransportAction extends HandledTransportAction<ADStatsRequest, StatsAnomalyDetectorResponse> {
+
+    private final Client client;
+    private final ADStats adStats;
+    private final ClusterService clusterService;
+
+    @Inject
+    public StatsAnomalyDetectorTransportAction(
+            TransportService transportService,
+            ActionFilters actionFilters,
+            Client client,
+            ADStats adStats,
+            ClusterService clusterService
+
+    ) {
+        super(StatsAnomalyDetectorAction.NAME, transportService, actionFilters, ADStatsRequest::new);
+        this.client = client;
+        this.adStats = adStats;
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    protected void doExecute(Task task, ADStatsRequest request, ActionListener<StatsAnomalyDetectorResponse> listener) {
+        getStats(client, listener, request);
+    }
+
+    /**
+     * Make the 2 requests to get the node and cluster statistics
+     *
+     * @param client Client
+     * @param listener Listener to send response
+     * @param adStatsRequest Request containing stats to be retrieved
+     */
+    private void getStats(Client client, ActionListener<StatsAnomalyDetectorResponse> listener, ADStatsRequest adStatsRequest) {
+        // Use MultiResponsesDelegateActionListener to execute 2 async requests and create the response once they finish
+        MultiResponsesDelegateActionListener<ADStatsResponse> delegateListener = new MultiResponsesDelegateActionListener<>(
+                getRestStatsListener(listener),
+                2,
+                "Unable to return AD Stats"
+        );
+
+        getClusterStats(client, delegateListener, adStatsRequest);
+        getNodeStats(client, delegateListener, adStatsRequest);
+    }
+
+    /**
+     * Listener sends response once Node Stats and Cluster Stats are gathered
+     *
+     * @param listener Listener to send response
+     * @return ActionListener for ADStatsResponse
+     */
+    private ActionListener<ADStatsResponse> getRestStatsListener(ActionListener<StatsAnomalyDetectorResponse> listener) {
+        return ActionListener
+                .wrap(
+                        adStatsResponse -> {
+                            listener.onResponse(new StatsAnomalyDetectorResponse(adStatsResponse));
+                        },
+                        exception -> listener.onFailure(new ElasticsearchStatusException(exception.getMessage(), RestStatus.INTERNAL_SERVER_ERROR))
+                );
+    }
+
+    /**
+     * Make async request to get the number of detectors in AnomalyDetector.ANOMALY_DETECTORS_INDEX if necessary
+     * and, onResponse, gather the cluster statistics
+     *
+     * @param client Client
+     * @param listener MultiResponsesDelegateActionListener to be used once both requests complete
+     * @param adStatsRequest Request containing stats to be retrieved
+     */
+    private void getClusterStats(
+            Client client,
+            MultiResponsesDelegateActionListener<ADStatsResponse> listener,
+            ADStatsRequest adStatsRequest
+    ) {
+        ADStatsResponse adStatsResponse = new ADStatsResponse();
+        if (adStatsRequest.getStatsToBeRetrieved().contains(StatNames.DETECTOR_COUNT.getName())) {
+            if (clusterService.state().getRoutingTable().hasIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
+                final SearchRequest request = client
+                        .prepareSearch(AnomalyDetector.ANOMALY_DETECTORS_INDEX)
+                        .setSize(0)
+                        .setTrackTotalHits(true)
+                        .request();
+                client.search(request, ActionListener.wrap(indicesStatsResponse -> {
+                    adStats.getStat(StatNames.DETECTOR_COUNT.getName()).setValue(indicesStatsResponse.getHits().getTotalHits().value);
+                    adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
+                    listener.onResponse(adStatsResponse);
+                }, e -> listener.onFailure(new RuntimeException("Failed to get AD cluster stats", e))));
+            } else {
+                adStats.getStat(StatNames.DETECTOR_COUNT.getName()).setValue(0L);
+                adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
+                listener.onResponse(adStatsResponse);
+            }
+        } else {
+            adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
+            listener.onResponse(adStatsResponse);
+        }
+    }
+
+    /**
+     * Collect Cluster Stats into map to be retrieved
+     *
+     * @param adStatsRequest Request containing stats to be retrieved
+     * @return Map containing Cluster Stats
+     */
+    private Map<String, Object> getClusterStatsMap(ADStatsRequest adStatsRequest) {
+        Map<String, Object> clusterStats = new HashMap<>();
+        Set<String> statsToBeRetrieved = adStatsRequest.getStatsToBeRetrieved();
+        adStats
+                .getClusterStats()
+                .entrySet()
+                .stream()
+                .filter(s -> statsToBeRetrieved.contains(s.getKey()))
+                .forEach(s -> clusterStats.put(s.getKey(), s.getValue().getValue()));
+        return clusterStats;
+    }
+
+    /**
+     * Make async request to get the Anomaly Detection statistics from each node and, onResponse, set the
+     * ADStatsNodesResponse field of ADStatsResponse
+     *
+     * @param client Client
+     * @param listener MultiResponsesDelegateActionListener to be used once both requests complete
+     * @param adStatsRequest Request containing stats to be retrieved
+     */
+    private void getNodeStats(
+            Client client,
+            MultiResponsesDelegateActionListener<ADStatsResponse> listener,
+            ADStatsRequest adStatsRequest
+    ) {
+        client.execute(ADStatsNodesAction.INSTANCE, adStatsRequest, ActionListener.wrap(adStatsResponse -> {
+            ADStatsResponse restADStatsResponse = new ADStatsResponse();
+            restADStatsResponse.setADStatsNodesResponse(adStatsResponse);
+            listener.onResponse(restADStatsResponse);
+        }, listener::onFailure));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorActionTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.amazon.opendistroforelasticsearch.ad.stats.ADStatsResponse;
+
+public class StatsAnomalyDetectorActionTests extends ESTestCase {
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Test
+    public void testStatsAction() {
+        Assert.assertNotNull(StatsAnomalyDetectorAction.INSTANCE.name());
+        Assert.assertEquals(StatsAnomalyDetectorAction.INSTANCE.name(), StatsAnomalyDetectorAction.NAME);
+    }
+
+    @Test
+    public void testStatsResponse() throws IOException {
+        ADStatsResponse adStatsResponse = new ADStatsResponse();
+        Map<String, Object> testClusterStats = new HashMap<>();
+        testClusterStats.put("test_response", 1);
+        adStatsResponse.setClusterStats(testClusterStats);
+        List<ADStatsNodeResponse> responses = Collections.emptyList();
+        List<FailedNodeException> failures = Collections.emptyList();
+        ADStatsNodesResponse adStatsNodesResponse = new ADStatsNodesResponse(ClusterName.DEFAULT, responses, failures);
+        adStatsResponse.setADStatsNodesResponse(adStatsNodesResponse);
+
+        StatsAnomalyDetectorResponse response = new StatsAnomalyDetectorResponse(adStatsResponse);
+        BytesStreamOutput out = new BytesStreamOutput();
+        response.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        StatsAnomalyDetectorResponse newResponse = new StatsAnomalyDetectorResponse(input);
+        assertNotNull(newResponse);
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder = newResponse.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        XContentParser parser = createParser(builder);
+        assertEquals(1, parser.map().get("test_response"));
+    }
+}


### PR DESCRIPTION
*Issue #195 *

*Description of changes:*
Adding RestActions support Detector Stats API which is needed for FGAC support. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
