### PR TITLE
Choose the number of primary shards while creating indices

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/DiscoveryNodeFilterer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/DiscoveryNodeFilterer.java
@@ -62,6 +62,14 @@ public class DiscoveryNodeFilterer {
     }
 
     /**
+     *
+     * @return the number of eligible data nodes
+     */
+    public int getNumberOfEligibleDataNodes() {
+        return getEligibleDataNodes().length;
+    }
+
+    /**
      * @param node a discovery node
      * @return whether we should use this node for AD
      */

--- a/src/main/resources/mappings/anomaly-detectors.json
+++ b/src/main/resources/mappings/anomaly-detectors.json
@@ -103,6 +103,9 @@
     "ui_metadata": {
       "type": "object",
       "enabled": false
+    },
+    "category_field": {
+      "type": "keyword"
     }
   }
 }

--- a/src/main/resources/mappings/anomaly-results.json
+++ b/src/main/resources/mappings/anomaly-results.json
@@ -48,6 +48,17 @@
     },
     "error": {
       "type": "text"
+    },
+    "entity": {
+      "type": "nested",
+      "properties": {
+        "name": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword"
+        }
+      }
     }
   }
 }

--- a/src/main/resources/mappings/checkpoint.json
+++ b/src/main/resources/mappings/checkpoint.json
@@ -1,0 +1,18 @@
+{
+  "dynamic": true,
+  "_meta": {
+    "schema_version": 1
+  },
+  "properties": {
+    "detectorId": {
+      "type": "keyword"
+    },
+    "model": {
+      "type": "text"
+    },
+    "timestamp": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    }
+  }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndicesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndicesTests.java
@@ -34,12 +34,14 @@ import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 
 public class AnomalyDetectionIndicesTests extends ESIntegTestCase {
 
     private AnomalyDetectionIndices indices;
     private Settings settings;
+    private DiscoveryNodeFilterer nodeFilter;
 
     // help register setting using AnomalyDetectorPlugin.getSettings. Otherwise, AnomalyDetectionIndices's constructor would fail due to
     // unregistered settings like AD_RESULT_HISTORY_MAX_DOCS.
@@ -58,7 +60,9 @@ public class AnomalyDetectionIndicesTests extends ESIntegTestCase {
             .put("opendistro.anomaly_detection.request_timeout", TimeValue.timeValueSeconds(10))
             .build();
 
-        indices = new AnomalyDetectionIndices(client(), clusterService(), client().threadPool(), settings);
+        nodeFilter = new DiscoveryNodeFilterer(clusterService());
+
+        indices = new AnomalyDetectionIndices(client(), clusterService(), client().threadPool(), settings, nodeFilter);
     }
 
     public void testAnomalyDetectorIndexNotExists() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/InitAnomalyDetectionIndicesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/InitAnomalyDetectionIndicesTests.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.indices;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.client.AdminClient;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.client.IndicesAdminClient;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.mockito.ArgumentCaptor;
+
+import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
+
+public class InitAnomalyDetectionIndicesTests extends AbstractADTest {
+    Client client;
+    ClusterService clusterService;
+    ThreadPool threadPool;
+    Settings settings;
+    DiscoveryNodeFilterer nodeFilter;
+    AnomalyDetectionIndices adIndices;
+    ClusterName clusterName;
+    ClusterState clusterState;
+    IndicesAdminClient indicesClient;
+    int numberOfHotNodes;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        client = mock(Client.class);
+        indicesClient = mock(IndicesAdminClient.class);
+        AdminClient adminClient = mock(AdminClient.class);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesClient);
+
+        clusterService = mock(ClusterService.class);
+        threadPool = mock(ThreadPool.class);
+
+        numberOfHotNodes = 4;
+        nodeFilter = mock(DiscoveryNodeFilterer.class);
+        when(nodeFilter.getNumberOfEligibleDataNodes()).thenReturn(numberOfHotNodes);
+
+        Settings settings = Settings.EMPTY;
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Collections
+                .unmodifiableSet(
+                    new HashSet<>(
+                        Arrays
+                            .asList(
+                                AnomalyDetectorSettings.AD_RESULT_HISTORY_MAX_DOCS,
+                                AnomalyDetectorSettings.AD_RESULT_HISTORY_ROLLOVER_PERIOD,
+                                AnomalyDetectorSettings.AD_RESULT_HISTORY_RETENTION_PERIOD,
+                                AnomalyDetectorSettings.MAX_PRIMARY_SHARDS
+                            )
+                    )
+                )
+        );
+
+        clusterName = new ClusterName("test");
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        clusterState = ClusterState.builder(clusterName).metadata(Metadata.builder().build()).build();
+        when(clusterService.state()).thenReturn(clusterState);
+
+        adIndices = new AnomalyDetectionIndices(client, clusterService, threadPool, settings, nodeFilter);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void fixedPrimaryShardsIndexCreationTemplate(String index) throws IOException {
+        doAnswer(invocation -> {
+            CreateIndexRequest request = invocation.getArgument(0);
+            assertEquals(index, request.index());
+
+            ActionListener<CreateIndexResponse> listener = (ActionListener<CreateIndexResponse>) invocation.getArgument(1);
+
+            listener.onResponse(new CreateIndexResponse(true, true, index));
+            return null;
+        }).when(indicesClient).create(any(), any());
+
+        ActionListener<CreateIndexResponse> listener = mock(ActionListener.class);
+        if (index.equals(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
+            adIndices.initAnomalyDetectorIndexIfAbsent(listener);
+        } else {
+            adIndices.initDetectorStateIndex(listener);
+        }
+
+        ArgumentCaptor<CreateIndexResponse> captor = ArgumentCaptor.forClass(CreateIndexResponse.class);
+        verify(listener).onResponse(captor.capture());
+        CreateIndexResponse result = captor.getValue();
+        assertEquals(index, result.index());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void fixedPrimaryShardsIndexNoCreationTemplate(String index, String alias) throws IOException {
+        clusterState = mock(ClusterState.class);
+        when(clusterService.state()).thenReturn(clusterState);
+
+        RoutingTable.Builder rb = RoutingTable.builder();
+        rb.addAsNew(indexMeta(index, 1L));
+        when(clusterState.getRoutingTable()).thenReturn(rb.build());
+
+        Metadata.Builder mb = Metadata.builder();
+        mb.put(indexMeta(".opendistro-anomaly-results-history-2020.06.24-000003", 1L, CommonName.ANOMALY_RESULT_INDEX_ALIAS), true);
+
+        ActionListener<CreateIndexResponse> listener = mock(ActionListener.class);
+        if (index.equals(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
+            adIndices.initAnomalyDetectorIndexIfAbsent(listener);
+        } else {
+            adIndices.initAnomalyResultIndexIfAbsent(listener);
+        }
+
+        verify(indicesClient, never()).create(any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void adaptivePrimaryShardsIndexCreationTemplate(String index) throws IOException {
+
+        doAnswer(invocation -> {
+            CreateIndexRequest request = invocation.getArgument(0);
+            if (index.equals(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
+                assertTrue(request.aliases().contains(new Alias(CommonName.ANOMALY_RESULT_INDEX_ALIAS)));
+            } else {
+                assertEquals(index, request.index());
+            }
+
+            Settings settings = request.settings();
+            assertThat(settings.get("index.number_of_shards"), equalTo(Integer.toString(numberOfHotNodes)));
+
+            ActionListener<CreateIndexResponse> listener = (ActionListener<CreateIndexResponse>) invocation.getArgument(1);
+
+            listener.onResponse(new CreateIndexResponse(true, true, index));
+            return null;
+        }).when(indicesClient).create(any(), any());
+
+        ActionListener<CreateIndexResponse> listener = mock(ActionListener.class);
+        if (index.equals(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
+            adIndices.initAnomalyDetectorIndexIfAbsent(listener);
+        } else if (index.equals(DetectorInternalState.DETECTOR_STATE_INDEX)) {
+            adIndices.initDetectorStateIndex(listener);
+        } else if (index.equals(CommonName.CHECKPOINT_INDEX_NAME)) {
+            adIndices.initCheckpointIndex(listener);
+        } else if (index.equals(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)) {
+            adIndices.initAnomalyDetectorJobIndex(listener);
+        } else {
+            adIndices.initAnomalyResultIndexIfAbsent(listener);
+        }
+
+        ArgumentCaptor<CreateIndexResponse> captor = ArgumentCaptor.forClass(CreateIndexResponse.class);
+        verify(listener).onResponse(captor.capture());
+        CreateIndexResponse result = captor.getValue();
+        assertEquals(index, result.index());
+    }
+
+    public void testNotCreateDetector() throws IOException {
+        fixedPrimaryShardsIndexNoCreationTemplate(AnomalyDetector.ANOMALY_DETECTORS_INDEX, null);
+    }
+
+    public void testNotCreateResult() throws IOException {
+        fixedPrimaryShardsIndexNoCreationTemplate(AnomalyDetector.ANOMALY_DETECTORS_INDEX, null);
+    }
+
+    public void testCreateDetector() throws IOException {
+        fixedPrimaryShardsIndexCreationTemplate(AnomalyDetector.ANOMALY_DETECTORS_INDEX);
+    }
+
+    public void testCreateState() throws IOException {
+        fixedPrimaryShardsIndexCreationTemplate(DetectorInternalState.DETECTOR_STATE_INDEX);
+    }
+
+    public void testCreateJob() throws IOException {
+        adaptivePrimaryShardsIndexCreationTemplate(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX);
+    }
+
+    public void testCreateResult() throws IOException {
+        adaptivePrimaryShardsIndexCreationTemplate(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+    }
+
+    public void testCreateCheckpoint() throws IOException {
+        adaptivePrimaryShardsIndexCreationTemplate(CommonName.CHECKPOINT_INDEX_NAME);
+    }
+}


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*
AD is bottle-necked by the number of primary shards of job, result, and checkpoint index in HC.  The number of primary shards in the job index determines how many nodes can run as AD's coordinating nodes.  The number of primary shards in the result and checkpoint index determines the extent of index pressure given the same indexing workload. 

Previously, we used the default setting: in ODFE, the number is 1; in AES, the number is 5. This PR uses the number of hot nodes as the number of primary shards for the checkpoint, result, and job index . The upper limit is 10.

Testing done:
1. added unit tests.
2. end-to-end testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
