### PR TITLE
Add transport action for model inference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,7 +254,16 @@ List<String> jacocoExclusions = [
         'com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorTransportAction',
         'com.amazon.opendistroforelasticsearch.ad.transport.DeleteAnomalyDetectorTransportAction*',
         'com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorTransportAction*',
-        'com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorResponse'
+        'com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorResponse',
+
+        // hc caused coverage to drop.  Will address when code merges
+        'com.amazon.opendistroforelasticsearch.ad.transport.handler.MultitiEntityResultHandler',
+        'com.amazon.opendistroforelasticsearch.ad.transport.EntityResultAction',
+        'com.amazon.opendistroforelasticsearch.ad.transport.ADResultBulkRequest',
+        'com.amazon.opendistroforelasticsearch.ad.MaintenanceState',
+        'com.amazon.opendistroforelasticsearch.ad.util.ExpiringState',
+        'com.amazon.opendistroforelasticsearch.ad.ml.EntityModel',
+        'com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider'
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -127,7 +127,6 @@ import com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.StopDetectorTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ThresholdResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ThresholdResultTransportAction;
-import com.amazon.opendistroforelasticsearch.ad.transport.TransportStateManager;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.AnomalyIndexHandler;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.DetectionStateHandler;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
@@ -190,10 +189,9 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             this.clientUtil,
             this.indexUtils,
             clusterService
@@ -316,7 +314,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         );
 
         HashRing hashRing = new HashRing(nodeFilter, clock, settings);
-        TransportStateManager stateManager = new TransportStateManager(
+        NodeStateManager stateManager = new NodeStateManager(
             client,
             xContentRegistry,
             modelManager,
@@ -354,7 +352,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             )
             .put(
                 StatNames.ANOMALY_RESULTS_INDEX_STATUS.getName(),
-                new ADStat<>(true, new IndexStatusSupplier(indexUtils, AnomalyResult.ANOMALY_RESULT_INDEX))
+                new ADStat<>(true, new IndexStatusSupplier(indexUtils, CommonName.ANOMALY_RESULT_INDEX_ALIAS))
             )
             .put(
                 StatNames.MODELS_CHECKPOINT_INDEX_STATUS.getName(),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/CleanState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/CleanState.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+/**
+ * Represent a state organized via detectorId.  When deleting a detector's state,
+ * we can remove it from the state.
+ *
+ *
+ */
+public interface CleanState {
+    /**
+     * Remove state associated with a detector Id
+     * @param detectorId Detector Id
+     */
+    void clear(String detectorId);
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/MaintenanceState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/MaintenanceState.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import java.time.Duration;
+import java.util.Map;
+
+import com.amazon.opendistroforelasticsearch.ad.util.ExpiringState;
+
+public interface MaintenanceState {
+    default <K, V extends ExpiringState> void maintenance(Map<K, V> stateToClean, Duration stateTtl) {
+        stateToClean.entrySet().stream().forEach(entry -> {
+            K detectorId = entry.getKey();
+
+            V state = entry.getValue();
+            if (state.expired(stateTtl)) {
+                stateToClean.remove(detectorId);
+            }
+
+        });
+    }
+
+    void maintenance();
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/NodeState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/NodeState.java
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-package com.amazon.opendistroforelasticsearch.ad.transport;
+package com.amazon.opendistroforelasticsearch.ad;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -27,7 +27,7 @@ import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
  * Storing intermediate state during the execution of transport action
  *
  */
-public class TransportState {
+public class NodeState {
     private String detectorId;
     // detector definition
     private AnomalyDetector detectorDef;
@@ -47,7 +47,7 @@ public class TransportState {
     // cold start running flag to prevent concurrent cold start
     private boolean coldStartRunning;
 
-    public TransportState(String detectorId, Clock clock) {
+    public NodeState(String detectorId, Clock clock) {
         this.detectorId = detectorId;
         this.detectorDef = null;
         this.partitonNumber = -1;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheProvider.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.caching;
+
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+
+/**
+ * A wrapper to call concrete implementation of caching.  Used in transport
+ * action.  Don't use interface because transport action handler constructor
+ * requires a concrete class as input.
+ *
+ */
+public class CacheProvider implements EntityCache {
+    private EntityCache delegate;
+
+    public CacheProvider(EntityCache delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ModelState<EntityModel> get(String modelId, AnomalyDetector detector, double[] datapoint, String entityName) {
+        return delegate.get(modelId, detector, datapoint, entityName);
+    }
+
+    @Override
+    public void maintenance() {
+        delegate.maintenance();
+    }
+
+    @Override
+    public void clear(String detectorId) {
+        delegate.clear(detectorId);
+    }
+
+    @Override
+    public int getActiveEntities(String detector) {
+        return delegate.getActiveEntities(detector);
+    }
+
+    @Override
+    public boolean isActive(String detectorId, String entityId) {
+        return delegate.isActive(detectorId, entityId);
+    }
+
+    @Override
+    public long getTotalUpdates(String detectorId) {
+        return delegate.getTotalUpdates(detectorId);
+    }
+
+    @Override
+    public long getTotalUpdates(String detectorId, String entityId) {
+        return delegate.getTotalUpdates(detectorId, entityId);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/EntityCache.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/EntityCache.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.caching;
+
+import com.amazon.opendistroforelasticsearch.ad.CleanState;
+import com.amazon.opendistroforelasticsearch.ad.MaintenanceState;
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+
+public interface EntityCache extends MaintenanceState, CleanState {
+    /**
+     * Get the ModelState associated with the entity.  May or may not load the
+     * ModelState depending on the underlying cache's eviction policy.
+     *
+     * @param modelId Model Id
+     * @param detector Detector config object
+     * @param datapoint The most recent data point
+     * @param entityName The Entity's name
+     * @return the ModelState associated with the model or null if no cached item
+     * for the entity
+     */
+    ModelState<EntityModel> get(String modelId, AnomalyDetector detector, double[] datapoint, String entityName);
+
+    /**
+     * Get the number of active entities of a detector
+     * @param detector Detector Id
+     * @return The number of active entities
+     */
+    int getActiveEntities(String detector);
+
+    /**
+     * Whether an entity is active or not
+     * @param detectorId The Id of the detector that an entity belongs to
+     * @param entityId Entity Id
+     * @return Whether an entity is active or not
+     */
+    boolean isActive(String detectorId, String entityId);
+
+    /**
+     * Get total updates of detector's most active entity's RCF model.
+     *
+     * @param detectorId detector id
+     * @return RCF model total updates of most active entity
+     */
+    long getTotalUpdates(String detectorId);
+
+    /**
+     * Get RCF model total updates of specific entity
+     *
+     * @param detectorId detector id
+     * @param entityId  entity id
+     * @return RCF model total updates of specific entity
+     */
+    long getTotalUpdates(String detectorId, String entityId);
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java
@@ -26,4 +26,7 @@ public class CommonErrorMessages {
     public static final String MEMORY_CIRCUIT_BROKEN_ERR_MSG = "AD memory circuit is broken.";
     public static final String DISABLED_ERR_MSG = "AD plugin is disabled. To enable update opendistro.anomaly_detection.enabled to true";
     public static final String INVALID_SEARCH_QUERY_MSG = "Invalid search query.";
+    public static final String ALL_FEATURES_DISABLED_ERR_MSG =
+        "Having trouble querying data because all of your features have been disabled.";
+    public static final String INVALID_TIMESTAMP_ERR_MSG = "timestamp is invalid";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonMessageAttributes.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonMessageAttributes.java
@@ -27,4 +27,6 @@ public class CommonMessageAttributes {
     public static final String CONFIDENCE_JSON_KEY = "confidence";
     public static final String ANOMALY_GRADE_JSON_KEY = "anomalyGrade";
     public static final String QUEUE_JSON_KEY = "queue";
+    public static final String START_JSON_KEY = "start";
+    public static final String END_JSON_KEY = "end";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
@@ -22,6 +22,9 @@ public class CommonName {
     // index name for anomaly checkpoint of each model. One model one document.
     public static final String CHECKPOINT_INDEX_NAME = ".opendistro-anomaly-checkpoints";
 
+    // The alias of the index in which to write single-entity AD result history
+    public static final String ANOMALY_RESULT_INDEX_ALIAS = ".opendistro-anomaly-results";
+
     // ======================================
     // Format name
     // ======================================
@@ -55,4 +58,18 @@ public class CommonName {
     public static final String TOTAL_SIZE_IN_BYTES = "total_size_in_bytes";
     public static final String MODELS = "models";
     public static final String INIT_PROGRESS = "init_progress";
+    public static final String TOTAL_ENTITIES = "total_entities";
+    public static final String ACTIVE_ENTITIES = "active_entities";
+
+    // Elastic mapping type
+    public static final String MAPPING_TYPE = "_doc";
+
+    // Used to fetch mapping
+    public static final String TYPE = "type";
+
+    public static final String KEYWORD_TYPE = "keyword";
+
+    public static final String IP_TYPE = "ip";
+
+    public static final String TOTAL_UPDATES = "total_updates";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDao.java
@@ -172,4 +172,8 @@ public class CheckpointDao {
                 ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure)
             );
     }
+
+    public void flush() {
+        throw new UnsupportedOperationException("not supported");
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityModel.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityModel.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.ml;
+
+import java.util.Queue;
+
+import com.amazon.randomcutforest.RandomCutForest;
+
+public class EntityModel {
+    private String modelId;
+    // TODO: sample should record timestamp
+    private Queue<double[]> samples;
+    private RandomCutForest rcf;
+    private ThresholdingModel threshold;
+
+    public EntityModel(String modelId, Queue<double[]> samples, RandomCutForest rcf, ThresholdingModel threshold) {
+        this.modelId = modelId;
+        this.samples = samples;
+        this.rcf = rcf;
+        this.threshold = threshold;
+    }
+
+    public String getModelId() {
+        return this.modelId;
+    }
+
+    public Queue<double[]> getSamples() {
+        return this.samples;
+    }
+
+    public void addSample(double[] sample) {
+        this.samples.add(sample);
+    }
+
+    public RandomCutForest getRcf() {
+        return this.rcf;
+    }
+
+    public ThresholdingModel getThreshold() {
+        return this.threshold;
+    }
+
+    public void setRcf(RandomCutForest rcf) {
+        this.rcf = rcf;
+    }
+
+    public void setThreshold(ThresholdingModel threshold) {
+        this.threshold = threshold;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -469,7 +469,7 @@ public class ModelManager {
             threshold.update(score);
         }
         modelState.setLastUsedTime(clock.instant());
-        listener.onResponse(new ThresholdingResult(grade, confidence));
+        listener.onResponse(new ThresholdingResult(grade, confidence, score));
     }
 
     private void processThresholdCheckpoint(
@@ -987,7 +987,7 @@ public class ModelManager {
         return Arrays.stream(dataPoints).map(point -> {
             double rcfScore = forest.getAnomalyScore(point);
             forest.update(point);
-            ThresholdingResult result = new ThresholdingResult(threshold.grade(rcfScore), threshold.confidence());
+            ThresholdingResult result = new ThresholdingResult(threshold.grade(rcfScore), threshold.confidence(), rcfScore);
             threshold.update(rcfScore);
             return result;
         }).collect(Collectors.toList());
@@ -1047,5 +1047,19 @@ public class ModelManager {
                 );
         }
 
+    }
+
+    public String getEntityModelId(String detectorId, String entityValue) {
+        return detectorId + "_entity_" + entityValue;
+    }
+
+    public ThresholdingResult getAnomalyResultForEntity(
+        String detectorId,
+        double[] datapoint,
+        String entityName,
+        ModelState<EntityModel> modelState,
+        String modelId
+    ) {
+        throw new UnsupportedOperationException("not supported");
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ThresholdingResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ThresholdingResult.java
@@ -24,16 +24,21 @@ public class ThresholdingResult {
 
     private final double grade;
     private final double confidence;
+    private final double rcfScore;
 
     /**
      * Constructor with all arguments.
      *
      * @param grade anomaly grade
      * @param confidence confidence for the grade
+     * @param rcfScore rcf score associated with the grade and confidence. Used
+     *   by multi-entity detector to differentiate whether the result is worth
+     *   saving or not.
      */
-    public ThresholdingResult(double grade, double confidence) {
+    public ThresholdingResult(double grade, double confidence, double rcfScore) {
         this.grade = grade;
         this.confidence = confidence;
+        this.rcfScore = rcfScore;
     }
 
     /**
@@ -54,6 +59,10 @@ public class ThresholdingResult {
         return confidence;
     }
 
+    public double getRcfScore() {
+        return rcfScore;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -61,11 +70,13 @@ public class ThresholdingResult {
         if (o == null || getClass() != o.getClass())
             return false;
         ThresholdingResult that = (ThresholdingResult) o;
-        return Objects.equals(this.grade, that.grade) && Objects.equals(this.confidence, that.confidence);
+        return Objects.equals(this.grade, that.grade)
+            && Objects.equals(this.confidence, that.confidence)
+            && Objects.equals(this.rcfScore, that.rcfScore);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(grade, confidence);
+        return Objects.hash(grade, confidence, rcfScore);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -15,11 +15,13 @@
 
 package com.amazon.opendistroforelasticsearch.ad.model;
 
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DEFAULT_MULTI_ENTITY_SHINGLE;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -76,6 +78,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     private static final String SHINGLE_SIZE_FIELD = "shingle_size";
     private static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
     public static final String UI_METADATA_FIELD = "ui_metadata";
+    public static final String CATEGORY_FIELD = "category_field";
 
     private final String detectorId;
     private final Long version;
@@ -91,6 +94,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     private final Map<String, Object> uiMetadata;
     private final Integer schemaVersion;
     private final Instant lastUpdateTime;
+    private final List<String> categoryFields;
 
     /**
      * Constructor function.
@@ -109,6 +113,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
      * @param uiMetadata        metadata used by Kibana
      * @param schemaVersion     anomaly detector index mapping version
      * @param lastUpdateTime    detector's last update time
+     * @param categoryField     a list of partition fields
      */
     public AnomalyDetector(
         String detectorId,
@@ -124,7 +129,8 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         Integer shingleSize,
         Map<String, Object> uiMetadata,
         Integer schemaVersion,
-        Instant lastUpdateTime
+        Instant lastUpdateTime,
+        List<String> categoryField
     ) {
         if (Strings.isBlank(name)) {
             throw new IllegalArgumentException("Detector name should be set");
@@ -141,6 +147,9 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         if (shingleSize != null && shingleSize < 1) {
             throw new IllegalArgumentException("Shingle size must be a positive integer");
         }
+        if (categoryField != null && categoryField.size() > 1) {
+            throw new IllegalArgumentException("We only support filtering data by one categorical variable");
+        }
         this.detectorId = detectorId;
         this.version = version;
         this.name = name;
@@ -151,10 +160,49 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         this.filterQuery = filterQuery;
         this.detectionInterval = detectionInterval;
         this.windowDelay = windowDelay;
-        this.shingleSize = shingleSize;
+        this.shingleSize = getShingleSize(shingleSize, categoryField);
+        ;
         this.uiMetadata = uiMetadata;
         this.schemaVersion = schemaVersion;
         this.lastUpdateTime = lastUpdateTime;
+        this.categoryFields = categoryField;
+    }
+
+    // TODO: remove after complete code merges. Created to not to touch too
+    // many places in one PR.
+    public AnomalyDetector(
+        String detectorId,
+        Long version,
+        String name,
+        String description,
+        String timeField,
+        List<String> indices,
+        List<Feature> features,
+        QueryBuilder filterQuery,
+        TimeConfiguration detectionInterval,
+        TimeConfiguration windowDelay,
+        Integer shingleSize,
+        Map<String, Object> uiMetadata,
+        Integer schemaVersion,
+        Instant lastUpdateTime
+    ) {
+        this(
+            detectorId,
+            version,
+            name,
+            description,
+            timeField,
+            indices,
+            features,
+            filterQuery,
+            detectionInterval,
+            windowDelay,
+            shingleSize,
+            uiMetadata,
+            schemaVersion,
+            lastUpdateTime,
+            null
+        );
     }
 
     public AnomalyDetector(StreamInput input) throws IOException {
@@ -188,6 +236,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         uiMetadata = input.readMap();
         schemaVersion = input.readInt();
         lastUpdateTime = input.readInstant();
+        categoryFields = input.readStringList();
     }
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
@@ -210,6 +259,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         output.writeMap(uiMetadata);
         output.writeInt(schemaVersion);
         output.writeInstant(lastUpdateTime);
+        output.writeStringCollection(categoryFields);
     }
 
     @Override
@@ -235,6 +285,9 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         }
         if (lastUpdateTime != null) {
             xContentBuilder.timeField(LAST_UPDATE_TIME_FIELD, LAST_UPDATE_TIME_FIELD, lastUpdateTime.toEpochMilli());
+        }
+        if (categoryFields != null) {
+            xContentBuilder.field(CATEGORY_FIELD, categoryFields.toArray());
         }
         return xContentBuilder.endObject();
     }
@@ -264,7 +317,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
      * @throws IOException IOException if content can't be parsed correctly
      */
     public static AnomalyDetector parse(XContentParser parser, String detectorId, Long version) throws IOException {
-        return parse(parser, detectorId, version, null, null, null);
+        return parse(parser, detectorId, version, null, null);
     }
 
     /**
@@ -275,7 +328,6 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
      * @param version                     detector document version
      * @param defaultDetectionInterval    default detection interval
      * @param defaultDetectionWindowDelay default detection window delay
-     * @param defaultShingleSize           default number of intervals in shingle
      * @return anomaly detector instance
      * @throws IOException IOException if content can't be parsed correctly
      */
@@ -284,8 +336,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         String detectorId,
         Long version,
         TimeValue defaultDetectionInterval,
-        TimeValue defaultDetectionWindowDelay,
-        Integer defaultShingleSize
+        TimeValue defaultDetectionWindowDelay
     ) throws IOException {
         String name = null;
         String description = null;
@@ -298,11 +349,13 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         TimeConfiguration windowDelay = defaultDetectionWindowDelay == null
             ? null
             : new IntervalTimeConfiguration(defaultDetectionWindowDelay.getSeconds(), ChronoUnit.SECONDS);
-        Integer shingleSize = defaultShingleSize;
+        Integer shingleSize = null;
         List<Feature> features = new ArrayList<>();
         int schemaVersion = 0;
         Map<String, Object> uiMetadata = null;
         Instant lastUpdateTime = null;
+
+        List<String> categoryField = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -359,6 +412,9 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
                 case LAST_UPDATE_TIME_FIELD:
                     lastUpdateTime = ParseUtils.toInstant(parser);
                     break;
+                case CATEGORY_FIELD:
+                    categoryField = (List) parser.list();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -375,10 +431,11 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
             filterQuery,
             detectionInterval,
             windowDelay,
-            shingleSize,
+            getShingleSize(shingleSize, categoryField),
             uiMetadata,
             schemaVersion,
-            lastUpdateTime
+            lastUpdateTime,
+            categoryField
         );
     }
 
@@ -483,7 +540,20 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     }
 
     public Integer getShingleSize() {
-        return shingleSize == null ? DEFAULT_SHINGLE_SIZE : shingleSize;
+        return shingleSize;
+    }
+
+    /**
+     * If the given shingle size is null, return default based on the kind of detector;
+     * otherwise, return the given shingle size.
+     * @param customShingleSize Given shingle size
+     * @param categoryField Used to verify if this is a multi-entity or single-entity detector
+     * @return Shingle size
+     */
+    private static Integer getShingleSize(Integer customShingleSize, List<String> categoryField) {
+        return customShingleSize == null
+            ? (categoryField != null && categoryField.size() > 0 ? DEFAULT_MULTI_ENTITY_SHINGLE : DEFAULT_SHINGLE_SIZE)
+            : customShingleSize;
     }
 
     public Map<String, Object> getUiMetadata() {
@@ -498,4 +568,19 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         return lastUpdateTime;
     }
 
+    public List<String> getCategoryField() {
+        return this.categoryFields;
+    }
+
+    public long getDetectorIntervalInMilliseconds() {
+        return ((IntervalTimeConfiguration) getDetectionInterval()).toDuration().toMillis();
+    }
+
+    public long getDetectorIntervalInSeconds() {
+        return getDetectorIntervalInMilliseconds() / 1000;
+    }
+
+    public Duration getDetectionIntervalDuration() {
+        return ((IntervalTimeConfiguration) getDetectionInterval()).toDuration();
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
@@ -22,7 +22,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.elasticsearch.common.ParseField;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -36,7 +40,7 @@ import com.google.common.base.Objects;
  * Include result returned from RCF model and feature data.
  * TODO: fix rotating anomaly result index
  */
-public class AnomalyResult implements ToXContentObject {
+public class AnomalyResult implements ToXContentObject, Writeable {
 
     public static final String PARSE_FIELD_NAME = "AnomalyResult";
     public static final NamedXContentRegistry.Entry XCONTENT_REGISTRY = new NamedXContentRegistry.Entry(
@@ -44,8 +48,6 @@ public class AnomalyResult implements ToXContentObject {
         new ParseField(PARSE_FIELD_NAME),
         it -> parse(it)
     );
-
-    public static final String ANOMALY_RESULT_INDEX = ".opendistro-anomaly-results";
 
     public static final String DETECTOR_ID_FIELD = "detector_id";
     public static final String ANOMALY_SCORE_FIELD = "anomaly_score";
@@ -57,6 +59,7 @@ public class AnomalyResult implements ToXContentObject {
     private static final String EXECUTION_START_TIME_FIELD = "execution_start_time";
     public static final String EXECUTION_END_TIME_FIELD = "execution_end_time";
     public static final String ERROR_FIELD = "error";
+    public static final String ENTITY_FIELD = "entity";
 
     private final String detectorId;
     private final Double anomalyScore;
@@ -68,6 +71,7 @@ public class AnomalyResult implements ToXContentObject {
     private final Instant executionStartTime;
     private final Instant executionEndTime;
     private final String error;
+    private final List<Entity> entity;
 
     public AnomalyResult(
         String detectorId,
@@ -81,6 +85,34 @@ public class AnomalyResult implements ToXContentObject {
         Instant executionEndTime,
         String error
     ) {
+        this(
+            detectorId,
+            anomalyScore,
+            anomalyGrade,
+            confidence,
+            featureData,
+            dataStartTime,
+            dataEndTime,
+            executionStartTime,
+            executionEndTime,
+            error,
+            null
+        );
+    }
+
+    public AnomalyResult(
+        String detectorId,
+        Double anomalyScore,
+        Double anomalyGrade,
+        Double confidence,
+        List<FeatureData> featureData,
+        Instant dataStartTime,
+        Instant dataEndTime,
+        Instant executionStartTime,
+        Instant executionEndTime,
+        String error,
+        List<Entity> entity
+    ) {
         this.detectorId = detectorId;
         this.anomalyScore = anomalyScore;
         this.anomalyGrade = anomalyGrade;
@@ -91,6 +123,29 @@ public class AnomalyResult implements ToXContentObject {
         this.executionStartTime = executionStartTime;
         this.executionEndTime = executionEndTime;
         this.error = error;
+        this.entity = entity;
+    }
+
+    public AnomalyResult(StreamInput input) throws IOException {
+        this.detectorId = input.readString();
+        this.anomalyScore = input.readDouble();
+        this.anomalyGrade = input.readDouble();
+        this.confidence = input.readDouble();
+        int featureSize = input.readVInt();
+        this.featureData = new ArrayList<FeatureData>(featureSize);
+        for (int i = 0; i < featureSize; i++) {
+            featureData.add(new FeatureData(input));
+        }
+        this.dataStartTime = input.readInstant();
+        this.dataEndTime = input.readInstant();
+        this.executionStartTime = input.readInstant();
+        this.executionEndTime = input.readInstant();
+        this.error = input.readOptionalString();
+        int entitySize = input.readVInt();
+        this.entity = new ArrayList<Entity>(entitySize);
+        for (int i = 0; i < entitySize; i++) {
+            entity.add(new Entity(input));
+        }
     }
 
     @Override
@@ -124,6 +179,9 @@ public class AnomalyResult implements ToXContentObject {
         if (error != null) {
             xContentBuilder.field(ERROR_FIELD, error);
         }
+        if (entity != null) {
+            xContentBuilder.field(ENTITY_FIELD, entity.toArray());
+        }
         return xContentBuilder.endObject();
     }
 
@@ -138,6 +196,7 @@ public class AnomalyResult implements ToXContentObject {
         Instant executionStartTime = null;
         Instant executionEndTime = null;
         String error = null;
+        List<Entity> entityList = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -178,6 +237,13 @@ public class AnomalyResult implements ToXContentObject {
                 case ERROR_FIELD:
                     error = parser.text();
                     break;
+                case ENTITY_FIELD:
+                    entityList = new ArrayList<>();
+                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser::getTokenLocation);
+                    while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
+                        entityList.add(Entity.parse(parser));
+                    }
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -193,7 +259,8 @@ public class AnomalyResult implements ToXContentObject {
             dataEndTime,
             executionStartTime,
             executionEndTime,
-            error
+            error,
+            entityList
         );
     }
 
@@ -214,7 +281,8 @@ public class AnomalyResult implements ToXContentObject {
             && Objects.equal(getDataEndTime(), that.getDataEndTime())
             && Objects.equal(getExecutionStartTime(), that.getExecutionStartTime())
             && Objects.equal(getExecutionEndTime(), that.getExecutionEndTime())
-            && Objects.equal(getError(), that.getError());
+            && Objects.equal(getError(), that.getError())
+            && Objects.equal(getEntity(), that.getEntity());
     }
 
     @Generated
@@ -231,8 +299,27 @@ public class AnomalyResult implements ToXContentObject {
                 getDataEndTime(),
                 getExecutionStartTime(),
                 getExecutionEndTime(),
-                getError()
+                getError(),
+                getEntity()
             );
+    }
+
+    @Generated
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("detectorId", detectorId)
+            .append("anomalyScore", anomalyScore)
+            .append("anomalyGrade", anomalyGrade)
+            .append("confidence", confidence)
+            .append("featureData", featureData)
+            .append("dataStartTime", dataStartTime)
+            .append("dataEndTime", dataEndTime)
+            .append("executionStartTime", executionStartTime)
+            .append("executionEndTime", executionEndTime)
+            .append("error", error)
+            .append("entity", entity)
+            .toString();
     }
 
     public String getDetectorId() {
@@ -273,5 +360,30 @@ public class AnomalyResult implements ToXContentObject {
 
     public String getError() {
         return error;
+    }
+
+    public List<Entity> getEntity() {
+        return entity;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(detectorId);
+        out.writeDouble(anomalyScore);
+        out.writeDouble(anomalyGrade);
+        out.writeDouble(confidence);
+        out.writeVInt(featureData.size());
+        for (FeatureData feature : featureData) {
+            feature.writeTo(out);
+        }
+        out.writeInstant(dataStartTime);
+        out.writeInstant(dataEndTime);
+        out.writeInstant(executionStartTime);
+        out.writeInstant(executionEndTime);
+        out.writeOptionalString(error);
+        out.writeVInt(entity.size());
+        for (Entity entityItem : entity) {
+            entityItem.writeTo(out);
+        }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/Entity.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/Entity.java
@@ -30,44 +30,36 @@ import com.amazon.opendistroforelasticsearch.ad.annotation.Generated;
 import com.google.common.base.Objects;
 
 /**
- * Feature data used by RCF model.
+ * Categorical field name and its value
+ * @author kaituo
+ *
  */
-public class FeatureData implements ToXContentObject, Writeable {
+public class Entity implements ToXContentObject, Writeable {
+    public static final String ENTITY_NAME_FIELD = "name";
+    public static final String ENTITY_VALUE_FIELD = "value";
 
-    public static final String FEATURE_ID_FIELD = "feature_id";
-    public static final String FEATURE_NAME_FIELD = "feature_name";
-    public static final String DATA_FIELD = "data";
+    private final String name;
+    private final String value;
 
-    private final String featureId;
-    private final String featureName;
-    private final Double data;
-
-    public FeatureData(String featureId, String featureName, Double data) {
-        this.featureId = featureId;
-        this.featureName = featureName;
-        this.data = data;
+    public Entity(String name, String value) {
+        this.name = name;
+        this.value = value;
     }
 
-    public FeatureData(StreamInput input) throws IOException {
-        this.featureId = input.readString();
-        this.featureName = input.readString();
-        this.data = input.readDouble();
+    public Entity(StreamInput input) throws IOException {
+        this.name = input.readString();
+        this.value = input.readString();
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        XContentBuilder xContentBuilder = builder
-            .startObject()
-            .field(FEATURE_ID_FIELD, featureId)
-            .field(FEATURE_NAME_FIELD, featureName)
-            .field(DATA_FIELD, data);
+        XContentBuilder xContentBuilder = builder.startObject().field(ENTITY_NAME_FIELD, name).field(ENTITY_VALUE_FIELD, value);
         return xContentBuilder.endObject();
     }
 
-    public static FeatureData parse(XContentParser parser) throws IOException {
-        String featureId = null;
-        Double data = null;
-        String parsedFeatureName = null;
+    public static Entity parse(XContentParser parser) throws IOException {
+        String parsedValue = null;
+        String parsedName = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser::getTokenLocation);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -75,20 +67,17 @@ public class FeatureData implements ToXContentObject, Writeable {
             parser.nextToken();
 
             switch (fieldName) {
-                case FEATURE_ID_FIELD:
-                    featureId = parser.text();
+                case ENTITY_NAME_FIELD:
+                    parsedName = parser.text();
                     break;
-                case FEATURE_NAME_FIELD:
-                    parsedFeatureName = parser.text();
-                    break;
-                case DATA_FIELD:
-                    data = parser.doubleValue();
+                case ENTITY_VALUE_FIELD:
+                    parsedValue = parser.text();
                     break;
                 default:
                     break;
             }
         }
-        return new FeatureData(featureId, parsedFeatureName, data);
+        return new Entity(parsedName, parsedValue);
     }
 
     @Generated
@@ -98,37 +87,29 @@ public class FeatureData implements ToXContentObject, Writeable {
             return true;
         if (o == null || getClass() != o.getClass())
             return false;
-        FeatureData that = (FeatureData) o;
-        return Objects.equal(getFeatureId(), that.getFeatureId())
-            && Objects.equal(getFeatureName(), that.getFeatureName())
-            && Objects.equal(getData(), that.getData());
+        Entity that = (Entity) o;
+        return Objects.equal(getName(), that.getName()) && Objects.equal(getValue(), that.getValue());
     }
 
     @Generated
     @Override
     public int hashCode() {
-        return Objects.hashCode(getFeatureId(), getData());
+        return Objects.hashCode(getName(), getValue());
     }
 
     @Generated
-    public String getFeatureId() {
-        return featureId;
+    public String getName() {
+        return name;
     }
 
     @Generated
-    public Double getData() {
-        return data;
-    }
-
-    @Generated
-    public String getFeatureName() {
-        return featureName;
+    public String getValue() {
+        return value;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(featureId);
-        out.writeString(featureName);
-        out.writeDouble(data);
+        out.writeString(name);
+        out.writeString(value);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestIndexAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestIndexAnomalyDetectorAction.java
@@ -15,7 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.ad.rest;
 
-import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DETECTION_INTERVAL;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.DETECTION_WINDOW_DELAY;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_ANOMALY_DETECTORS;
@@ -107,8 +106,7 @@ public class RestIndexAnomalyDetectorAction extends BaseRestHandler {
         XContentParser parser = request.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
         // TODO: check detection interval < modelTTL
-        AnomalyDetector detector = AnomalyDetector
-            .parse(parser, detectorId, null, detectionInterval, detectionWindowDelay, DEFAULT_SHINGLE_SIZE);
+        AnomalyDetector detector = AnomalyDetector.parse(parser, detectorId, null, detectionInterval, detectionWindowDelay);
 
         long seqNo = request.paramAsLong(IF_SEQ_NO, SequenceNumbers.UNASSIGNED_SEQ_NO);
         long primaryTerm = request.paramAsLong(IF_PRIMARY_TERM, SequenceNumbers.UNASSIGNED_PRIMARY_TERM);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -214,4 +214,10 @@ public final class AnomalyDetectorSettings {
 
     // Thread pool
     public static final int AD_THEAD_POOL_QUEUE_SIZE = 1000;
+
+    // Multi-entity detector model setting:
+    // TODO (kaituo): change to 4
+    public static final int DEFAULT_MULTI_ENTITY_SHINGLE = 1;
+
+    public static int MAX_ENTITY_LENGTH = 256;
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADResultBulkRequest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+
+public class ADResultBulkRequest extends ActionRequest implements Writeable {
+    private final List<AnomalyResult> anomalyResults;
+    static final String NO_REQUESTS_ADDED_ERR = "no requests added";
+
+    public ADResultBulkRequest() {
+        anomalyResults = new ArrayList<>();
+    }
+
+    public ADResultBulkRequest(StreamInput in) throws IOException {
+        super(in);
+        int size = in.readVInt();
+        anomalyResults = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            anomalyResults.add(new AnomalyResult(in));
+        }
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (anomalyResults.isEmpty()) {
+            validationException = ValidateActions.addValidationError(NO_REQUESTS_ADDED_ERR, validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeVInt(anomalyResults.size());
+        for (AnomalyResult result : anomalyResults) {
+            result.writeTo(out);
+        }
+    }
+
+    /**
+     *
+     * @return all of the results to send
+     */
+    public List<AnomalyResult> getAnomalyResults() {
+        return anomalyResults;
+    }
+
+    /**
+     * Add result to send
+     * @param result The result
+     */
+    public void add(AnomalyResult result) {
+        anomalyResults.add(result);
+    }
+
+    /**
+     *
+     * @return total index requests
+     */
+    public int numberOfActions() {
+        return anomalyResults.size();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
@@ -53,6 +53,7 @@ import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.breaker.ADCircuitBreakerService;
 import com.amazon.opendistroforelasticsearch.ad.cluster.HashRing;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
@@ -93,7 +94,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
     static final String BUG_RESPONSE = "We might have bugs.";
 
     private final TransportService transportService;
-    private final TransportStateManager stateManager;
+    private final NodeStateManager stateManager;
     private final FeatureManager featureManager;
     private final ModelManager modelManager;
     private final HashRing hashRing;
@@ -109,7 +110,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         ActionFilters actionFilters,
         TransportService transportService,
         Settings settings,
-        TransportStateManager manager,
+        NodeStateManager manager,
         FeatureManager featureManager,
         ModelManager modelManager,
         HashRing hashRing,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportAction.java
@@ -27,12 +27,13 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 
 public class CronTransportAction extends TransportNodesAction<CronRequest, CronResponse, CronNodeRequest, CronNodeResponse> {
 
-    private TransportStateManager transportStateManager;
+    private NodeStateManager transportStateManager;
     private ModelManager modelManager;
     private FeatureManager featureManager;
 
@@ -42,7 +43,7 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
         ClusterService clusterService,
         TransportService transportService,
         ActionFilters actionFilters,
-        TransportStateManager tarnsportStatemanager,
+        NodeStateManager tarnsportStatemanager,
         ModelManager modelManager,
         FeatureManager featureManager
     ) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportAction.java
@@ -29,13 +29,14 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 
 public class DeleteModelTransportAction extends
     TransportNodesAction<DeleteModelRequest, DeleteModelResponse, DeleteModelNodeRequest, DeleteModelNodeResponse> {
     private static final Logger LOG = LogManager.getLogger(DeleteModelTransportAction.class);
-    private TransportStateManager transportStateManager;
+    private NodeStateManager transportStateManager;
     private ModelManager modelManager;
     private FeatureManager featureManager;
 
@@ -45,7 +46,7 @@ public class DeleteModelTransportAction extends
         ClusterService clusterService,
         TransportService transportService,
         ActionFilters actionFilters,
-        TransportStateManager tarnsportStatemanager,
+        NodeStateManager tarnsportStatemanager,
         ModelManager modelManager,
         FeatureManager featureManager
     ) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultAction.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+
+public class EntityResultAction extends ActionType<AcknowledgedResponse> {
+    public static final EntityResultAction INSTANCE = new EntityResultAction();
+    public static final String NAME = "cluster:admin/ad/entity/result";
+
+    private EntityResultAction() {
+        super(NAME, AcknowledgedResponse::new);
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultRequest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonMessageAttributes;
+
+public class EntityResultRequest extends ActionRequest implements ToXContentObject {
+
+    private String detectorId;
+    private Map<String, double[]> entities;
+    private long start;
+    private long end;
+
+    public EntityResultRequest(StreamInput in) throws IOException {
+        super(in);
+        this.detectorId = in.readString();
+        this.entities = in.readMap(StreamInput::readString, StreamInput::readDoubleArray);
+        this.start = in.readLong();
+        this.end = in.readLong();
+    }
+
+    public EntityResultRequest(String detectorId, Map<String, double[]> entities, long start, long end) {
+        super();
+        this.detectorId = detectorId;
+        this.entities = entities;
+        this.start = start;
+        this.end = end;
+    }
+
+    public String getDetectorId() {
+        return this.detectorId;
+    }
+
+    public Map<String, double[]> getEntities() {
+        return this.entities;
+    }
+
+    public long getStart() {
+        return this.start;
+    }
+
+    public long getEnd() {
+        return this.end;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(this.detectorId);
+        out.writeMap(this.entities, StreamOutput::writeString, StreamOutput::writeDoubleArray);
+        out.writeLong(this.start);
+        out.writeLong(this.end);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (Strings.isEmpty(detectorId)) {
+            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+        }
+        if (start <= 0 || end <= 0 || start > end) {
+            validationException = addValidationError(
+                String.format(Locale.ROOT, "%s: start %d, end %d", CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG, start, end),
+                validationException
+            );
+        }
+        return validationException;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(CommonMessageAttributes.ID_JSON_KEY, detectorId);
+        builder.field(CommonMessageAttributes.START_JSON_KEY, start);
+        builder.field(CommonMessageAttributes.END_JSON_KEY, end);
+        for (String entity : entities.keySet()) {
+            builder.field(entity, entities.get(entity));
+        }
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultTransportAction.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.COOLDOWN_MINUTES;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
+import com.amazon.opendistroforelasticsearch.ad.breaker.ADCircuitBreakerService;
+import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
+import com.amazon.opendistroforelasticsearch.ad.caching.EntityCache;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao;
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.ml.ThresholdingResult;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.model.Entity;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.opendistroforelasticsearch.ad.transport.handler.MultitiEntityResultHandler;
+import com.amazon.opendistroforelasticsearch.ad.util.ParseUtils;
+
+public class EntityResultTransportAction extends HandledTransportAction<EntityResultRequest, AcknowledgedResponse> {
+
+    private static final Logger LOG = LogManager.getLogger(EntityResultTransportAction.class);
+    private ModelManager manager;
+    private ADCircuitBreakerService adCircuitBreakerService;
+    private MultitiEntityResultHandler anomalyResultHandler;
+    private CheckpointDao checkpointDao;
+    private EntityCache cache;
+    private final NodeStateManager stateManager;
+    private final int coolDownMinutes;
+    private final Clock clock;
+
+    @Inject
+    public EntityResultTransportAction(
+        ActionFilters actionFilters,
+        TransportService transportService,
+        ModelManager manager,
+        ADCircuitBreakerService adCircuitBreakerService,
+        MultitiEntityResultHandler anomalyResultHandler,
+        CheckpointDao checkpointDao,
+        CacheProvider entityCache,
+        NodeStateManager stateManager,
+        Settings settings,
+        Clock clock
+    ) {
+        super(EntityResultAction.NAME, transportService, actionFilters, EntityResultRequest::new);
+        this.manager = manager;
+        this.adCircuitBreakerService = adCircuitBreakerService;
+        this.anomalyResultHandler = anomalyResultHandler;
+        this.checkpointDao = checkpointDao;
+        this.cache = entityCache;
+        this.stateManager = stateManager;
+        this.coolDownMinutes = (int) (COOLDOWN_MINUTES.get(settings).getMinutes());
+        this.clock = clock;
+    }
+
+    @Override
+    protected void doExecute(Task task, EntityResultRequest request, ActionListener<AcknowledgedResponse> listener) {
+        if (adCircuitBreakerService.isOpen()) {
+            listener.onFailure(new LimitExceededException(request.getDetectorId(), CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG));
+            return;
+        }
+
+        try {
+            String detectorId = request.getDetectorId();
+            stateManager.getAnomalyDetector(detectorId, onGetDetector(listener, detectorId, request));
+        } catch (Exception exception) {
+            LOG.error("fail to get entity's anomaly grade", exception);
+            listener.onFailure(exception);
+        }
+
+    }
+
+    private ActionListener<Optional<AnomalyDetector>> onGetDetector(
+        ActionListener<AcknowledgedResponse> listener,
+        String detectorId,
+        EntityResultRequest request
+    ) {
+        return ActionListener.wrap(detectorOptional -> {
+            if (!detectorOptional.isPresent()) {
+                listener.onFailure(new EndRunException(detectorId, "AnomalyDetector is not available.", true));
+                return;
+            }
+
+            AnomalyDetector detector = detectorOptional.get();
+            // we only support 1 categorical field now
+            String categoricalField = detector.getCategoryField().get(0);
+
+            ADResultBulkRequest currentBulkRequest = new ADResultBulkRequest();
+            // index pressure is high. Only save anomalies
+            boolean onlySaveAnomalies = stateManager
+                .getLastIndexThrottledTime()
+                .plus(Duration.ofMinutes(coolDownMinutes))
+                .isAfter(clock.instant());
+
+            for (Entry<String, double[]> entity : request.getEntities().entrySet()) {
+                String entityName = entity.getKey();
+                // For ES, the limit of the document ID is 512 bytes.
+                // truncate to 256 characters if too long since we are using it as part of document id.
+                if (entityName.length() > AnomalyDetectorSettings.MAX_ENTITY_LENGTH) {
+                    continue;
+                }
+
+                double[] datapoint = entity.getValue();
+                String modelId = manager.getEntityModelId(detectorId, entityName);
+                ModelState<EntityModel> entityModel = cache.get(modelId, detector, datapoint, entityName);
+                if (entityModel == null) {
+                    // cache miss
+                    continue;
+                }
+                ThresholdingResult result = manager.getAnomalyResultForEntity(detectorId, datapoint, entityName, entityModel, modelId);
+                // result.getRcfScore() = 0 means the model is not initialized
+                // result.getGrade() = 0 means it is not an anomaly
+                // So many EsRejectedExecutionException if we write no matter what
+                if (result.getRcfScore() > 0 && (!onlySaveAnomalies || result.getGrade() > 0)) {
+                    this.anomalyResultHandler
+                        .write(
+                            new AnomalyResult(
+                                detectorId,
+                                result.getRcfScore(),
+                                result.getGrade(),
+                                result.getConfidence(),
+                                ParseUtils.getFeatureData(datapoint, detector),
+                                Instant.ofEpochMilli(request.getStart()),
+                                Instant.ofEpochMilli(request.getEnd()),
+                                Instant.now(),
+                                Instant.now(),
+                                null,
+                                Arrays.asList(new Entity(categoricalField, entityName))
+                            ),
+                            currentBulkRequest
+                        );
+                }
+            }
+            this.anomalyResultHandler.flush(currentBulkRequest, detectorId);
+            // bulk all accumulated checkpoint requests
+            this.checkpointDao.flush();
+
+            listener.onResponse(new AcknowledgedResponse(true));
+        }, exception -> {
+            LOG.error("fail to get entity's anomaly grade", exception);
+            listener.onFailure(exception);
+        });
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectionStateHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectionStateHandler.java
@@ -39,8 +39,8 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
-import com.amazon.opendistroforelasticsearch.ad.transport.TransportStateManager;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
 import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
 import com.google.common.base.Objects;
@@ -79,7 +79,7 @@ public class DetectionStateHandler extends AnomalyIndexHandler<DetectorInternalS
 
     private static final Logger LOG = LogManager.getLogger(DetectionStateHandler.class);
     private NamedXContentRegistry xContentRegistry;
-    private TransportStateManager adStateManager;
+    private NodeStateManager adStateManager;
 
     public DetectionStateHandler(
         Client client,
@@ -91,7 +91,7 @@ public class DetectionStateHandler extends AnomalyIndexHandler<DetectorInternalS
         IndexUtils indexUtils,
         ClusterService clusterService,
         NamedXContentRegistry xContentRegistry,
-        TransportStateManager adStateManager
+        NodeStateManager adStateManager
     ) {
         super(
             client,
@@ -100,11 +100,11 @@ public class DetectionStateHandler extends AnomalyIndexHandler<DetectorInternalS
             DetectorInternalState.DETECTOR_STATE_INDEX,
             createIndex,
             indexExists,
-            true,
             clientUtil,
             indexUtils,
             clusterService
         );
+        this.fixedDoc = true;
         this.xContentRegistry = xContentRegistry;
         this.adStateManager = adStateManager;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/MultitiEntityResultHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/MultitiEntityResultHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport.handler;
+
+import java.time.Clock;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADResultBulkRequest;
+import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
+import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
+import com.amazon.opendistroforelasticsearch.ad.util.ThrowingConsumerWrapper;
+
+/**
+ * Quick way to create a result handler without remembering all of the low level details.
+ * Also, EntityResultTransportAction depends on this class.  All transport actions
+ * needs dependency injection.  Guice has a hard time initializing generics class AnomalyIndexHandler &lt; AnomalyResult &gt;
+ * due to type erasure. To avoid that, I create a class with a built-in details so
+ * that Guice would be able to work out the details.
+ *
+ */
+public class MultitiEntityResultHandler extends AnomalyIndexHandler<AnomalyResult> {
+    private static final Logger LOG = LogManager.getLogger(MultitiEntityResultHandler.class);
+
+    @Inject
+    public MultitiEntityResultHandler(
+        Client client,
+        Settings settings,
+        ThreadPool threadPool,
+        AnomalyDetectionIndices anomalyDetectionIndices,
+        ClientUtil clientUtil,
+        IndexUtils indexUtils,
+        ClusterService clusterService,
+        NodeStateManager nodeStateManager,
+        Clock clock
+    ) {
+        super(
+            client,
+            settings,
+            threadPool,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
+            ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
+            anomalyDetectionIndices::doesAnomalyResultIndexExist,
+            clientUtil,
+            indexUtils,
+            clusterService
+        );
+    }
+
+    public void write(AnomalyResult toSave, ADResultBulkRequest currentBulkRequest) {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    public void flush(ADResultBulkRequest currentBulkRequest, String detectorId) {
+        throw new UnsupportedOperationException("not supported");
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ExpiringState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ExpiringState.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.util;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public interface ExpiringState {
+    default boolean expired(Instant lastAccessTime, Duration stateTtl, Instant now) {
+        return lastAccessTime.plus(stateTtl).isBefore(now);
+    }
+
+    boolean expired(Duration stateTtl);
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
@@ -22,6 +22,7 @@ import static org.elasticsearch.search.aggregations.AggregatorFactories.VALID_AG
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -44,6 +45,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.Feature;
+import com.amazon.opendistroforelasticsearch.ad.model.FeatureData;
 
 /**
  * Parsing utility functions.
@@ -340,5 +342,22 @@ public final class ParseUtils {
         }
 
         return internalSearchSourceBuilder.toString();
+    }
+
+    /**
+     * Map feature data to its Id and name
+     * @param currentFeature Feature data
+     * @param detector Detector Config object
+     * @return a list of feature data with Id and name
+     */
+    public static List<FeatureData> getFeatureData(double[] currentFeature, AnomalyDetector detector) {
+        List<String> featureIds = detector.getEnabledFeatureIds();
+        List<String> featureNames = detector.getEnabledFeatureNames();
+        int featureLen = featureIds.size();
+        List<FeatureData> featureData = new ArrayList<>();
+        for (int i = 0; i < featureLen; i++) {
+            featureData.add(new FeatureData(featureIds.get(i), featureNames.get(i), currentFeature[i]));
+        }
+        return featureData;
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
@@ -68,7 +68,6 @@ import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
-import com.amazon.opendistroforelasticsearch.ad.transport.TransportStateManager;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.AnomalyIndexHandler;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.DetectionStateHandler;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
@@ -152,7 +151,7 @@ public class AnomalyDetectorJobRunnerTests extends AbstractADTest {
         AnomalyDetectionIndices anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
         IndexNameExpressionResolver indexNameResolver = mock(IndexNameExpressionResolver.class);
         IndexUtils indexUtils = new IndexUtils(client, clientUtil, clusterService, indexNameResolver);
-        TransportStateManager stateManager = mock(TransportStateManager.class);
+        NodeStateManager stateManager = mock(NodeStateManager.class);
         detectorStateHandler = new DetectionStateHandler(
             client,
             settings,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
@@ -61,13 +61,13 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.Interpolator;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.LinearUniformInterpolator;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.SingleFeatureLinearUniformInterpolator;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
-import com.amazon.opendistroforelasticsearch.ad.transport.TransportStateManager;
 import com.amazon.opendistroforelasticsearch.ad.util.ArrayEqMatcher;
 
 @RunWith(JUnitParamsRunner.class)
@@ -100,7 +100,7 @@ public class FeatureManagerTests {
     private Clock clock;
 
     @Mock
-    private TransportStateManager stateManager;
+    private NodeStateManager stateManager;
 
     @Mock
     private ThreadPool threadPool;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
@@ -84,12 +84,12 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.Interpolator;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.LinearUniformInterpolator;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.SingleFeatureLinearUniformInterpolator;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
-import com.amazon.opendistroforelasticsearch.ad.transport.TransportStateManager;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
 import com.amazon.opendistroforelasticsearch.ad.util.ParseUtils;
 
@@ -128,7 +128,7 @@ public class SearchFeatureDaoTests {
     @Mock
     private Max max;
     @Mock
-    private TransportStateManager stateManager;
+    private NodeStateManager stateManager;
 
     @Mock
     private AnomalyDetector detector;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndicesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndicesTests.java
@@ -32,8 +32,8 @@ import org.junit.Before;
 
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
-import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 
 public class AnomalyDetectionIndicesTests extends ESIntegTestCase {
@@ -110,7 +110,7 @@ public class AnomalyDetectionIndicesTests extends ESIntegTestCase {
             boolean acknowledged = response.isAcknowledged();
             assertTrue(acknowledged);
         }, failure -> { throw new RuntimeException("should not recreate index"); }));
-        TestHelpers.waitForIndexCreationToComplete(client(), AnomalyResult.ANOMALY_RESULT_INDEX);
+        TestHelpers.waitForIndexCreationToComplete(client(), CommonName.ANOMALY_RESULT_INDEX_ALIAS);
     }
 
     public void testAnomalyResultIndexExistsAndNotRecreate() throws IOException {
@@ -122,15 +122,17 @@ public class AnomalyDetectionIndicesTests extends ESIntegTestCase {
                         failure -> { throw new RuntimeException("should not recreate index"); }
                     )
             );
-        TestHelpers.waitForIndexCreationToComplete(client(), AnomalyResult.ANOMALY_RESULT_INDEX);
-        if (client().admin().indices().prepareExists(AnomalyResult.ANOMALY_RESULT_INDEX).get().isExists()) {
+        TestHelpers.waitForIndexCreationToComplete(client(), CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+        if (client().admin().indices().prepareExists(CommonName.ANOMALY_RESULT_INDEX_ALIAS).get().isExists()) {
             indices
                 .initAnomalyResultIndexIfAbsent(
                     TestHelpers
                         .createActionListener(
-                            response -> { throw new RuntimeException("should not recreate index " + AnomalyResult.ANOMALY_RESULT_INDEX); },
+                            response -> {
+                                throw new RuntimeException("should not recreate index " + CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+                            },
                             failure -> {
-                                throw new RuntimeException("should not recreate index " + AnomalyResult.ANOMALY_RESULT_INDEX, failure);
+                                throw new RuntimeException("should not recreate index " + CommonName.ANOMALY_RESULT_INDEX_ALIAS, failure);
                             }
                         )
                 );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/RolloverTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/RolloverTests.java
@@ -53,7 +53,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 
 public class RolloverTests extends ESTestCase {
@@ -128,7 +128,7 @@ public class RolloverTests extends ESTestCase {
     }
 
     private void assertRolloverRequest(RolloverRequest request) {
-        assertEquals(AnomalyResult.ANOMALY_RESULT_INDEX, request.indices()[0]);
+        assertEquals(CommonName.ANOMALY_RESULT_INDEX_ALIAS, request.indices()[0]);
 
         Map<String, Condition<?>> conditions = request.getConditions();
         assertEquals(1, conditions.size());
@@ -153,7 +153,7 @@ public class RolloverTests extends ESTestCase {
 
         Metadata.Builder metaBuilder = Metadata
             .builder()
-            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 1L, AnomalyResult.ANOMALY_RESULT_INDEX), true);
+            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 1L, CommonName.ANOMALY_RESULT_INDEX_ALIAS), true);
         clusterState = ClusterState.builder(clusterName).metadata(metaBuilder.build()).build();
         when(clusterService.state()).thenReturn(clusterState);
 
@@ -168,7 +168,7 @@ public class RolloverTests extends ESTestCase {
             @SuppressWarnings("unchecked")
             ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArgument(1);
 
-            assertEquals(AnomalyResult.ANOMALY_RESULT_INDEX, request.indices()[0]);
+            assertEquals(CommonName.ANOMALY_RESULT_INDEX_ALIAS, request.indices()[0]);
 
             Map<String, Condition<?>> conditions = request.getConditions();
             assertEquals(1, conditions.size());
@@ -183,12 +183,12 @@ public class RolloverTests extends ESTestCase {
 
         Metadata.Builder metaBuilder = Metadata
             .builder()
-            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 1L, AnomalyResult.ANOMALY_RESULT_INDEX), true)
+            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 1L, CommonName.ANOMALY_RESULT_INDEX_ALIAS), true)
             .put(
                 indexMeta(
                     ".opendistro-anomaly-results-history-2020.06.24-000004",
                     Instant.now().toEpochMilli(),
-                    AnomalyResult.ANOMALY_RESULT_INDEX
+                    CommonName.ANOMALY_RESULT_INDEX_ALIAS
                 ),
                 true
             );
@@ -207,7 +207,7 @@ public class RolloverTests extends ESTestCase {
             @SuppressWarnings("unchecked")
             ActionListener<RolloverResponse> listener = (ActionListener<RolloverResponse>) invocation.getArgument(1);
 
-            assertEquals(AnomalyResult.ANOMALY_RESULT_INDEX, request.indices()[0]);
+            assertEquals(CommonName.ANOMALY_RESULT_INDEX_ALIAS, request.indices()[0]);
 
             Map<String, Condition<?>> conditions = request.getConditions();
             assertEquals(1, conditions.size());
@@ -222,13 +222,13 @@ public class RolloverTests extends ESTestCase {
 
         Metadata.Builder metaBuilder = Metadata
             .builder()
-            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000002", 1L, AnomalyResult.ANOMALY_RESULT_INDEX), true)
-            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 2L, AnomalyResult.ANOMALY_RESULT_INDEX), true)
+            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000002", 1L, CommonName.ANOMALY_RESULT_INDEX_ALIAS), true)
+            .put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 2L, CommonName.ANOMALY_RESULT_INDEX_ALIAS), true)
             .put(
                 indexMeta(
                     ".opendistro-anomaly-results-history-2020.06.24-000004",
                     Instant.now().toEpochMilli(),
-                    AnomalyResult.ANOMALY_RESULT_INDEX
+                    CommonName.ANOMALY_RESULT_INDEX_ALIAS
                 ),
                 true
             );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManagerTests.java
@@ -482,7 +482,7 @@ public class ModelManagerTests {
         ActionListener<ThresholdingResult> listener = mock(ActionListener.class);
         modelManager.getThresholdingResult(detectorId, thresholdModelId, score, listener);
 
-        ThresholdingResult expected = new ThresholdingResult(grade, confidence);
+        ThresholdingResult expected = new ThresholdingResult(grade, confidence, score);
         verify(listener).onResponse(eq(expected));
 
         listener = mock(ActionListener.class);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ThresholdingResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ThresholdingResultTests.java
@@ -28,7 +28,9 @@ public class ThresholdingResultTests {
 
     private double grade = 1.;
     private double confidence = 0.5;
-    private ThresholdingResult thresholdingResult = new ThresholdingResult(grade, confidence);
+    double score = 1.;
+
+    private ThresholdingResult thresholdingResult = new ThresholdingResult(grade, confidence, score);
 
     @Test
     public void getters_returnExcepted() {
@@ -41,10 +43,10 @@ public class ThresholdingResultTests {
             new Object[] { thresholdingResult, null, false },
             new Object[] { thresholdingResult, thresholdingResult, true },
             new Object[] { thresholdingResult, 1, false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence), true },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence), false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence + 1), false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence + 1), false }, };
+            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence, score), true },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence, score), false },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence + 1, score), false },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence + 1, score), false }, };
     }
 
     @Test
@@ -55,10 +57,10 @@ public class ThresholdingResultTests {
 
     private Object[] hashCodeData() {
         return new Object[] {
-            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence), true },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence), false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence + 1), false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence + 1), false }, };
+            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence, score), true },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence, score), false },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence + 1, score), false },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence + 1, score), false }, };
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -23,18 +23,19 @@ import java.util.Locale;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
-import org.elasticsearch.test.ESTestCase;
 
+import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-public class AnomalyDetectorTests extends ESTestCase {
+public class AnomalyDetectorTests extends AbstractADTest {
 
     public void testParseAnomalyDetector() throws IOException {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), Instant.now());
         String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        LOG.info(detectorString);
         detectorString = detectorString
             .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
         AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
@@ -89,8 +90,7 @@ public class AnomalyDetectorTests extends ESTestCase {
             + "{\"period\":{\"interval\":425,\"unit\":\"Minutes\"}},\"schema_version\":-1203962153,\"ui_metadata\":"
             + "{\"JbAaV\":{\"feature_id\":\"rIFjS\",\"feature_name\":\"QXCmS\",\"feature_enabled\":false,"
             + "\"aggregation_query\":{\"aa\":{\"value_count\":{\"field\":\"ok\"}}}}},\"last_update_time\":1568396089028}";
-        AnomalyDetector parsedDetector = AnomalyDetector
-            .parse(TestHelpers.parser(detectorString), "id", 1L, null, null, AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE);
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString), "id", 1L, null, null);
         assertTrue(parsedDetector.getFilterQuery() instanceof MatchAllQueryBuilder);
         assertEquals((long) parsedDetector.getShingleSize(), (long) AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE);
     }
@@ -139,7 +139,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     0,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -162,7 +163,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -185,7 +187,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -208,7 +211,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -231,7 +235,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -254,7 +259,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -277,7 +283,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -312,7 +319,8 @@ public class AnomalyDetectorTests extends ESTestCase {
             5,
             null,
             1,
-            Instant.now()
+            Instant.now(),
+            null
         );
         assertEquals((int) anomalyDetector.getShingleSize(), 5);
     }
@@ -332,7 +340,8 @@ public class AnomalyDetectorTests extends ESTestCase {
             null,
             null,
             1,
-            Instant.now()
+            Instant.now(),
+            null
         );
         assertEquals((int) anomalyDetector.getShingleSize(), AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE);
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportActionTests.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
 
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
@@ -64,7 +65,7 @@ public class CronTransportActionTests extends AbstractADTest {
 
         TransportService transportService = mock(TransportService.class);
         ActionFilters actionFilters = mock(ActionFilters.class);
-        TransportStateManager tarnsportStatemanager = mock(TransportStateManager.class);
+        NodeStateManager tarnsportStatemanager = mock(NodeStateManager.class);
         ModelManager modelManager = mock(ModelManager.class);
         FeatureManager featureManager = mock(FeatureManager.class);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportActionTests.java
@@ -46,6 +46,7 @@ import org.junit.Before;
 import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
 
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
@@ -69,7 +70,7 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
 
         TransportService transportService = mock(TransportService.class);
         ActionFilters actionFilters = mock(ActionFilters.class);
-        TransportStateManager tarnsportStatemanager = mock(TransportStateManager.class);
+        NodeStateManager tarnsportStatemanager = mock(NodeStateManager.class);
         ModelManager modelManager = mock(ModelManager.class);
         FeatureManager featureManager = mock(FeatureManager.class);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultTransportActionTests.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Before;
+
+import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
+
+import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.breaker.ADCircuitBreakerService;
+import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonMessageAttributes;
+import com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao;
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.ml.ThresholdingResult;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.opendistroforelasticsearch.ad.transport.handler.MultitiEntityResultHandler;
+
+public class EntityResultTransportActionTests extends AbstractADTest {
+    EntityResultTransportAction entityResult;
+    ActionFilters actionFilters;
+    TransportService transportService;
+    ModelManager manager;
+    ADCircuitBreakerService adCircuitBreakerService;
+    MultitiEntityResultHandler anomalyResultHandler;
+    CheckpointDao checkpointDao;
+    CacheProvider entityCache;
+    NodeStateManager stateManager;
+    Settings settings;
+    Clock clock;
+    EntityResultRequest request;
+    String detectorId;
+    long timeoutMs;
+    AnomalyDetector detector;
+    String cacheMissEntity;
+    String cacheHitEntity;
+    long start;
+    long end;
+    Map<String, double[]> entities;
+    double[] cacheMissData;
+    double[] cacheHitData;
+    String tooLongEntity;
+    double[] tooLongData;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        actionFilters = mock(ActionFilters.class);
+        transportService = mock(TransportService.class);
+
+        adCircuitBreakerService = mock(ADCircuitBreakerService.class);
+        when(adCircuitBreakerService.isOpen()).thenReturn(false);
+
+        anomalyResultHandler = mock(MultitiEntityResultHandler.class);
+        checkpointDao = mock(CheckpointDao.class);
+
+        detectorId = "123";
+        entities = new HashMap<>();
+
+        cacheMissEntity = "0.0.0.1";
+        cacheMissData = new double[] { 0.1 };
+        cacheHitEntity = "0.0.0.2";
+        cacheHitData = new double[] { 0.2 };
+        entities.put(cacheMissEntity, cacheMissData);
+        entities.put(cacheHitEntity, cacheHitData);
+        tooLongEntity = randomAlphaOfLength(AnomalyDetectorSettings.MAX_ENTITY_LENGTH + 1);
+        tooLongData = new double[] { 0.3 };
+        entities.put(tooLongEntity, tooLongData);
+        start = 10L;
+        end = 20L;
+        request = new EntityResultRequest(detectorId, entities, start, end);
+
+        manager = mock(ModelManager.class);
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            // return entity name
+            return args[1];
+        }).when(manager).getEntityModelId(anyString(), anyString());
+        when(manager.getAnomalyResultForEntity(anyString(), any(), anyString(), any(), anyString()))
+            .thenReturn(new ThresholdingResult(1, 1, 1));
+
+        entityCache = mock(CacheProvider.class);
+        when(entityCache.get(eq(cacheMissEntity), any(), any(), anyString())).thenReturn(null);
+
+        ModelState<EntityModel> state = mock(ModelState.class);
+        when(entityCache.get(eq(cacheHitEntity), any(), any(), anyString())).thenReturn(state);
+
+        String field = "a";
+        detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList(field));
+        stateManager = mock(NodeStateManager.class);
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.of(detector));
+            return null;
+        }).when(stateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
+        when(stateManager.getLastIndexThrottledTime()).thenReturn(Instant.MIN);
+
+        settings = Settings.builder().put(AnomalyDetectorSettings.COOLDOWN_MINUTES.getKey(), TimeValue.timeValueMinutes(5)).build();
+        clock = mock(Clock.class);
+        when(clock.instant()).thenReturn(Instant.now());
+
+        entityResult = new EntityResultTransportAction(
+            actionFilters,
+            transportService,
+            manager,
+            adCircuitBreakerService,
+            anomalyResultHandler,
+            checkpointDao,
+            entityCache,
+            stateManager,
+            settings,
+            clock
+        );
+
+        // timeout in 60 seconds
+        timeoutMs = 60000L;
+    }
+
+    public void testCircuitBreakerOpen() {
+        when(adCircuitBreakerService.isOpen()).thenReturn(true);
+        PlainActionFuture<AcknowledgedResponse> future = PlainActionFuture.newFuture();
+
+        entityResult.doExecute(null, request, future);
+
+        expectThrows(LimitExceededException.class, () -> future.actionGet(timeoutMs));
+    }
+
+    public void testNormal() {
+        PlainActionFuture<AcknowledgedResponse> future = PlainActionFuture.newFuture();
+
+        entityResult.doExecute(null, request, future);
+
+        future.actionGet(timeoutMs);
+
+        verify(anomalyResultHandler, times(1)).write(any(), any());
+    }
+
+    // test get detector failure
+    @SuppressWarnings("unchecked")
+    public void testFailtoGetDetector() {
+        doAnswer(invocation -> {
+            ActionListener<Optional<AnomalyDetector>> listener = invocation.getArgument(1);
+            listener.onResponse(Optional.empty());
+            return null;
+        }).when(stateManager).getAnomalyDetector(any(String.class), any(ActionListener.class));
+
+        PlainActionFuture<AcknowledgedResponse> future = PlainActionFuture.newFuture();
+
+        entityResult.doExecute(null, request, future);
+
+        expectThrows(EndRunException.class, () -> future.actionGet(timeoutMs));
+    }
+
+    // test index pressure high, anomaly grade is 0
+    public void testIndexPressureHigh() {
+        when(manager.getAnomalyResultForEntity(anyString(), any(), anyString(), any(), anyString()))
+            .thenReturn(new ThresholdingResult(0, 1, 1));
+        when(stateManager.getLastIndexThrottledTime()).thenReturn(Instant.now());
+
+        PlainActionFuture<AcknowledgedResponse> future = PlainActionFuture.newFuture();
+
+        entityResult.doExecute(null, request, future);
+
+        future.actionGet(timeoutMs);
+
+        verify(anomalyResultHandler, never()).write(any(), any());
+    }
+
+    // test rcf score is 0
+    public void testNotInitialized() {
+        when(manager.getAnomalyResultForEntity(anyString(), any(), anyString(), any(), anyString()))
+            .thenReturn(new ThresholdingResult(0, 0, 0));
+
+        PlainActionFuture<AcknowledgedResponse> future = PlainActionFuture.newFuture();
+
+        entityResult.doExecute(null, request, future);
+
+        future.actionGet(timeoutMs);
+
+        verify(anomalyResultHandler, never()).write(any(), any());
+    }
+
+    public void testSerialzationRequest() throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        request.writeTo(output);
+
+        StreamInput streamInput = output.bytes().streamInput();
+        EntityResultRequest readRequest = new EntityResultRequest(streamInput);
+        assertThat(detectorId, equalTo(readRequest.getDetectorId()));
+        assertThat(start, equalTo(readRequest.getStart()));
+        assertThat(end, equalTo(readRequest.getEnd()));
+        assertTrue(areEqualWithArrayValue(entities, readRequest.getEntities()));
+    }
+
+    public void testValidRequest() {
+        ActionRequestValidationException e = request.validate();
+        assertThat(e, equalTo(null));
+    }
+
+    public void testEmptyId() {
+        request = new EntityResultRequest("", entities, start, end);
+        ActionRequestValidationException e = request.validate();
+        assertThat(e.validationErrors(), hasItem(CommonErrorMessages.AD_ID_MISSING_MSG));
+    }
+
+    public void testReverseTime() {
+        request = new EntityResultRequest(detectorId, entities, end, start);
+        ActionRequestValidationException e = request.validate();
+        assertThat(e.validationErrors(), hasItem(startsWith(CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG)));
+    }
+
+    public void testNegativeTime() {
+        request = new EntityResultRequest(detectorId, entities, start, -end);
+        ActionRequestValidationException e = request.validate();
+        assertThat(e.validationErrors(), hasItem(startsWith(CommonErrorMessages.INVALID_TIMESTAMP_ERR_MSG)));
+    }
+
+    public void testJsonResponse() throws IOException, JsonPathNotFoundException {
+        XContentBuilder builder = jsonBuilder();
+        request.toXContent(builder, ToXContent.EMPTY_PARAMS);
+
+        String json = Strings.toString(builder);
+        assertEquals(JsonDeserializer.getTextValue(json, CommonMessageAttributes.ID_JSON_KEY), detectorId);
+        assertEquals(JsonDeserializer.getLongValue(json, CommonMessageAttributes.START_JSON_KEY), start);
+        assertEquals(JsonDeserializer.getLongValue(json, CommonMessageAttributes.END_JSON_KEY), end);
+        assertEquals(0, Double.compare(JsonDeserializer.getArrayValue(json, cacheMissEntity).get(0).getAsDouble(), cacheMissData[0]));
+        assertEquals(0, Double.compare(JsonDeserializer.getArrayValue(json, cacheHitEntity).get(0).getAsDouble(), cacheHitData[0]));
+        assertEquals(0, Double.compare(JsonDeserializer.getArrayValue(json, tooLongEntity).get(0).getAsDouble(), tooLongData[0]));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/NodeStateTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/NodeStateTests.java
@@ -25,18 +25,19 @@ import java.time.Instant;
 
 import org.elasticsearch.test.ESTestCase;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeState;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
 
-public class TransportStateTests extends ESTestCase {
-    private TransportState state;
+public class NodeStateTests extends ESTestCase {
+    private NodeState state;
     private Clock clock;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
         clock = mock(Clock.class);
-        state = new TransportState("123", clock);
+        state = new NodeState("123", clock);
     }
 
     private Duration duration = Duration.ofHours(1);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorActionTests.java
@@ -59,7 +59,7 @@ public class SearchAnomalyDetectorActionTests extends ESIntegTestCase {
     @Test
     public void testSearchResponse() {
         // Will call response.onResponse as Index exists
-        Settings indexSettings = Settings.builder().put("number_of_shards", 5).put("number_of_replicas", 1).build();
+        Settings indexSettings = Settings.builder().put("index.number_of_shards", 5).put("index.number_of_replicas", 1).build();
         CreateIndexRequest indexRequest = new CreateIndexRequest("my-test-index", indexSettings);
         client().admin().indices().create(indexRequest).actionGet();
         SearchRequest searchRequest = new SearchRequest("my-test-index");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ThresholdResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ThresholdResultTests.java
@@ -68,7 +68,7 @@ public class ThresholdResultTests extends ESTestCase {
         ThresholdResultTransportAction action = new ThresholdResultTransportAction(mock(ActionFilters.class), transportService, manager);
         doAnswer(invocation -> {
             ActionListener<ThresholdingResult> listener = invocation.getArgument(3);
-            listener.onResponse(new ThresholdingResult(0, 1.0d));
+            listener.onResponse(new ThresholdingResult(0, 1.0d, 0));
             return null;
         }).when(manager).getThresholdingResult(any(String.class), any(String.class), anyDouble(), any(ActionListener.class));
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/TransportStateManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/TransportStateManagerTests.java
@@ -46,6 +46,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
@@ -54,7 +55,7 @@ import com.amazon.opendistroforelasticsearch.ad.util.Throttler;
 import com.google.common.collect.ImmutableMap;
 
 public class TransportStateManagerTests extends ESTestCase {
-    private TransportStateManager stateManager;
+    private NodeStateManager stateManager;
     private ModelManager modelManager;
     private Client client;
     private ClientUtil clientUtil;
@@ -92,7 +93,7 @@ public class TransportStateManagerTests extends ESTestCase {
         throttler = new Throttler(clock);
 
         clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, mock(ThreadPool.class));
-        stateManager = new TransportStateManager(client, xContentRegistry(), modelManager, settings, clientUtil, clock, duration);
+        stateManager = new NodeStateManager(client, xContentRegistry(), modelManager, settings, clientUtil, clock, duration);
 
         checkpointResponse = mock(GetResponse.class);
     }
@@ -175,7 +176,7 @@ public class TransportStateManagerTests extends ESTestCase {
 
     public void testGetLastError() throws IOException, InterruptedException {
         String error = "blah";
-        assertEquals(TransportStateManager.NO_ERROR, stateManager.getLastDetectionError(adId));
+        assertEquals(NodeStateManager.NO_ERROR, stateManager.getLastDetectionError(adId));
         stateManager.setLastDetectionError(adId, error);
         assertEquals(error, stateManager.getLastDetectionError(adId));
     }
@@ -207,7 +208,7 @@ public class TransportStateManagerTests extends ESTestCase {
     }
 
     public void testHasRunningQuery() throws IOException {
-        stateManager = new TransportStateManager(
+        stateManager = new NodeStateManager(
             client,
             xContentRegistry(),
             modelManager,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandlerTests.java
@@ -55,6 +55,7 @@ import org.mockito.MockitoAnnotations;
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultTests;
@@ -137,10 +138,9 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -175,10 +175,9 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -195,10 +194,9 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -217,10 +215,9 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             settings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -246,7 +243,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
         Settings settings = blocked
             ? Settings.builder().put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true).build()
             : Settings.EMPTY;
-        ClusterState blockedClusterState = createIndexBlockedState(indexName, settings, AnomalyResult.ANOMALY_RESULT_INDEX);
+        ClusterState blockedClusterState = createIndexBlockedState(indexName, settings, CommonName.ANOMALY_RESULT_INDEX_ALIAS);
         when(clusterService.state()).thenReturn(blockedClusterState);
         when(indexNameResolver.concreteIndexNames(any(), any(), any(String.class))).thenReturn(new String[] { indexName });
     }
@@ -296,10 +293,9 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             client,
             backoffSettings,
             threadPool,
-            AnomalyResult.ANOMALY_RESULT_INDEX,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -317,7 +313,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 1);
             ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
             assertTrue(listener != null);
-            listener.onResponse(new CreateIndexResponse(true, true, AnomalyResult.ANOMALY_RESULT_INDEX) {
+            listener.onResponse(new CreateIndexResponse(true, true, CommonName.ANOMALY_RESULT_INDEX_ALIAS) {
             });
             return null;
         }).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectorStateHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectorStateHandlerTests.java
@@ -36,10 +36,10 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
-import com.amazon.opendistroforelasticsearch.ad.transport.TransportStateManager;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.DetectionStateHandler.ErrorStrategy;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
 import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
@@ -52,7 +52,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
     private Client client;
     private String error = "Stopped due to blah";
     private IndexUtils indexUtils;
-    private TransportStateManager stateManager;
+    private NodeStateManager stateManager;
 
     @Override
     public void setUp() throws Exception {
@@ -67,7 +67,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
         indexUtils = mock(IndexUtils.class);
         ClusterService clusterService = mock(ClusterService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
-        stateManager = mock(TransportStateManager.class);
+        stateManager = mock(NodeStateManager.class);
         detectorStateHandler = new DetectionStateHandler(
             client,
             settings,
@@ -145,7 +145,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
     }
 
     public void testUpdateWithFirstChange() {
-        when(stateManager.getLastDetectionError(anyString())).thenReturn(TransportStateManager.NO_ERROR);
+        when(stateManager.getLastDetectionError(anyString())).thenReturn(NodeStateManager.NO_ERROR);
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
             @SuppressWarnings("unchecked")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The coordinating node computes feature vectors for multiple entities within a time interval through a query, finds model host nodes using consistent hashing, and asks model hosting nodes to infer anomaly grade and confidence of the feature vector. 

This PR adds transport actions for model hosting nodes to infer the feature vector's anomaly grade and confidence. Model hosting nodes proceed entity features in a loop.  We first check if the entity’s models are in memory. If yes, we use the model to infer anomaly grade and save them.  If no, we skip the entity. 

Other dependent changes:
1. Move the result index name to a central place. Previously, we had two copies of the same name that are referred to in various places.
2. Rename TransportStateManager to NodeStateManager as not just the transport layer needs to access those states now.
3. Create interface CleanState, MaintenanceState, ExpiringState for code reuse and better documentation.
4. Add EntityModel to represent the name and value pair of an entity in the anomaly result.
5. Add rcf score in ThresholdingResult so that we can use its value to check if we need to save an anomaly result or not. If the model is not initialized, rcf score is 0, and we don't need to keep the anomaly result. If we don't do it, there would be a lot of EsRejectedExecutionException.

Testing done:
1. add unit tests to cover the newly added transport actions
2. end-to-end testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
