### PR TITLE
Selectively store anomaly results when index pressure is high

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -99,6 +99,8 @@ import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.CounterSupplier;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.IndexStatusSupplier;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.ModelsOnNodeSupplier;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.SettableSupplier;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADResultBulkAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADResultBulkTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsNodesAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsNodesTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobAction;
@@ -194,7 +196,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
             false,
@@ -354,7 +356,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             )
             .put(
                 StatNames.ANOMALY_RESULTS_INDEX_STATUS.getName(),
-                new ADStat<>(true, new IndexStatusSupplier(indexUtils, AnomalyResult.ANOMALY_RESULT_INDEX))
+                new ADStat<>(true, new IndexStatusSupplier(indexUtils, CommonName.ANOMALY_RESULT_INDEX_ALIAS))
             )
             .put(
                 StatNames.MODELS_CHECKPOINT_INDEX_STATUS.getName(),
@@ -436,7 +438,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 AnomalyDetectorSettings.BACKOFF_INITIAL_DELAY,
                 AnomalyDetectorSettings.MAX_RETRY_FOR_BACKOFF,
                 AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
-                AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE
+                AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE,
+                AnomalyDetectorSettings.INDEX_PRESSURE_SOFT_LIMIT
             );
         return unmodifiableList(Stream.concat(enabledSetting.stream(), systemSetting.stream()).collect(Collectors.toList()));
     }
@@ -474,7 +477,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ActionHandler<>(DeleteAnomalyDetectorAction.INSTANCE, DeleteAnomalyDetectorTransportAction.class),
                 new ActionHandler<>(GetAnomalyDetectorAction.INSTANCE, GetAnomalyDetectorTransportAction.class),
                 new ActionHandler<>(IndexAnomalyDetectorAction.INSTANCE, IndexAnomalyDetectorTransportAction.class),
-                new ActionHandler<>(AnomalyDetectorJobAction.INSTANCE, AnomalyDetectorJobTransportAction.class)
+                new ActionHandler<>(AnomalyDetectorJobAction.INSTANCE, AnomalyDetectorJobTransportAction.class),
+                new ActionHandler<>(ADResultBulkAction.INSTANCE, ADResultBulkTransportAction.class)
             );
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -93,6 +93,7 @@ public class FeatureManager {
      * @param maxPreviewSamples max number of samples from search for preview features
      * @param featureBufferTtl time to live for stale feature buffers
      * @param threadPool object through which we can invoke different threadpool using different names
+     * @param adThreadPoolName AD threadpool's name
      */
     public FeatureManager(
         SearchFeatureDao searchFeatureDao,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -161,7 +161,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         this.filterQuery = filterQuery;
         this.detectionInterval = detectionInterval;
         this.windowDelay = windowDelay;
-        this.shingleSize = shingleSize;
+        this.shingleSize = getShingleSize(shingleSize, categoryField);
         this.uiMetadata = uiMetadata;
         this.schemaVersion = schemaVersion;
         this.lastUpdateTime = lastUpdateTime;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -114,7 +114,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
      * @param uiMetadata        metadata used by Kibana
      * @param schemaVersion     anomaly detector index mapping version
      * @param lastUpdateTime    detector's last update time
-     * @param categoryField     a list of partition fields
+     * @param categoryFields     a list of partition fields
      */
     public AnomalyDetector(
         String detectorId,
@@ -161,7 +161,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         this.filterQuery = filterQuery;
         this.detectionInterval = detectionInterval;
         this.windowDelay = windowDelay;
-        this.shingleSize = getShingleSize(shingleSize, categoryField);
+        this.shingleSize = getShingleSize(shingleSize, categoryFields);
         this.uiMetadata = uiMetadata;
         this.schemaVersion = schemaVersion;
         this.lastUpdateTime = lastUpdateTime;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -131,7 +131,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         Map<String, Object> uiMetadata,
         Integer schemaVersion,
         Instant lastUpdateTime,
-        List<String> categoryField
+        List<String> categoryFields
     ) {
         if (Strings.isBlank(name)) {
             throw new IllegalArgumentException("Detector name should be set");
@@ -148,7 +148,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         if (shingleSize != null && shingleSize < 1) {
             throw new IllegalArgumentException("Shingle size must be a positive integer");
         }
-        if (categoryField != null && categoryField.size() > CATEGORY_FIELD_LIMIT) {
+        if (categoryFields != null && categoryFields.size() > CATEGORY_FIELD_LIMIT) {
             throw new IllegalArgumentException("We only support filtering data by one categorical variable");
         }
         this.detectorId = detectorId;
@@ -165,7 +165,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         this.uiMetadata = uiMetadata;
         this.schemaVersion = schemaVersion;
         this.lastUpdateTime = lastUpdateTime;
-        this.categoryFields = categoryField;
+        this.categoryFields = categoryFields;
     }
 
     // TODO: remove after complete code merges. Created to not to touch too
@@ -540,7 +540,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     }
 
     public Integer getShingleSize() {
-        return getShingleSize(shingleSize, categoryFields);
+        return shingleSize;
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
@@ -85,17 +85,19 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         Instant executionEndTime,
         String error
     ) {
-        this.detectorId = detectorId;
-        this.anomalyScore = anomalyScore;
-        this.anomalyGrade = anomalyGrade;
-        this.confidence = confidence;
-        this.featureData = featureData;
-        this.dataStartTime = dataStartTime;
-        this.dataEndTime = dataEndTime;
-        this.executionStartTime = executionStartTime;
-        this.executionEndTime = executionEndTime;
-        this.error = error;
-        this.entity = null;
+        this(
+            detectorId,
+            anomalyScore,
+            anomalyGrade,
+            confidence,
+            featureData,
+            dataStartTime,
+            dataEndTime,
+            executionStartTime,
+            executionEndTime,
+            error,
+            null
+        );
     }
 
     public AnomalyResult(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/Entity.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/Entity.java
@@ -30,44 +30,36 @@ import com.amazon.opendistroforelasticsearch.ad.annotation.Generated;
 import com.google.common.base.Objects;
 
 /**
- * Feature data used by RCF model.
+ * Categorical field name and its value
+ * @author kaituo
+ *
  */
-public class FeatureData implements ToXContentObject, Writeable {
+public class Entity implements ToXContentObject, Writeable {
+    public static final String ENTITY_NAME_FIELD = "name";
+    public static final String ENTITY_VALUE_FIELD = "value";
 
-    public static final String FEATURE_ID_FIELD = "feature_id";
-    public static final String FEATURE_NAME_FIELD = "feature_name";
-    public static final String DATA_FIELD = "data";
+    private final String name;
+    private final String value;
 
-    private final String featureId;
-    private final String featureName;
-    private final Double data;
-
-    public FeatureData(String featureId, String featureName, Double data) {
-        this.featureId = featureId;
-        this.featureName = featureName;
-        this.data = data;
+    public Entity(String name, String value) {
+        this.name = name;
+        this.value = value;
     }
 
-    public FeatureData(StreamInput input) throws IOException {
-        this.featureId = input.readString();
-        this.featureName = input.readString();
-        this.data = input.readDouble();
+    public Entity(StreamInput input) throws IOException {
+        this.name = input.readString();
+        this.value = input.readString();
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        XContentBuilder xContentBuilder = builder
-            .startObject()
-            .field(FEATURE_ID_FIELD, featureId)
-            .field(FEATURE_NAME_FIELD, featureName)
-            .field(DATA_FIELD, data);
+        XContentBuilder xContentBuilder = builder.startObject().field(ENTITY_NAME_FIELD, name).field(ENTITY_VALUE_FIELD, value);
         return xContentBuilder.endObject();
     }
 
-    public static FeatureData parse(XContentParser parser) throws IOException {
-        String featureId = null;
-        Double data = null;
-        String parsedFeatureName = null;
+    public static Entity parse(XContentParser parser) throws IOException {
+        String parsedValue = null;
+        String parsedName = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -75,20 +67,17 @@ public class FeatureData implements ToXContentObject, Writeable {
             parser.nextToken();
 
             switch (fieldName) {
-                case FEATURE_ID_FIELD:
-                    featureId = parser.text();
+                case ENTITY_NAME_FIELD:
+                    parsedName = parser.text();
                     break;
-                case FEATURE_NAME_FIELD:
-                    parsedFeatureName = parser.text();
-                    break;
-                case DATA_FIELD:
-                    data = parser.doubleValue();
+                case ENTITY_VALUE_FIELD:
+                    parsedValue = parser.text();
                     break;
                 default:
                     break;
             }
         }
-        return new FeatureData(featureId, parsedFeatureName, data);
+        return new Entity(parsedName, parsedValue);
     }
 
     @Generated
@@ -98,37 +87,29 @@ public class FeatureData implements ToXContentObject, Writeable {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        FeatureData that = (FeatureData) o;
-        return Objects.equal(getFeatureId(), that.getFeatureId())
-            && Objects.equal(getFeatureName(), that.getFeatureName())
-            && Objects.equal(getData(), that.getData());
+        Entity that = (Entity) o;
+        return Objects.equal(getName(), that.getName()) && Objects.equal(getValue(), that.getValue());
     }
 
     @Generated
     @Override
     public int hashCode() {
-        return Objects.hashCode(getFeatureId(), getData());
+        return Objects.hashCode(getName(), getValue());
     }
 
     @Generated
-    public String getFeatureId() {
-        return featureId;
+    public String getName() {
+        return name;
     }
 
     @Generated
-    public Double getData() {
-        return data;
-    }
-
-    @Generated
-    public String getFeatureName() {
-        return featureName;
+    public String getValue() {
+        return value;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(featureId);
-        out.writeString(featureName);
-        out.writeDouble(data);
+        out.writeString(name);
+        out.writeString(value);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -227,6 +227,18 @@ public final class AnomalyDetectorSettings {
     // TODO (kaituo): change to 4
     public static final int DEFAULT_MULTI_ENTITY_SHINGLE = 1;
 
+<<<<<<< HEAD
     // how many categorical fields we support
     public static final int CATEGORY_FIELD_LIMIT = 1;
+=======
+    // save partial zero-anomaly grade results after indexing pressure reaching the limit
+    public static final Setting<Float> INDEX_PRESSURE_SOFT_LIMIT = Setting
+        .floatSetting(
+            "opendistro.anomaly_detection.index_pressure_soft_limit",
+            0.8f,
+            0.0f,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+>>>>>>> Selectively store anomaly results when index pressure exceeds a threshold.
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -227,10 +227,9 @@ public final class AnomalyDetectorSettings {
     // TODO (kaituo): change to 4
     public static final int DEFAULT_MULTI_ENTITY_SHINGLE = 1;
 
-<<<<<<< HEAD
     // how many categorical fields we support
     public static final int CATEGORY_FIELD_LIMIT = 1;
-=======
+
     // save partial zero-anomaly grade results after indexing pressure reaching the limit
     public static final Setting<Float> INDEX_PRESSURE_SOFT_LIMIT = Setting
         .floatSetting(
@@ -240,5 +239,4 @@ public final class AnomalyDetectorSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         );
->>>>>>> Selectively store anomaly results when index pressure exceeds a threshold.
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkAction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.TransportRequestOptions;
+
+public class ADResultBulkAction extends ActionType<BulkResponse> {
+
+    public static final ADResultBulkAction INSTANCE = new ADResultBulkAction();
+    public static final String NAME = "cluster:admin/ad/write/bulk";
+
+    private ADResultBulkAction() {
+        super(NAME, BulkResponse::new);
+    }
+
+    @Override
+    public TransportRequestOptions transportOptions(Settings settings) {
+        return TransportRequestOptions.builder().withType(TransportRequestOptions.Type.BULK).build();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkRequest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+
+public class ADResultBulkRequest extends ActionRequest implements Writeable {
+    private final List<AnomalyResult> anomalyResults;
+    static final String NO_REQUESTS_ADDED_ERR = "no requests added";
+
+    public ADResultBulkRequest() {
+        anomalyResults = new ArrayList<>();
+    }
+
+    public ADResultBulkRequest(StreamInput in) throws IOException {
+        super(in);
+        int size = in.readVInt();
+        anomalyResults = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            anomalyResults.add(new AnomalyResult(in));
+        }
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (anomalyResults.isEmpty()) {
+            validationException = ValidateActions.addValidationError(NO_REQUESTS_ADDED_ERR, validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeVInt(anomalyResults.size());
+        for (AnomalyResult result : anomalyResults) {
+            result.writeTo(out);
+        }
+    }
+
+    /**
+     *
+     * @return all of the results to send
+     */
+    public List<AnomalyResult> getAnomalyResults() {
+        return anomalyResults;
+    }
+
+    /**
+     * Add result to send
+     * @param result The result
+     */
+    public void add(AnomalyResult result) {
+        anomalyResults.add(result);
+    }
+
+    /**
+     *
+     * @return total index requests
+     */
+    public int numberOfActions() {
+        return anomalyResults.size();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkTransportAction.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.INDEX_PRESSURE_SOFT_LIMIT;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.index.IndexingPressure.MAX_INDEXING_BYTES;
+
+import java.io.IOException;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkAction;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
+
+public class ADResultBulkTransportAction extends HandledTransportAction<ADResultBulkRequest, BulkResponse> {
+
+    private static final Logger LOG = LogManager.getLogger(ADResultBulkAction.class);
+    private IndexingPressure indexingPressure;
+    private final long primaryAndCoordinatingLimits;
+    private float softLimit;
+    private String indexName;
+    private Client client;
+
+    @Inject
+    public ADResultBulkTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        IndexingPressure indexingPressure,
+        Settings settings,
+        ClusterService clusterService,
+        Client client
+    ) {
+        super(ADResultBulkAction.NAME, transportService, actionFilters, ADResultBulkRequest::new, ThreadPool.Names.SAME);
+        this.indexingPressure = indexingPressure;
+        this.primaryAndCoordinatingLimits = MAX_INDEXING_BYTES.get(settings).getBytes();
+        this.softLimit = INDEX_PRESSURE_SOFT_LIMIT.get(settings);
+        this.indexName = CommonName.ANOMALY_RESULT_INDEX_ALIAS;
+        this.client = client;
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(INDEX_PRESSURE_SOFT_LIMIT, it -> softLimit = it);
+    }
+
+    @Override
+    protected void doExecute(Task task, ADResultBulkRequest request, ActionListener<BulkResponse> listener) {
+        // Concurrent indexing memory limit = 10% of heap
+        // indexing pressure = indexing bytes / indexing limit
+        // Write all until index pressure (global indexing memory pressure) is less than 80% of 10% of heap. Otherwise, index
+        // all non-zero anomaly grade index requests and index zero anomaly grade index requests with probability (1 - index pressure).
+        long totalBytes = indexingPressure.getCurrentCombinedCoordinatingAndPrimaryBytes() + indexingPressure.getCurrentReplicaBytes();
+        LOG.info(primaryAndCoordinatingLimits + " " + totalBytes);
+        float indexingPressurePercent = (float) totalBytes / primaryAndCoordinatingLimits;
+
+        BulkRequest bulkRequest = new BulkRequest();
+
+        if (indexingPressurePercent <= softLimit) {
+            for (AnomalyResult result : request.getAnomalyResults()) {
+                addResult(bulkRequest, result);
+            }
+        } else if (Float.compare(indexingPressurePercent, 1.0f) < 0) {
+            // exceed soft limit (80%) but smaller than hard limit (100%)
+            // random seed is 42. Can be any number
+            Random random = new Random(42);
+            float acceptProbability = 1 - indexingPressurePercent;
+            for (AnomalyResult result : request.getAnomalyResults()) {
+                if (result.getAnomalyGrade() > 0 || random.nextFloat() < acceptProbability) {
+                    addResult(bulkRequest, result);
+                }
+            }
+        } else {
+            // if exceeding 100% of hard limit, try our luck and only index non-zero grade result
+            for (AnomalyResult result : request.getAnomalyResults()) {
+                if (result.getAnomalyGrade() > 0) {
+                    addResult(bulkRequest, result);
+                }
+            }
+        }
+
+        client
+            .execute(
+                BulkAction.INSTANCE,
+                bulkRequest,
+                ActionListener.<BulkResponse>wrap(response -> listener.onResponse(response), listener::onFailure)
+            );
+    }
+
+    private void addResult(BulkRequest bulkRequest, AnomalyResult result) {
+        try (XContentBuilder builder = jsonBuilder()) {
+            IndexRequest indexRequest = new IndexRequest(indexName).source(result.toXContent(builder, RestHandlerUtils.XCONTENT_WITH_TYPE));
+            bulkRequest.add(indexRequest);
+        } catch (IOException e) {
+            LOG.error(String.format("Failed to prepare bulk %s", indexName), e);
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkTransportAction.java
@@ -107,12 +107,14 @@ public class ADResultBulkTransportAction extends HandledTransportAction<ADResult
             }
         }
 
-        client
-            .execute(
-                BulkAction.INSTANCE,
-                bulkRequest,
-                ActionListener.<BulkResponse>wrap(response -> listener.onResponse(response), listener::onFailure)
-            );
+        if (bulkRequest.numberOfActions() > 0) {
+            client
+                .execute(
+                    BulkAction.INSTANCE,
+                    bulkRequest,
+                    ActionListener.<BulkResponse>wrap(response -> listener.onResponse(response), listener::onFailure)
+                );
+        }
     }
 
     private void addResult(BulkRequest bulkRequest, AnomalyResult result) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -29,6 +29,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -105,6 +106,7 @@ import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorExecutionIn
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
+import com.amazon.opendistroforelasticsearch.ad.model.Entity;
 import com.amazon.opendistroforelasticsearch.ad.model.Feature;
 import com.amazon.opendistroforelasticsearch.ad.model.FeatureData;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
@@ -411,6 +413,26 @@ public class TestHelpers {
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             error
+        );
+    }
+
+    public static AnomalyResult randomMultiEntityAnomalyDetectResult(double score, double grade) {
+        return randomMutlEntityAnomalyDetectResult(score, grade, null);
+    }
+
+    public static AnomalyResult randomMutlEntityAnomalyDetectResult(double score, double grade, String error) {
+        return new AnomalyResult(
+            randomAlphaOfLength(5),
+            score,
+            grade,
+            randomDouble(),
+            ImmutableList.of(randomFeatureData(), randomFeatureData()),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            error,
+            Arrays.asList(new Entity(randomAlphaOfLength(5), randomAlphaOfLength(5)))
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndicesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndicesTests.java
@@ -32,8 +32,8 @@ import org.junit.Before;
 
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
-import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 
 public class AnomalyDetectionIndicesTests extends ESIntegTestCase {
@@ -110,7 +110,7 @@ public class AnomalyDetectionIndicesTests extends ESIntegTestCase {
             boolean acknowledged = response.isAcknowledged();
             assertTrue(acknowledged);
         }, failure -> { throw new RuntimeException("should not recreate index"); }));
-        TestHelpers.waitForIndexCreationToComplete(client(), AnomalyResult.ANOMALY_RESULT_INDEX);
+        TestHelpers.waitForIndexCreationToComplete(client(), CommonName.ANOMALY_RESULT_INDEX_ALIAS);
     }
 
     public void testAnomalyResultIndexExistsAndNotRecreate() throws IOException {
@@ -122,15 +122,17 @@ public class AnomalyDetectionIndicesTests extends ESIntegTestCase {
                         failure -> { throw new RuntimeException("should not recreate index"); }
                     )
             );
-        TestHelpers.waitForIndexCreationToComplete(client(), AnomalyResult.ANOMALY_RESULT_INDEX);
-        if (client().admin().indices().prepareExists(AnomalyResult.ANOMALY_RESULT_INDEX).get().isExists()) {
+        TestHelpers.waitForIndexCreationToComplete(client(), CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+        if (client().admin().indices().prepareExists(CommonName.ANOMALY_RESULT_INDEX_ALIAS).get().isExists()) {
             indices
                 .initAnomalyResultIndexIfAbsent(
                     TestHelpers
                         .createActionListener(
-                            response -> { throw new RuntimeException("should not recreate index " + AnomalyResult.ANOMALY_RESULT_INDEX); },
+                            response -> {
+                                throw new RuntimeException("should not recreate index " + CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+                            },
                             failure -> {
-                                throw new RuntimeException("should not recreate index " + AnomalyResult.ANOMALY_RESULT_INDEX, failure);
+                                throw new RuntimeException("should not recreate index " + CommonName.ANOMALY_RESULT_INDEX_ALIAS, failure);
                             }
                         )
                 );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/RolloverTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/RolloverTests.java
@@ -53,7 +53,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 
 public class RolloverTests extends ESTestCase {
@@ -128,7 +128,7 @@ public class RolloverTests extends ESTestCase {
     }
 
     private void assertRolloverRequest(RolloverRequest request) {
-        assertEquals(AnomalyResult.ANOMALY_RESULT_INDEX, request.indices()[0]);
+        assertEquals(CommonName.ANOMALY_RESULT_INDEX_ALIAS, request.indices()[0]);
 
         Map<String, Condition<?>> conditions = request.getConditions();
         assertEquals(1, conditions.size());
@@ -153,7 +153,7 @@ public class RolloverTests extends ESTestCase {
 
         Metadata.Builder metaBuilder = Metadata
             .builder()
-            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 1L, AnomalyResult.ANOMALY_RESULT_INDEX), true);
+            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 1L, CommonName.ANOMALY_RESULT_INDEX_ALIAS), true);
         clusterState = ClusterState.builder(clusterName).metadata(metaBuilder.build()).build();
         when(clusterService.state()).thenReturn(clusterState);
 
@@ -168,7 +168,7 @@ public class RolloverTests extends ESTestCase {
             @SuppressWarnings("unchecked")
             ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArgument(1);
 
-            assertEquals(AnomalyResult.ANOMALY_RESULT_INDEX, request.indices()[0]);
+            assertEquals(CommonName.ANOMALY_RESULT_INDEX_ALIAS, request.indices()[0]);
 
             Map<String, Condition<?>> conditions = request.getConditions();
             assertEquals(1, conditions.size());
@@ -183,12 +183,12 @@ public class RolloverTests extends ESTestCase {
 
         Metadata.Builder metaBuilder = Metadata
             .builder()
-            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 1L, AnomalyResult.ANOMALY_RESULT_INDEX), true)
+            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 1L, CommonName.ANOMALY_RESULT_INDEX_ALIAS), true)
             .put(
                 indexMeta(
                     ".opendistro-anomaly-results-history-2020.06.24-000004",
                     Instant.now().toEpochMilli(),
-                    AnomalyResult.ANOMALY_RESULT_INDEX
+                    CommonName.ANOMALY_RESULT_INDEX_ALIAS
                 ),
                 true
             );
@@ -207,7 +207,7 @@ public class RolloverTests extends ESTestCase {
             @SuppressWarnings("unchecked")
             ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArgument(1);
 
-            assertEquals(AnomalyResult.ANOMALY_RESULT_INDEX, request.indices()[0]);
+            assertEquals(CommonName.ANOMALY_RESULT_INDEX_ALIAS, request.indices()[0]);
 
             Map<String, Condition<?>> conditions = request.getConditions();
             assertEquals(1, conditions.size());
@@ -222,13 +222,13 @@ public class RolloverTests extends ESTestCase {
 
         Metadata.Builder metaBuilder = Metadata
             .builder()
-            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000002", 1L, AnomalyResult.ANOMALY_RESULT_INDEX), true)
-            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 2L, AnomalyResult.ANOMALY_RESULT_INDEX), true)
+            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000002", 1L, CommonName.ANOMALY_RESULT_INDEX_ALIAS), true)
+            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 2L, CommonName.ANOMALY_RESULT_INDEX_ALIAS), true)
             .put(
                 indexMeta(
                     ".opendistro-anomaly-results-history-2020.06.24-000004",
                     Instant.now().toEpochMilli(),
-                    AnomalyResult.ANOMALY_RESULT_INDEX
+                    CommonName.ANOMALY_RESULT_INDEX_ALIAS
                 ),
                 true
             );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkTransportActionTests.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.transport.TransportService;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+
+public class ADResultBulkTransportActionTests extends AbstractADTest {
+    private ADResultBulkTransportAction resultBulk;
+    private TransportService transportService;
+    private ClusterService clusterService;
+    private IndexingPressure indexingPressure;
+    private Client client;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        setUpThreadPool(AnomalyResultTests.class.getSimpleName());
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        tearDownThreadPool();
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        Settings settings = Settings
+            .builder()
+            .put(IndexingPressure.MAX_INDEXING_BYTES.getKey(), "1KB")
+            .put(AnomalyDetectorSettings.INDEX_PRESSURE_SOFT_LIMIT.getKey(), 0.8)
+            .build();
+        setupTestNodes(settings);
+        transportService = testNodes[0].transportService;
+        clusterService = spy(testNodes[0].clusterService);
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.INDEX_PRESSURE_SOFT_LIMIT)))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        ActionFilters actionFilters = mock(ActionFilters.class);
+        indexingPressure = mock(IndexingPressure.class);
+
+        client = mock(Client.class);
+
+        resultBulk = new ADResultBulkTransportAction(transportService, actionFilters, indexingPressure, settings, clusterService, client);
+    }
+
+    @Override
+    @After
+    public final void tearDown() throws Exception {
+        tearDownTestNodes();
+        super.tearDown();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSendAll() {
+        when(indexingPressure.getCurrentCombinedCoordinatingAndPrimaryBytes()).thenReturn(0L);
+        when(indexingPressure.getCurrentReplicaBytes()).thenReturn(0L);
+
+        ADResultBulkRequest originalRequest = new ADResultBulkRequest();
+        originalRequest.add(TestHelpers.randomMultiEntityAnomalyDetectResult(0.8d, 0d));
+        originalRequest.add(TestHelpers.randomMultiEntityAnomalyDetectResult(8d, 0.2d));
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length == 3);
+
+            assertTrue(args[1] instanceof BulkRequest);
+            assertTrue(args[2] instanceof ActionListener);
+            BulkRequest request = (BulkRequest) args[1];
+            ActionListener<BulkResponse> listener = (ActionListener<BulkResponse>) args[2];
+
+            assertEquals(2, request.requests().size());
+            listener.onResponse(null);
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        PlainActionFuture<BulkResponse> future = PlainActionFuture.newFuture();
+        resultBulk.doExecute(null, originalRequest, future);
+
+        future.actionGet();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSendPartial() {
+        // the limit is 1024 Bytes
+        when(indexingPressure.getCurrentCombinedCoordinatingAndPrimaryBytes()).thenReturn(1000L);
+        when(indexingPressure.getCurrentReplicaBytes()).thenReturn(24L);
+
+        ADResultBulkRequest originalRequest = new ADResultBulkRequest();
+        originalRequest.add(TestHelpers.randomMultiEntityAnomalyDetectResult(0.8d, 0d));
+        originalRequest.add(TestHelpers.randomMultiEntityAnomalyDetectResult(8d, 0.2d));
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length == 3);
+
+            assertTrue(args[1] instanceof BulkRequest);
+            assertTrue(args[2] instanceof ActionListener);
+            BulkRequest request = (BulkRequest) args[1];
+            ActionListener<BulkResponse> listener = (ActionListener<BulkResponse>) args[2];
+
+            assertEquals(1, request.requests().size());
+            listener.onResponse(null);
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        PlainActionFuture<BulkResponse> future = PlainActionFuture.newFuture();
+        resultBulk.doExecute(null, originalRequest, future);
+
+        future.actionGet();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testSendRandomPartial() {
+        // 400 + 421 > 1024 * 0.8. 1024 is 1KB, our INDEX_PRESSURE_SOFT_LIMIT
+        when(indexingPressure.getCurrentCombinedCoordinatingAndPrimaryBytes()).thenReturn(400L);
+        when(indexingPressure.getCurrentReplicaBytes()).thenReturn(421L);
+
+        ADResultBulkRequest originalRequest = new ADResultBulkRequest();
+        for (int i = 0; i < 1000; i++) {
+            originalRequest.add(TestHelpers.randomMultiEntityAnomalyDetectResult(0.8d, 0d));
+        }
+
+        originalRequest.add(TestHelpers.randomMultiEntityAnomalyDetectResult(8d, 0.2d));
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length == 3);
+
+            assertTrue(args[1] instanceof BulkRequest);
+            assertTrue(args[2] instanceof ActionListener);
+            BulkRequest request = (BulkRequest) args[1];
+            ActionListener<BulkResponse> listener = (ActionListener<BulkResponse>) args[2];
+
+            int size = request.requests().size();
+            assertTrue(1 < size);
+            // at least 1 half should be removed
+            assertTrue(String.format("size is actually %d", size), size < 500);
+            listener.onResponse(null);
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        PlainActionFuture<BulkResponse> future = PlainActionFuture.newFuture();
+        resultBulk.doExecute(null, originalRequest, future);
+
+        future.actionGet();
+    }
+
+    public void testSerialzationRequest() throws IOException {
+        ADResultBulkRequest request = new ADResultBulkRequest();
+        request.add(TestHelpers.randomMultiEntityAnomalyDetectResult(0.8d, 0d));
+        request.add(TestHelpers.randomMultiEntityAnomalyDetectResult(8d, 0.2d));
+        BytesStreamOutput output = new BytesStreamOutput();
+        request.writeTo(output);
+
+        StreamInput streamInput = output.bytes().streamInput();
+        ADResultBulkRequest readRequest = new ADResultBulkRequest(streamInput);
+        assertThat(2, equalTo(readRequest.numberOfActions()));
+    }
+
+    public void testValidateRequest() {
+        ActionRequestValidationException e = new ADResultBulkRequest().validate();
+        assertThat(e.validationErrors(), hasItem(ADResultBulkRequest.NO_REQUESTS_ADDED_ERR));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
@@ -122,7 +122,6 @@ import com.amazon.opendistroforelasticsearch.ad.ml.RcfResult;
 import com.amazon.opendistroforelasticsearch.ad.ml.ThresholdingResult;
 import com.amazon.opendistroforelasticsearch.ad.ml.rcf.CombinedRcfResult;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
-import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.model.FeatureData;
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStat;
@@ -245,7 +244,7 @@ public class AnomalyResultTests extends AbstractADTest {
             }
 
             assertTrue(request != null && listener != null);
-            ShardId shardId = new ShardId(new Index(AnomalyResult.ANOMALY_RESULT_INDEX, randomAlphaOfLength(10)), 0);
+            ShardId shardId = new ShardId(new Index(CommonName.ANOMALY_RESULT_INDEX_ALIAS, randomAlphaOfLength(10)), 0);
             listener.onResponse(new IndexResponse(shardId, randomAlphaOfLength(10), request.id(), 1, 1, 1, true));
 
             return null;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyResultActionTests.java
@@ -58,7 +58,7 @@ public class SearchAnomalyResultActionTests extends ESIntegTestCase {
     @Test
     public void testSearchResponse() {
         // Will call response.onResponse as Index exists
-        Settings indexSettings = Settings.builder().put("number_of_shards", 5).put("number_of_replicas", 1).build();
+        Settings indexSettings = Settings.builder().put("index.number_of_shards", 5).put("index.number_of_replicas", 1).build();
         CreateIndexRequest indexRequest = new CreateIndexRequest("my-test-index", indexSettings);
         client().admin().indices().create(indexRequest).actionGet();
         SearchRequest searchRequest = new SearchRequest("my-test-index");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandlerTests.java
@@ -55,6 +55,7 @@ import org.mockito.MockitoAnnotations;
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultTests;
@@ -137,7 +138,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
             false,
@@ -175,7 +176,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
             false,
@@ -195,7 +196,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
             false,
@@ -217,7 +218,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
             false,
@@ -246,7 +247,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
         Settings settings = blocked
             ? Settings.builder().put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true).build()
             : Settings.EMPTY;
-        ClusterState blockedClusterState = createIndexBlockedState(indexName, settings, AnomalyResult.ANOMALY_RESULT_INDEX);
+        ClusterState blockedClusterState = createIndexBlockedState(indexName, settings, CommonName.ANOMALY_RESULT_INDEX_ALIAS);
         when(clusterService.state()).thenReturn(blockedClusterState);
         when(indexNameResolver.concreteIndexNames(any(), any(), any(String.class))).thenReturn(new String[] { indexName });
     }
@@ -296,7 +297,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             backoffSettings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
             false,
@@ -317,7 +318,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 1);
             ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
             assertTrue(listener != null);
-            listener.onResponse(new CreateIndexResponse(true, true, AnomalyResult.ANOMALY_RESULT_INDEX) {
+            listener.onResponse(new CreateIndexResponse(true, true, CommonName.ANOMALY_RESULT_INDEX_ALIAS) {
             });
             return null;
         }).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Our performance evaluation has observed a large number of EsRejectedExecutionException due to indexing too many anomaly results. This PR adds a customized bulk transport action to deal with high index memory pressure. When the index pressure exceeds 80%, we only index non-zero anomaly grade index results and a random subset of zero anomaly grade index results.

This PR adds a few supporting data structures related changes:1. add constructors in AnomalyResult/FeatureData to use them in the newly added transport action.2. add Entity class to represent an entity in anomaly results.
This PR also renames ANOMALY_RESULT_INDEX to ANOMALY_RESULT_INDEX_ALIAS and moves it to the CommonName class. The name refers to an alias and is accessed in multiple places.

Testing done:
1. we don't observe EsRejectedExecutionException after applying the change (together with a series of other related changes).
2. added unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
