### PR TITLE
Add caching

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBuffer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBuffer.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.amazon.opendistroforelasticsearch.ad.ExpiringState;
 import com.amazon.opendistroforelasticsearch.ad.MaintenanceState;
 import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
 import com.amazon.opendistroforelasticsearch.ad.MemoryTracker.Origin;
@@ -39,7 +40,6 @@ import com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao;
 import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
 import com.amazon.opendistroforelasticsearch.ad.model.InitProgressProfile;
-import com.amazon.opendistroforelasticsearch.ad.util.ExpiringState;
 
 /**
  * We use a layered cache to manage active entities’ states.  We have a two-level

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBuffer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBuffer.java
@@ -1,0 +1,515 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.caching;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Comparator;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.amazon.opendistroforelasticsearch.ad.MaintenanceState;
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker.Origin;
+import com.amazon.opendistroforelasticsearch.ad.annotation.Generated;
+import com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao;
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.model.InitProgressProfile;
+import com.amazon.opendistroforelasticsearch.ad.util.ExpiringState;
+
+/**
+ * We use a layered cache to manage active entities’ states.  We have a two-level
+ * cache that stores active entity states in each node.  Each detector has its
+ * dedicated cache that stores ten (dynamically adjustable) entities’ states per
+ * node.  A detector’s hottest entities load their states in the dedicated cache.
+ * If less than 10 entities use the dedicated cache, the secondary cache can use
+ * the rest of the free memory available to AD.  The secondary cache is a shared
+ * memory among all detectors for the long tail.  The shared cache size is 10%
+ * heap minus all of the dedicated cache consumed by single-entity and multi-entity
+ * detectors.  The shared cache’s size shrinks as the dedicated cache is filled
+ * up or more detectors are started.
+ */
+public class CacheBuffer implements ExpiringState, MaintenanceState {
+    private static final Logger LOG = LogManager.getLogger(CacheBuffer.class);
+
+    static class PriorityNode {
+        private String key;
+        private float priority;
+
+        PriorityNode(String key, float priority) {
+            this.priority = priority;
+            this.key = key;
+        }
+
+        @Generated
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            if (obj instanceof PriorityNode) {
+                PriorityNode other = (PriorityNode) obj;
+
+                EqualsBuilder equalsBuilder = new EqualsBuilder();
+                equalsBuilder.append(key, other.key);
+                return equalsBuilder.isEquals();
+            }
+            return false;
+        }
+
+        @Generated
+        @Override
+        public int hashCode() {
+            return new HashCodeBuilder().append(key).toHashCode();
+        }
+
+        @Generated
+        @Override
+        public String toString() {
+            ToStringBuilder builder = new ToStringBuilder(this);
+            builder.append("key", key);
+            builder.append("priority", priority);
+            return builder.toString();
+        }
+    }
+
+    static class PriorityNodeComparator implements Comparator<PriorityNode> {
+
+        @Override
+        public int compare(PriorityNode priority, PriorityNode priority2) {
+            int cmp = Float.compare(priority.priority, priority2.priority);
+            if (cmp == 0) {
+                cmp = priority.key.compareTo(priority2.key);
+            }
+            return cmp;
+        }
+    }
+
+    private final int minimumCapacity;
+    // key -> Priority node
+    private final ConcurrentHashMap<String, PriorityNode> key2Priority;
+    private final ConcurrentSkipListSet<PriorityNode> priorityList;
+    // key -> value
+    private final ConcurrentHashMap<String, ModelState<EntityModel>> items;
+    // when detector is created.  Can be reset.  Unit: seconds
+    private long landmarkSecs;
+    // length of seconds in one interval.  Used to compute elapsed periods
+    // since the detector has been enabled.
+    private long intervalSecs;
+    // memory consumption per entity
+    private final long memoryConsumptionPerEntity;
+    private final MemoryTracker memoryTracker;
+    private final Clock clock;
+    private final CheckpointDao checkpointDao;
+    private final Duration modelTtl;
+    private final String detectorId;
+    private Instant lastUsedTime;
+    private final int decayConstant;
+    private final long reservedBytes;
+
+    public CacheBuffer(
+        int minimumCapacity,
+        long intervalSecs,
+        CheckpointDao checkpointDao,
+        long memoryConsumptionPerEntity,
+        MemoryTracker memoryTracker,
+        Clock clock,
+        Duration modelTtl,
+        String detectorId
+    ) {
+        this.minimumCapacity = minimumCapacity;
+        this.key2Priority = new ConcurrentHashMap<>();
+        this.priorityList = new ConcurrentSkipListSet<>(new PriorityNodeComparator());
+        this.items = new ConcurrentHashMap<>();
+        this.landmarkSecs = clock.instant().getEpochSecond();
+        this.intervalSecs = intervalSecs;
+        this.memoryConsumptionPerEntity = memoryConsumptionPerEntity;
+        this.memoryTracker = memoryTracker;
+        this.clock = clock;
+        this.checkpointDao = checkpointDao;
+        this.modelTtl = modelTtl;
+        this.detectorId = detectorId;
+        this.lastUsedTime = clock.instant();
+        this.decayConstant = 3;
+        this.reservedBytes = memoryConsumptionPerEntity * minimumCapacity;
+    }
+
+    /**
+     * Update step at period t_k:
+     * new priority = old priority + log(1+e^{\log(g(t_k-L))-old priority}) where g(n) = e^{0.125n},
+     * and n is the period.
+     * @param entityId model Id
+     */
+    private void update(String entityId) {
+        PriorityNode node = key2Priority.computeIfAbsent(entityId, k -> new PriorityNode(entityId, 0f));
+        // reposition this node
+        this.priorityList.remove(node);
+        node.priority = getUpdatedPriority(node.priority);
+        this.priorityList.add(node);
+
+        Instant now = clock.instant();
+        items.get(entityId).setLastUsedTime(now);
+        lastUsedTime = now;
+    }
+
+    public float getUpdatedPriority(float oldPriority) {
+        long increment = computeWeightedCountIncrement();
+        // if overflowed, we take the short cut from now on
+
+        oldPriority += Math.log(1 + Math.exp(increment - oldPriority));
+        // if overflow happens, using \log(g(t_k-L)) instead.
+        if (oldPriority == Float.POSITIVE_INFINITY) {
+            oldPriority = increment;
+        }
+        return oldPriority;
+    }
+
+    /**
+     * Compute periods relative to landmark and the weighted count increment using 0.125n.
+     * Multiply by 0.125 is implemented using right shift for efficiency.
+     * @return the weighted count increment used in the priority update step.
+     */
+    private long computeWeightedCountIncrement() {
+        long periods = (clock.instant().getEpochSecond() - landmarkSecs) / intervalSecs;
+        return periods >> decayConstant;
+    }
+
+    /**
+     * Compute the weighted total count by considering landmark
+     * \log(C)=\log(\sum_{i=1}^{n} (g(t_i-L)/g(t-L)))=\log(\sum_{i=1}^{n} (g(t_i-L))-\log(g(t-L))
+     * @return the minimum priority entity's ID and priority
+     */
+    public Entry<String, Float> getMinimumPriority() {
+        PriorityNode smallest = priorityList.first();
+        long periods = (clock.instant().getEpochSecond() - landmarkSecs) / intervalSecs;
+        float detectorWeight = periods >> decayConstant;
+        return new SimpleImmutableEntry<>(smallest.key, smallest.priority - detectorWeight);
+    }
+
+    /**
+     * Insert the model state associated with a model Id to the cache
+     * @param entityId the model Id
+     * @param value the ModelState
+     */
+    public void put(String entityId, ModelState<EntityModel> value) {
+        // race conditions can happen between the put and one of the following operations:
+        // remove: not a problem as it is unlikely we are removing and putting the same thing
+        // maintenance: not a problem as we are unlikely to maintain an entry that's not
+        // already in the cache
+        // clear: not a problem as we are releasing memory in MemoryTracker.
+        // The newly added one loses references and soon GC will collect it.
+        // We have memory tracking correction to fix incorrect memory usage record.
+        // put from other threads: not a problem as the entry is associated with
+        // entityId and our put is idempotent
+        put(entityId, value, value.getPriority());
+    }
+
+    /**
+    * Insert the model state associated with a model Id to the cache.  Update priority.
+    * @param entityId the model Id
+    * @param value the ModelState
+    * @param priority the priority
+    */
+    private void put(String entityId, ModelState<EntityModel> value, float priority) {
+        if (minimumCapacity <= 0) {
+            return;
+        }
+        ModelState<EntityModel> contentNode = items.get(entityId);
+        if (contentNode == null) {
+            PriorityNode node = new PriorityNode(entityId, priority);
+            key2Priority.put(entityId, node);
+            priorityList.add(node);
+            items.put(entityId, value);
+            Instant now = clock.instant();
+            value.setLastUsedTime(now);
+            lastUsedTime = now;
+            // shared cache empty means we are consuming reserved cache.
+            // Since we have already considered them while allocating CacheBuffer,
+            // skip bookkeeping.
+            if (!sharedCacheEmpty()) {
+                memoryTracker.consumeMemory(memoryConsumptionPerEntity, false, Origin.MULTI_ENTITY_DETECTOR);
+            }
+        } else {
+            update(entityId);
+            items.put(entityId, value);
+        }
+    }
+
+    /**
+     * Retrieve the ModelState associated with the model Id or null if the CacheBuffer
+     * contains no mapping for the model Id
+     * @param key the model Id
+     * @return the Model state to which the specified model Id is mapped, or null
+     * if this CacheBuffer contains no mapping for the model Id
+     */
+    public ModelState<EntityModel> get(String key) {
+        // We can get an item that is to be removed soon due to race condition.
+        // This is acceptable as it won't cause any corruption and exception.
+        // And this item is used for scoring one last time.
+        ModelState<EntityModel> node = items.get(key);
+        if (node == null) {
+            return null;
+        }
+        update(key);
+        return node;
+    }
+
+    /**
+     *
+     * @return whether there is one item that can be removed from shared cache
+     */
+    public boolean canRemove() {
+        return !items.isEmpty() && items.size() > minimumCapacity;
+    }
+
+    /**
+     * remove the smallest priority item.
+     */
+    public void remove() {
+        // race conditions can happen between the put and one of the following operations:
+        // remove from other threads: not a problem. If they remove the same item,
+        // our method is idempotent. If they remove two different items,
+        // they don't impact each other.
+        // maintenance: not a problem as all of the data structures are concurrent.
+        // Two threads removing the same entry is not a problem.
+        // clear: not a problem as we are releasing memory in MemoryTracker.
+        // The removed one loses references and soon GC will collect it.
+        // We have memory tracking correction to fix incorrect memory usage record.
+        // put: not a problem as it is unlikely we are removing and putting the same thing
+        PriorityNode smallest = priorityList.pollFirst();
+        if (smallest != null) {
+            remove(smallest.key);
+        }
+    }
+
+    /**
+     * Remove everything associated with the key and make a checkpoint.
+     *
+     * @param keyToRemove The key to remove
+     * @return the associated ModelState associated with the key, or null if there
+     * is no associated ModelState for the key
+     */
+    public ModelState<EntityModel> remove(String keyToRemove) {
+        // if shared cache is empty, we are using reserved memory
+        boolean reserved = sharedCacheEmpty();
+
+        key2Priority.remove(keyToRemove);
+        ModelState<EntityModel> valueRemoved = items.remove(keyToRemove);
+
+        if (valueRemoved != null) {
+            // if we releasing a shared cache item, release memory as well.
+            if (!reserved) {
+                memoryTracker.releaseMemory(memoryConsumptionPerEntity, false, Origin.MULTI_ENTITY_DETECTOR);
+            }
+            checkpointDao.write(valueRemoved, keyToRemove);
+        }
+
+        return valueRemoved;
+    }
+
+    /**
+     * @return whether dedicated cache is available or not
+     */
+    public boolean dedicatedCacheAvailable() {
+        return items.size() < minimumCapacity;
+    }
+
+    /**
+     * @return whether shared cache is empty or not
+     */
+    public boolean sharedCacheEmpty() {
+        return items.size() <= minimumCapacity;
+    }
+
+    /**
+     *
+     * @return the estimated number of bytes per entity state
+     */
+    public long getMemoryConsumptionPerEntity() {
+        return memoryConsumptionPerEntity;
+    }
+
+    /**
+     *
+     * If the cache is not full, check if some other items can replace internal entities.
+     * @param priority another entity's priority
+     * @return whether one entity can be replaced by another entity with a certain priority
+     */
+    public boolean canReplace(float priority) {
+        return !items.isEmpty() && priority > getMinimumPriority().getValue();
+    }
+
+    /**
+     * Replace the smallest priority entity with the input entity
+     * @param entityId the Model Id
+     * @param value the model State
+     */
+    public void replace(String entityId, ModelState<EntityModel> value) {
+        remove();
+        put(entityId, value);
+    }
+
+    @Override
+    public void maintenance() {
+        items.entrySet().stream().forEach(entry -> {
+            String entityId = entry.getKey();
+            try {
+                ModelState<EntityModel> modelState = entry.getValue();
+                Instant now = clock.instant();
+
+                // we can have ConcurrentModificationException when serializing
+                // and updating rcf model at the same time. To prevent this,
+                // we need to have a deep copy of models or have a lock. Both
+                // options are costly.
+                // As we are gonna retry serializing either when the entity is
+                // evicted out of cache or during the next maintenance period,
+                // don't do anything when the exception happens.
+                checkpointDao.write(modelState, entityId);
+
+                if (modelState.getLastUsedTime().plus(modelTtl).isBefore(now)) {
+                    // race conditions can happen between the put and one of the following operations:
+                    // remove: not a problem as all of the data structures are concurrent.
+                    // Two threads removing the same entry is not a problem.
+                    // clear: not a problem as we are releasing memory in MemoryTracker.
+                    // The removed one loses references and soon GC will collect it.
+                    // We have memory tracking correction to fix incorrect memory usage record.
+                    // put: not a problem as we are unlikely to maintain an entry that's not
+                    // already in the cache
+                    priorityList.remove(new PriorityNode(entityId, modelState.getPriority()));
+                    remove(entityId);
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to finish maintenance for model id " + entityId, e);
+            }
+        });
+    }
+
+    /**
+     *
+     * @return the number of active entities
+     */
+    public int getActiveEntities() {
+        return items.size();
+    }
+
+    /**
+     *
+     * @param entityId Model Id
+     * @return Whether the model is active or not
+     */
+    public boolean isActive(String entityId) {
+        return items.containsKey(entityId);
+    }
+
+    /**
+     *
+     * @return Get the model of highest priority entity
+     */
+    public Optional<String> getHighestPriorityEntityId() {
+        return Optional.of(priorityList).map(list -> list.last()).map(node -> node.key);
+    }
+
+    /**
+     *
+     * @param entityId entity Id
+     * @return Get the model of an entity
+     */
+    public Optional<EntityModel> getModel(String entityId) {
+        return Optional.of(items).map(map -> map.get(entityId)).map(state -> state.getModel());
+    }
+
+    /**
+     * Clear associated memory.  Used when we are removing an detector.
+     */
+    public void clear() {
+        // race conditions can happen between the put and remove/maintenance/put:
+        // not a problem as we are releasing memory in MemoryTracker.
+        // The newly added one loses references and soon GC will collect it.
+        // We have memory tracking correction to fix incorrect memory usage record.
+
+        memoryTracker.releaseMemory(getReservedBytes(), true, Origin.MULTI_ENTITY_DETECTOR);
+        if (!sharedCacheEmpty()) {
+            memoryTracker.releaseMemory(getBytesInSharedCache(), false, Origin.MULTI_ENTITY_DETECTOR);
+        }
+    }
+
+    /**
+     *
+     * @return reserved bytes by the CacheBuffer
+     */
+    public long getReservedBytes() {
+        return reservedBytes;
+    }
+
+    /**
+     *
+     * @return bytes consumed in the shared cache by the CacheBuffer
+     */
+    public long getBytesInSharedCache() {
+        int sharedCacheEntries = items.size() - minimumCapacity;
+        if (sharedCacheEntries > 0) {
+            return memoryConsumptionPerEntity * sharedCacheEntries;
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        if (obj instanceof InitProgressProfile) {
+            CacheBuffer other = (CacheBuffer) obj;
+
+            EqualsBuilder equalsBuilder = new EqualsBuilder();
+            equalsBuilder.append(detectorId, other.detectorId);
+
+            return equalsBuilder.isEquals();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(detectorId).toHashCode();
+    }
+
+    @Override
+    public boolean expired(Duration stateTtl) {
+        return expired(lastUsedTime, stateTtl, clock.instant());
+    }
+
+    public String getDetectorId() {
+        return detectorId;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBuffer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBuffer.java
@@ -131,7 +131,7 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
     private final Duration modelTtl;
     private final String detectorId;
     private Instant lastUsedTime;
-    private final int decayConstant;
+    private final int DECAY_CONSTANT;
     private final long reservedBytes;
 
     public CacheBuffer(
@@ -160,7 +160,7 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
         this.modelTtl = modelTtl;
         this.detectorId = detectorId;
         this.lastUsedTime = clock.instant();
-        this.decayConstant = 3;
+        this.DECAY_CONSTANT = 3;
         this.reservedBytes = memoryConsumptionPerEntity * minimumCapacity;
     }
 
@@ -200,7 +200,7 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
      */
     private long computeWeightedCountIncrement() {
         long periods = (clock.instant().getEpochSecond() - landmarkSecs) / intervalSecs;
-        return periods >> decayConstant;
+        return periods >> DECAY_CONSTANT;
     }
 
     /**
@@ -211,7 +211,7 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
     public Entry<String, Float> getMinimumPriority() {
         PriorityNode smallest = priorityList.first();
         long periods = (clock.instant().getEpochSecond() - landmarkSecs) / intervalSecs;
-        float detectorWeight = periods >> decayConstant;
+        float detectorWeight = periods >> DECAY_CONSTANT;
         return new SimpleImmutableEntry<>(smallest.key, smallest.priority - detectorWeight);
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheProvider.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.caching;
+
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+
+/**
+ * A wrapper to call concrete implementation of caching.  Used in transport
+ * action.  Don't use interface because transport action handler constructor
+ * requires a concrete class as input.
+ *
+ */
+public class CacheProvider implements EntityCache {
+    private EntityCache delegate;
+
+    public CacheProvider(EntityCache delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ModelState<EntityModel> get(String modelId, AnomalyDetector detector, double[] datapoint, String entityName) {
+        return delegate.get(modelId, detector, datapoint, entityName);
+    }
+
+    @Override
+    public void maintenance() {
+        delegate.maintenance();
+    }
+
+    @Override
+    public void clear(String detectorId) {
+        delegate.clear(detectorId);
+    }
+
+    @Override
+    public int getActiveEntities(String detector) {
+        return delegate.getActiveEntities(detector);
+    }
+
+    @Override
+    public boolean isActive(String detectorId, String entityId) {
+        return delegate.isActive(detectorId, entityId);
+    }
+
+    @Override
+    public long getTotalUpdates(String detectorId) {
+        return delegate.getTotalUpdates(detectorId);
+    }
+
+    @Override
+    public long getTotalUpdates(String detectorId, String entityId) {
+        return delegate.getTotalUpdates(detectorId, entityId);
+    }
+
+    @Override
+    public int getTotalActiveEntities() {
+        return delegate.getTotalActiveEntities();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheProvider.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheProvider.java
@@ -15,9 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.caching;
 
-import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
-import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
-import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import org.elasticsearch.common.inject.Provider;
 
 /**
  * A wrapper to call concrete implementation of caching.  Used in transport
@@ -25,50 +23,15 @@ import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
  * requires a concrete class as input.
  *
  */
-public class CacheProvider implements EntityCache {
-    private EntityCache delegate;
+public class CacheProvider implements Provider<EntityCache> {
+    private EntityCache cache;
 
-    public CacheProvider(EntityCache delegate) {
-        this.delegate = delegate;
+    public CacheProvider(EntityCache cache) {
+        this.cache = cache;
     }
 
     @Override
-    public ModelState<EntityModel> get(String modelId, AnomalyDetector detector, double[] datapoint, String entityName) {
-        return delegate.get(modelId, detector, datapoint, entityName);
-    }
-
-    @Override
-    public void maintenance() {
-        delegate.maintenance();
-    }
-
-    @Override
-    public void clear(String detectorId) {
-        delegate.clear(detectorId);
-    }
-
-    @Override
-    public int getActiveEntities(String detector) {
-        return delegate.getActiveEntities(detector);
-    }
-
-    @Override
-    public boolean isActive(String detectorId, String entityId) {
-        return delegate.isActive(detectorId, entityId);
-    }
-
-    @Override
-    public long getTotalUpdates(String detectorId) {
-        return delegate.getTotalUpdates(detectorId);
-    }
-
-    @Override
-    public long getTotalUpdates(String detectorId, String entityId) {
-        return delegate.getTotalUpdates(detectorId, entityId);
-    }
-
-    @Override
-    public int getTotalActiveEntities() {
-        return delegate.getTotalActiveEntities();
+    public EntityCache get() {
+        return cache;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/DoorKeeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/DoorKeeper.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.caching;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import com.amazon.opendistroforelasticsearch.ad.MaintenanceState;
+import com.amazon.opendistroforelasticsearch.ad.util.ExpiringState;
+import com.google.common.base.Charsets;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
+
+/**
+ * A bloom filter placed in front of inactive entity cache to
+ * filter out unpopular items that are not likely to appear more
+ * than once.
+ *
+ * Reference: https://arxiv.org/abs/1512.00727
+ *
+ */
+public class DoorKeeper implements MaintenanceState, ExpiringState {
+    // stores entity's model id
+    private BloomFilter<String> bloomFilter;
+    // the number of expected insertions to the constructed BloomFilter<T>; must be positive
+    private final long expectedInsertions;
+    // the desired false positive probability (must be positive and less than 1.0)
+    private final double fpp;
+    private Instant lastMaintenanceTime;
+    private final Duration resetInterval;
+    private final Clock clock;
+    private Instant lastAccessTime;
+
+    public DoorKeeper(long expectedInsertions, double fpp, Duration resetInterval, Clock clock) {
+        this.expectedInsertions = expectedInsertions;
+        this.fpp = fpp;
+        this.resetInterval = resetInterval;
+        this.clock = clock;
+        this.lastAccessTime = clock.instant();
+        maintenance();
+    }
+
+    public boolean mightContain(String modelId) {
+        this.lastAccessTime = clock.instant();
+        return bloomFilter.mightContain(modelId);
+    }
+
+    public boolean put(String modelId) {
+        this.lastAccessTime = clock.instant();
+        return bloomFilter.put(modelId);
+    }
+
+    /**
+     * We reset the bloom filter when bloom filter is null or it is state ttl is reached
+     */
+    @Override
+    public void maintenance() {
+        if (bloomFilter == null || lastMaintenanceTime.plus(resetInterval).isBefore(clock.instant())) {
+            bloomFilter = BloomFilter.create(Funnels.stringFunnel(Charsets.US_ASCII), expectedInsertions, fpp);
+            lastMaintenanceTime = Instant.now();
+        }
+    }
+
+    @Override
+    public boolean expired(Duration stateTtl) {
+        return expired(lastAccessTime, stateTtl, clock.instant());
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/DoorKeeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/DoorKeeper.java
@@ -71,7 +71,7 @@ public class DoorKeeper implements MaintenanceState, ExpiringState {
     public void maintenance() {
         if (bloomFilter == null || lastMaintenanceTime.plus(resetInterval).isBefore(clock.instant())) {
             bloomFilter = BloomFilter.create(Funnels.stringFunnel(Charsets.US_ASCII), expectedInsertions, fpp);
-            lastMaintenanceTime = Instant.now();
+            lastMaintenanceTime = clock.instant();
         }
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/DoorKeeper.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/DoorKeeper.java
@@ -19,8 +19,8 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 
+import com.amazon.opendistroforelasticsearch.ad.ExpiringState;
 import com.amazon.opendistroforelasticsearch.ad.MaintenanceState;
-import com.amazon.opendistroforelasticsearch.ad.util.ExpiringState;
 import com.google.common.base.Charsets;
 import com.google.common.hash.BloomFilter;
 import com.google.common.hash.Funnels;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/EntityCache.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/EntityCache.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.caching;
+
+import com.amazon.opendistroforelasticsearch.ad.CleanState;
+import com.amazon.opendistroforelasticsearch.ad.MaintenanceState;
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+
+public interface EntityCache extends MaintenanceState, CleanState {
+    /**
+     * Get the ModelState associated with the entity.  May or may not load the
+     * ModelState depending on the underlying cache's eviction policy.
+     *
+     * @param modelId Model Id
+     * @param detector Detector config object
+     * @param datapoint The most recent data point
+     * @param entityName The Entity's name
+     * @return the ModelState associated with the model or null if no cached item
+     * for the entity
+     */
+    ModelState<EntityModel> get(String modelId, AnomalyDetector detector, double[] datapoint, String entityName);
+
+    /**
+     * Get the number of active entities of a detector
+     * @param detector Detector Id
+     * @return The number of active entities
+     */
+    int getActiveEntities(String detector);
+
+    /**
+      *
+      * @return total active entities in the cache
+    */
+    int getTotalActiveEntities();
+
+    /**
+     * Whether an entity is active or not
+     * @param detectorId The Id of the detector that an entity belongs to
+     * @param entityId Entity Id
+     * @return Whether an entity is active or not
+     */
+    boolean isActive(String detectorId, String entityId);
+
+    /**
+     * Get total updates of detector's most active entity's RCF model.
+     *
+     * @param detectorId detector id
+     * @return RCF model total updates of most active entity
+     */
+    long getTotalUpdates(String detectorId);
+
+    /**
+     * Get RCF model total updates of specific entity
+     *
+     * @param detectorId detector id
+     * @param entityId  entity id
+     * @return RCF model total updates of specific entity
+     */
+    long getTotalUpdates(String detectorId, String entityId);
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCache.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCache.java
@@ -439,6 +439,13 @@ public class PriorityCache implements EntityCache {
         memoryTracker.syncMemoryState(Origin.MULTI_ENTITY_DETECTOR, reserved + shared, reserved);
     }
 
+    /**
+     * Maintain active entity's cache and door keepers.
+     *
+     * inActiveEntities is a Guava's LRU cache. The data structure itself is
+     * gonna evict items if they are inactive for 3 days or its maximum size
+     * reached (1 million entries)
+     */
     @Override
     public void maintenance() {
         // clean up memory if we allocate more memory than we should

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCache.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCache.java
@@ -1,0 +1,530 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.caching;
+
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.COOLDOWN_MINUTES;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayDeque;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker.Origin;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
+import com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao;
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager.ModelType;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.RateLimiter;
+
+public class PriorityCache implements EntityCache {
+    private final Logger LOG = LogManager.getLogger(PriorityCache.class);
+
+    // detector id -> CacheBuffer, weight based
+    private final Map<String, CacheBuffer> activeEnities;
+    private final CheckpointDao checkpointDao;
+    private final int dedicatedCacheSize;
+    // LRU Cache
+    private Cache<String, ModelState<EntityModel>> inActiveEntities;
+    private final MemoryTracker memoryTracker;
+    private final ModelManager modelManager;
+    private final ReentrantLock maintenanceLock;
+    private final int numberOfTrees;
+    private final Clock clock;
+    private final Duration modelTtl;
+    private final int numMinSamples;
+    private Map<String, DoorKeeper> doorKeepers;
+    private final RateLimiter cacheMissRateLimiter;
+    private Instant lastThrottledRestoreTime;
+    private int coolDownMinutes;
+    private ThreadPool threadPool;
+    private Random random;
+
+    public PriorityCache(
+        CheckpointDao checkpointDao,
+        int dedicatedCacheSize,
+        Duration inactiveEntityTtl,
+        int maxInactiveStates,
+        MemoryTracker memoryTracker,
+        ModelManager modelManager,
+        int numberOfTrees,
+        Clock clock,
+        ClusterService clusterService,
+        Duration modelTtl,
+        int numMinSamples,
+        Settings settings,
+        ThreadPool threadPool
+    ) {
+        this.checkpointDao = checkpointDao;
+        this.dedicatedCacheSize = dedicatedCacheSize;
+        this.activeEnities = new ConcurrentHashMap<>();
+        this.memoryTracker = memoryTracker;
+        this.modelManager = modelManager;
+        this.maintenanceLock = new ReentrantLock();
+        this.numberOfTrees = numberOfTrees;
+        this.clock = clock;
+        this.modelTtl = modelTtl;
+        this.numMinSamples = numMinSamples;
+        this.doorKeepers = new ConcurrentHashMap<>();
+        // respond to 10 cache misses per second allowed.
+        this.cacheMissRateLimiter = RateLimiter.create(10);
+
+        this.inActiveEntities = CacheBuilder
+            .newBuilder()
+            .expireAfterAccess(inactiveEntityTtl.toHours(), TimeUnit.HOURS)
+            .maximumSize(maxInactiveStates)
+            .concurrencyLevel(1)
+            .build();
+
+        this.lastThrottledRestoreTime = Instant.MIN;
+        this.coolDownMinutes = (int) (COOLDOWN_MINUTES.get(settings).getMinutes());
+        this.threadPool = threadPool;
+        this.random = new Random(42);
+    }
+
+    @Override
+    public ModelState<EntityModel> get(String modelId, AnomalyDetector detector, double[] datapoint, String entityName) {
+        String detectorId = detector.getDetectorId();
+        CacheBuffer buffer = computeBufferIfAbsent(detector, detectorId);
+        ModelState<EntityModel> modelState = buffer.get(modelId);
+        try {
+            // during maintenance period, stop putting new entries
+            if (modelState == null && maintenanceLock.tryLock() && cacheMissRateLimiter.tryAcquire()) {
+                DoorKeeper doorKeeper = doorKeepers
+                    .computeIfAbsent(
+                        detectorId,
+                        id -> {
+                            // reset every 60 intervals
+                            return new DoorKeeper(
+                                AnomalyDetectorSettings.DOOR_KEEPER_MAX_INSERTION,
+                                AnomalyDetectorSettings.DOOR_KEEPER_FAULSE_POSITIVE_RATE,
+                                detector.getDetectionIntervalDuration().multipliedBy(60),
+                                clock
+                            );
+                        }
+                    );
+
+                // first hit, ignore
+                if (doorKeeper.mightContain(modelId) == false) {
+                    doorKeeper.put(modelId);
+                    return null;
+                }
+
+                ModelState<EntityModel> state = inActiveEntities.getIfPresent(modelId);
+
+                // compute updated priority
+                float priority = 0;
+                if (state != null) {
+                    priority = state.getPriority();
+                }
+                priority = buffer.getUpdatedPriority(priority);
+
+                // update state using new priority or create a new one
+                if (state != null) {
+                    state.setPriority(priority);
+                } else {
+                    EntityModel model = new EntityModel(modelId, new ArrayDeque<>(), null, null);
+                    state = new ModelState<>(model, modelId, detectorId, ModelType.ENTITY.getName(), clock, priority);
+                }
+
+                if (random.nextInt(1000) == 1) {
+                    // clear up memory with 1/1000 probability since this operation is costly, but we have to do it from time to time.
+                    // e.g., we need to adjust shared entity memory size if some reserved memory gets allocated. Use 1000 since our
+                    // query limit is 1k by default. We also do this in hourly maintenance window no matter what.
+                    tryClearUpMemory();
+                }
+                if (hostIfPossible(buffer, detectorId, modelId, entityName, detector, state, priority)) {
+                    addSample(state, datapoint);
+                    inActiveEntities.invalidate(modelId);
+                } else {
+                    // only keep weights in inactive cache to keep it small.
+                    // It can be dangerous to exceed a few dozen MBs, especially
+                    // in small heap machine like t2.
+                    inActiveEntities.put(modelId, state);
+                }
+            }
+        } finally {
+            if (maintenanceLock.isHeldByCurrentThread()) {
+                maintenanceLock.unlock();
+            }
+        }
+
+        return modelState;
+    }
+
+    /**
+     * Whether host an entity is possible
+     * @param buffer the destination buffer for the given entity
+     * @param detectorId Detector Id
+     * @param modelId Model Id
+     * @param entityName Entity's name
+     * @param detector Detector Config
+     * @param state State to host
+     * @param priority The entity's priority
+     * @return true if possible; false otherwise
+     */
+    private boolean hostIfPossible(
+        CacheBuffer buffer,
+        String detectorId,
+        String modelId,
+        String entityName,
+        AnomalyDetector detector,
+        ModelState<EntityModel> state,
+        float priority
+    ) {
+        // current buffer's dedicated cache has free slots
+        // thread safe as each detector has one thread at one time and only the
+        // thread can access its buffer.
+        if (buffer.dedicatedCacheAvailable()) {
+            buffer.put(modelId, state);
+        } else if (buffer.canReplace(priority)) {
+            // can replace an entity in the same CacheBuffer living in reserved
+            // or shared cache
+            // thread safe as each detector has one thread at one time and only the
+            // thread can access its buffer.
+            buffer.replace(modelId, state);
+        } else {
+            // race conditions can happen when multiple threads evaluating this condition.
+            // This is a problem as our AD memory usage is close to full and we put
+            // more things than we planned. One model in multi-entity case is small,
+            // it is fine we exceed a little. We have regular maintenance to remove
+            // extra memory usage.
+            if (memoryTracker.canAllocate(buffer.getMemoryConsumptionPerEntity())) {
+                // can allocate in shared cache
+                buffer.put(modelId, state);
+            } else {
+                // If two threads try to remove the same entity and add their own state, the 2nd remove
+                // returns null and only the first one succeeds.
+                Entry<CacheBuffer, String> bufferToRemoveEntity = canReplaceInSharedCache(buffer, priority);
+                CacheBuffer bufferToRemove = bufferToRemoveEntity.getKey();
+                String entityId = bufferToRemoveEntity.getValue();
+                if (bufferToRemove != null && bufferToRemove.remove(entityId) != null) {
+                    buffer.put(modelId, state);
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        maybeRestoreOrTrainModel(modelId, entityName, state);
+        return true;
+    }
+
+    private void addSample(ModelState<EntityModel> stateToPromote, double[] datapoint) {
+        // add samples
+        Queue<double[]> samples = stateToPromote.getModel().getSamples();
+        samples.add(datapoint);
+        // only keep the recent numMinSamples
+        if (samples.size() > this.numMinSamples) {
+            samples.remove();
+        }
+    }
+
+    private void maybeRestoreOrTrainModel(String modelId, String entityName, ModelState<EntityModel> state) {
+        EntityModel entityModel = state.getModel();
+        // rate limit in case of EsRejectedExecutionException from get threadpool whose queue capacity is 1k
+        if (entityModel != null
+            && (entityModel.getRcf() == null || entityModel.getThreshold() == null)
+            && lastThrottledRestoreTime.plus(Duration.ofMinutes(coolDownMinutes)).isBefore(clock.instant())) {
+            checkpointDao
+                .restoreModelCheckpoint(
+                    modelId,
+                    ActionListener
+                        .wrap(checkpoint -> modelManager.processEntityCheckpoint(checkpoint, modelId, entityName, state), exception -> {
+                            if (exception instanceof IndexNotFoundException) {
+                                modelManager.processEntityCheckpoint(Optional.empty(), modelId, entityName, state);
+                            } else if (exception instanceof EsRejectedExecutionException
+                                || exception instanceof RejectedExecutionException) {
+                                LOG.error("too many requests");
+                                lastThrottledRestoreTime = Instant.now();
+                            } else {
+                                LOG.error("Fail to restore models for " + modelId, exception);
+                            }
+                        })
+                );
+        }
+    }
+
+    private CacheBuffer computeBufferIfAbsent(AnomalyDetector detector, String detectorId) {
+        return activeEnities.computeIfAbsent(detectorId, k -> {
+            long requiredBytes = getReservedDetectorMemory(detector);
+            tryClearUpMemory();
+            if (memoryTracker.canAllocateReserved(detectorId, requiredBytes)) {
+                memoryTracker.consumeMemory(requiredBytes, true, Origin.MULTI_ENTITY_DETECTOR);
+                long intervalSecs = detector.getDetectorIntervalInSeconds();
+                return new CacheBuffer(
+                    dedicatedCacheSize,
+                    intervalSecs,
+                    checkpointDao,
+                    memoryTracker.estimateModelSize(detector, numberOfTrees),
+                    memoryTracker,
+                    clock,
+                    modelTtl,
+                    detectorId
+                );
+            }
+            // if hosting not allowed, exception will be thrown by isHostingAllowed
+            throw new EndRunException(detectorId, "Unexpected bug", true);
+        });
+    }
+
+    private long getReservedDetectorMemory(AnomalyDetector detector) {
+        return dedicatedCacheSize * memoryTracker.estimateModelSize(detector, numberOfTrees);
+    }
+
+    /**
+     * Whether the candidate entity can replace any entity in the shared cache.
+     * We can have race conditions when multiple threads try to evaluate this
+     * function. The result is that we can have multiple threads thinks they
+     * can replace entities in the cache.
+     *
+     * @param originBuffer the CacheBuffer that the entity belongs to (with the same detector Id)
+     * @param candicatePriority the candidate entity's priority
+     * @return the CacheBuffer if we can find a CacheBuffer to make room for the candidate entity
+     */
+    private Entry<CacheBuffer, String> canReplaceInSharedCache(CacheBuffer originBuffer, float candicatePriority) {
+        CacheBuffer minPriorityBuffer = null;
+        float minPriority = Float.MAX_VALUE;
+        String minPriorityEntityId = null;
+        for (Map.Entry<String, CacheBuffer> entry : activeEnities.entrySet()) {
+            CacheBuffer buffer = entry.getValue();
+            if (buffer != originBuffer) {
+                Entry<String, Float> priorityEntry = buffer.getMinimumPriority();
+                float priority = priorityEntry.getValue();
+                if (buffer.canRemove() && candicatePriority > priority && priority < minPriority) {
+                    minPriority = priority;
+                    minPriorityBuffer = buffer;
+                    minPriorityEntityId = priorityEntry.getKey();
+                }
+            }
+        }
+        return new SimpleImmutableEntry<>(minPriorityBuffer, minPriorityEntityId);
+    }
+
+    private void tryClearUpMemory() {
+        try {
+            if (maintenanceLock.tryLock()) {
+                clearMemory();
+            } else {
+                AbstractRunnable clearMemoryRunnable = new AbstractRunnable() {
+                    @Override
+                    protected void doRun() throws Exception {
+                        clearMemory();
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        LOG.error("Fail to clear up memory taken by CacheBuffer.  Will retry during maintenance.");
+                    }
+                };
+                threadPool
+                    .schedule(
+                        () -> clearMemoryRunnable.run(),
+                        new TimeValue(random.nextInt(90), TimeUnit.SECONDS),
+                        AnomalyDetectorPlugin.AD_THREAD_POOL_NAME
+                    );
+            }
+        } finally {
+            if (maintenanceLock.isHeldByCurrentThread()) {
+                maintenanceLock.unlock();
+            }
+        }
+    }
+
+    private void clearMemory() {
+        recalculateUsedMemory();
+        long memoryToShed = memoryTracker.memoryToShed();
+        float minPriority = Float.MAX_VALUE;
+        CacheBuffer minPriorityBuffer = null;
+        String minPriorityEntityId = null;
+        while (memoryToShed > 0) {
+            for (Map.Entry<String, CacheBuffer> entry : activeEnities.entrySet()) {
+                CacheBuffer buffer = entry.getValue();
+                Entry<String, Float> priorityEntry = buffer.getMinimumPriority();
+                float priority = priorityEntry.getValue();
+                if (buffer.canRemove() && priority < minPriority) {
+                    minPriority = priority;
+                    minPriorityBuffer = buffer;
+                    minPriorityEntityId = priorityEntry.getKey();
+                }
+            }
+            if (minPriorityBuffer != null) {
+                minPriorityBuffer.remove(minPriorityEntityId);
+                long memoryReleased = minPriorityBuffer.getMemoryConsumptionPerEntity();
+                memoryTracker.releaseMemory(memoryReleased, false, Origin.MULTI_ENTITY_DETECTOR);
+                memoryToShed -= memoryReleased;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Recalculate memory consumption in case of bugs/race conditions when allocating/releasing memory
+     */
+    private void recalculateUsedMemory() {
+        long reserved = 0;
+        long shared = 0;
+        for (Map.Entry<String, CacheBuffer> entry : activeEnities.entrySet()) {
+            CacheBuffer buffer = entry.getValue();
+            reserved += buffer.getReservedBytes();
+            shared += buffer.getBytesInSharedCache();
+        }
+        memoryTracker.syncMemoryState(Origin.MULTI_ENTITY_DETECTOR, reserved + shared, reserved);
+    }
+
+    @Override
+    public void maintenance() {
+        // clean up memory if we allocate more memory than we should
+        tryClearUpMemory();
+        activeEnities.entrySet().stream().forEach(cacheBufferEntry -> {
+            String detectorId = cacheBufferEntry.getKey();
+            CacheBuffer cacheBuffer = cacheBufferEntry.getValue();
+            // remove expired cache buffer
+            if (cacheBuffer.expired(modelTtl)) {
+                activeEnities.remove(detectorId);
+                cacheBuffer.clear();
+            } else {
+                cacheBuffer.maintenance();
+            }
+        });
+        checkpointDao.flush();
+        doorKeepers.entrySet().stream().forEach(doorKeeperEntry -> {
+            String detectorId = doorKeeperEntry.getKey();
+            DoorKeeper doorKeeper = doorKeeperEntry.getValue();
+            if (doorKeeper.expired(modelTtl)) {
+                doorKeepers.remove(detectorId);
+            } else {
+                doorKeeper.maintenance();
+            }
+        });
+    }
+
+    /**
+     * Permanently deletes models hosted in memory and persisted in index.
+     *
+     * @param detectorId id the of the detector for which models are to be permanently deleted
+     */
+    @Override
+    public void clear(String detectorId) {
+        if (detectorId == null) {
+            return;
+        }
+        CacheBuffer buffer = activeEnities.remove(detectorId);
+        if (buffer != null) {
+            buffer.clear();
+        }
+        checkpointDao.deleteModelCheckpointByDetectorId(detectorId);
+        doorKeepers.remove(detectorId);
+    }
+
+    /**
+     * Get the number of active entities of a detector
+     * @param detectorId Detector Id
+     * @return The number of active entities
+     */
+    @Override
+    public int getActiveEntities(String detectorId) {
+        CacheBuffer cacheBuffer = activeEnities.get(detectorId);
+        if (cacheBuffer != null) {
+            return cacheBuffer.getActiveEntities();
+        }
+        return 0;
+    }
+
+    /**
+     * Whether an entity is active or not
+     * @param detectorId The Id of the detector that an entity belongs to
+     * @param entityId Entity Id
+     * @return Whether an entity is active or not
+     */
+    @Override
+    public boolean isActive(String detectorId, String entityId) {
+        CacheBuffer cacheBuffer = activeEnities.get(detectorId);
+        if (cacheBuffer != null) {
+            return cacheBuffer.isActive(entityId);
+        }
+        return false;
+    }
+
+    @Override
+    public long getTotalUpdates(String detectorId) {
+        return Optional
+            .of(activeEnities)
+            .map(entities -> entities.get(detectorId))
+            .map(buffer -> buffer.getHighestPriorityEntityId())
+            .map(entityIdOptional -> entityIdOptional.get())
+            .map(entityId -> getTotalUpdates(detectorId, entityId))
+            .orElse(0L);
+    }
+
+    @Override
+    public long getTotalUpdates(String detectorId, String entityId) {
+        CacheBuffer cacheBuffer = activeEnities.get(detectorId);
+        if (cacheBuffer != null) {
+            Optional<EntityModel> modelOptional = cacheBuffer.getModel(entityId);
+            // TODO: make it work for shingles. samples.size() is not the real shingle
+            long accumulatedShingles = modelOptional
+                .map(model -> model.getRcf())
+                .map(rcf -> rcf.getTotalUpdates())
+                .orElseGet(
+                    () -> modelOptional.map(model -> model.getSamples()).map(samples -> samples.size()).map(Long::valueOf).orElse(0L)
+                );
+            return accumulatedShingles;
+        }
+        return 0L;
+    }
+
+    /**
+     *
+     * @return total active entities in the cache
+     */
+    @Override
+    public int getTotalActiveEntities() {
+        AtomicInteger total = new AtomicInteger();
+        activeEnities.values().stream().forEach(cacheBuffer -> { total.addAndGet(cacheBuffer.getActiveEntities()); });
+        return total.get();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportAction.java
@@ -27,14 +27,17 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
+import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 
 public class CronTransportAction extends TransportNodesAction<CronRequest, CronResponse, CronNodeRequest, CronNodeResponse> {
 
-    private TransportStateManager transportStateManager;
+    private NodeStateManager transportStateManager;
     private ModelManager modelManager;
     private FeatureManager featureManager;
+    private CacheProvider cacheProvider;
 
     @Inject
     public CronTransportAction(
@@ -42,9 +45,10 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
         ClusterService clusterService,
         TransportService transportService,
         ActionFilters actionFilters,
-        TransportStateManager tarnsportStatemanager,
+        NodeStateManager tarnsportStatemanager,
         ModelManager modelManager,
-        FeatureManager featureManager
+        FeatureManager featureManager,
+        CacheProvider cacheProvider
     ) {
         super(
             CronAction.NAME,
@@ -60,6 +64,7 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
         this.transportStateManager = tarnsportStatemanager;
         this.modelManager = modelManager;
         this.featureManager = featureManager;
+        this.cacheProvider = cacheProvider;
     }
 
     @Override
@@ -89,7 +94,10 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
 
         // makes checkpoints for hosted models and stop hosting models not actively
         // used.
+        // for single-entity detector
         modelManager.maintenance();
+        // for multi-entity detector
+        cacheProvider.maintenance();
 
         // delete unused buffered shingle data
         featureManager.maintenance();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportAction.java
@@ -97,7 +97,7 @@ public class CronTransportAction extends TransportNodesAction<CronRequest, CronR
         // for single-entity detector
         modelManager.maintenance();
         // for multi-entity detector
-        cacheProvider.maintenance();
+        cacheProvider.get().maintenance();
 
         // delete unused buffered shingle data
         featureManager.maintenance();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportAction.java
@@ -29,15 +29,18 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
+import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 
 public class DeleteModelTransportAction extends
     TransportNodesAction<DeleteModelRequest, DeleteModelResponse, DeleteModelNodeRequest, DeleteModelNodeResponse> {
     private static final Logger LOG = LogManager.getLogger(DeleteModelTransportAction.class);
-    private TransportStateManager transportStateManager;
+    private NodeStateManager transportStateManager;
     private ModelManager modelManager;
     private FeatureManager featureManager;
+    private CacheProvider cache;
 
     @Inject
     public DeleteModelTransportAction(
@@ -45,9 +48,10 @@ public class DeleteModelTransportAction extends
         ClusterService clusterService,
         TransportService transportService,
         ActionFilters actionFilters,
-        TransportStateManager tarnsportStatemanager,
+        NodeStateManager tarnsportStatemanager,
         ModelManager modelManager,
-        FeatureManager featureManager
+        FeatureManager featureManager,
+        CacheProvider cache
     ) {
         super(
             DeleteModelAction.NAME,
@@ -63,6 +67,7 @@ public class DeleteModelTransportAction extends
         this.transportStateManager = tarnsportStatemanager;
         this.modelManager = modelManager;
         this.featureManager = featureManager;
+        this.cache = cache;
     }
 
     @Override
@@ -105,6 +110,8 @@ public class DeleteModelTransportAction extends
 
         // delete transport state
         transportStateManager.clear(adID);
+
+        cache.clear(adID);
 
         LOG.info("Finished deleting {}", adID);
         return new DeleteModelNodeResponse(clusterService.localNode());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportAction.java
@@ -111,7 +111,7 @@ public class DeleteModelTransportAction extends
         // delete transport state
         transportStateManager.clear(adID);
 
-        cache.clear(adID);
+        cache.get().clear(adID);
 
         LOG.info("Finished deleting {}", adID);
         return new DeleteModelNodeResponse(clusterService.localNode());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBufferTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBufferTests.java
@@ -98,9 +98,9 @@ public class CacheBufferTests extends ESTestCase {
         assertEquals(modelId3, cacheBuffer.get(modelId3).getModelId());
         removalCandidate = cacheBuffer.getMinimumPriority();
         assertEquals(modelId1, removalCandidate.getKey());
-        cacheBuffer.remove();
-        cacheBuffer.put(modelId4, MLUtil.randomModelState(initialPriority, modelId4));
+        cacheBuffer.remove(modelId1);
         assertEquals(null, cacheBuffer.get(modelId1));
+        cacheBuffer.put(modelId4, MLUtil.randomModelState(initialPriority, modelId4));
         assertEquals(modelId3, cacheBuffer.get(modelId3).getModelId());
         assertEquals(modelId4, cacheBuffer.get(modelId4).getModelId());
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBufferTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBufferTests.java
@@ -154,7 +154,7 @@ public class CacheBufferTests extends ESTestCase {
         cacheBuffer.replace(modelId3, MLUtil.randomModelState(initialPriority, modelId3));
         assertTrue(cacheBuffer.isActive(modelId2));
         assertTrue(cacheBuffer.isActive(modelId3));
-        assertEquals(modelId3, cacheBuffer.getHighestPriorityEntityId().get());
+        assertEquals(modelId3, cacheBuffer.getHighestPriorityEntityModelId().get());
         assertEquals(2, cacheBuffer.getActiveEntities());
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBufferTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBufferTests.java
@@ -16,9 +16,9 @@
 package com.amazon.opendistroforelasticsearch.ad.caching;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -130,7 +130,7 @@ public class CacheBufferTests extends ESTestCase {
         List<Long> capturedMemoryReleased = memoryReleased.getAllValues();
         List<Boolean> capturedreserved = reserved.getAllValues();
         List<MemoryTracker.Origin> capturedOrigin = orign.getAllValues();
-        assertEquals(3*memoryPerEntity, capturedMemoryReleased.stream().reduce(0L, (a, b) -> a+b).intValue());
+        assertEquals(3 * memoryPerEntity, capturedMemoryReleased.stream().reduce(0L, (a, b) -> a + b).intValue());
         assertTrue(capturedreserved.get(0));
         assertTrue(!capturedreserved.get(1));
         assertEquals(MemoryTracker.Origin.MULTI_ENTITY_DETECTOR, capturedOrigin.get(0));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBufferTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBufferTests.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.caching;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map.Entry;
+
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+
+import test.com.amazon.opendistroforelasticsearch.ad.util.MLUtil;
+
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
+import com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+
+public class CacheBufferTests extends ESTestCase {
+    CacheBuffer cacheBuffer;
+    CheckpointDao checkpointDao;
+    MemoryTracker memoryTracker;
+    Clock clock;
+    String detectorId;
+    float initialPriority;
+    long memoryPerEntity;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        checkpointDao = mock(CheckpointDao.class);
+        memoryTracker = mock(MemoryTracker.class);
+        clock = mock(Clock.class);
+        when(clock.instant()).thenReturn(Instant.now());
+
+        detectorId = "123";
+        memoryPerEntity = 81920;
+
+        cacheBuffer = new CacheBuffer(
+            1,
+            1,
+            checkpointDao,
+            memoryPerEntity,
+            memoryTracker,
+            clock,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            detectorId
+        );
+        initialPriority = cacheBuffer.getUpdatedPriority(0);
+    }
+
+    // cache.put(1, 1);
+    // cache.put(2, 2);
+    // cache.get(1); // returns 1
+    // cache.put(3, 3); // evicts key 2
+    // cache.get(2); // returns -1 (not found)
+    // cache.get(3); // returns 3.
+    // cache.put(4, 4); // evicts key 1.
+    // cache.get(1); // returns -1 (not found)
+    // cache.get(3); // returns 3
+    // cache.get(4); // returns 4
+    public void testRemovalCandidate() {
+        String modelId1 = "1";
+        String modelId2 = "2";
+        String modelId3 = "3";
+        String modelId4 = "4";
+
+        cacheBuffer.put(modelId1, MLUtil.randomModelState(initialPriority, modelId1));
+        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
+        assertEquals(modelId1, cacheBuffer.get(modelId1).getModelId());
+        Entry<String, Float> removalCandidate = cacheBuffer.getMinimumPriority();
+        assertEquals(modelId2, removalCandidate.getKey());
+        cacheBuffer.remove();
+        cacheBuffer.put(modelId3, MLUtil.randomModelState(initialPriority, modelId3));
+        assertEquals(null, cacheBuffer.get(modelId2));
+        assertEquals(modelId3, cacheBuffer.get(modelId3).getModelId());
+        removalCandidate = cacheBuffer.getMinimumPriority();
+        assertEquals(modelId1, removalCandidate.getKey());
+        cacheBuffer.remove();
+        cacheBuffer.put(modelId4, MLUtil.randomModelState(initialPriority, modelId4));
+        assertEquals(null, cacheBuffer.get(modelId1));
+        assertEquals(modelId3, cacheBuffer.get(modelId3).getModelId());
+        assertEquals(modelId4, cacheBuffer.get(modelId4).getModelId());
+    }
+
+    // cache.put(3, 3);
+    // cache.put(2, 2);
+    // cache.put(2, 2);
+    // cache.put(4, 4);
+    // cache.get(2) => returns 2
+    public void testRemovalCandidate2() throws InterruptedException {
+        String modelId2 = "2";
+        String modelId3 = "3";
+        String modelId4 = "4";
+        float initialPriority = cacheBuffer.getUpdatedPriority(0);
+        cacheBuffer.put(modelId3, MLUtil.randomModelState(initialPriority, modelId3));
+        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
+        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
+        cacheBuffer.put(modelId4, MLUtil.randomModelState(initialPriority, modelId4));
+        assertTrue(cacheBuffer.getModel(modelId2).isPresent());
+
+        ArgumentCaptor<Long> memoryReleased = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Boolean> reserved = ArgumentCaptor.forClass(Boolean.class);
+        ArgumentCaptor<MemoryTracker.Origin> orign = ArgumentCaptor.forClass(MemoryTracker.Origin.class);
+        cacheBuffer.clear();
+        verify(memoryTracker, times(2)).releaseMemory(memoryReleased.capture(), reserved.capture(), orign.capture());
+
+        List<Long> capturedMemoryReleased = memoryReleased.getAllValues();
+        List<Boolean> capturedreserved = reserved.getAllValues();
+        List<MemoryTracker.Origin> capturedOrigin = orign.getAllValues();
+        assertEquals(3*memoryPerEntity, capturedMemoryReleased.stream().reduce(0L, (a, b) -> a+b).intValue());
+        assertTrue(capturedreserved.get(0));
+        assertTrue(!capturedreserved.get(1));
+        assertEquals(MemoryTracker.Origin.MULTI_ENTITY_DETECTOR, capturedOrigin.get(0));
+
+        assertTrue(!cacheBuffer.expired(Duration.ofHours(1)));
+    }
+
+    public void testCanRemove() {
+        String modelId1 = "1";
+        String modelId2 = "2";
+        String modelId3 = "3";
+        assertTrue(cacheBuffer.dedicatedCacheAvailable());
+        assertTrue(!cacheBuffer.canReplace(100));
+
+        cacheBuffer.put(modelId1, MLUtil.randomModelState(initialPriority, modelId1));
+        assertTrue(cacheBuffer.canReplace(100));
+        assertTrue(!cacheBuffer.dedicatedCacheAvailable());
+        assertTrue(!cacheBuffer.canRemove());
+        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
+        assertTrue(cacheBuffer.canRemove());
+        cacheBuffer.replace(modelId3, MLUtil.randomModelState(initialPriority, modelId3));
+        assertTrue(cacheBuffer.isActive(modelId2));
+        assertTrue(cacheBuffer.isActive(modelId3));
+        assertEquals(modelId3, cacheBuffer.getHighestPriorityEntityId().get());
+        assertEquals(2, cacheBuffer.getActiveEntities());
+    }
+
+    public void testMaintenance() {
+        String modelId1 = "1";
+        String modelId2 = "2";
+        String modelId3 = "3";
+        cacheBuffer.put(modelId1, MLUtil.randomModelState(initialPriority, modelId1));
+        cacheBuffer.put(modelId2, MLUtil.randomModelState(initialPriority, modelId2));
+        cacheBuffer.put(modelId3, MLUtil.randomModelState(initialPriority, modelId3));
+        cacheBuffer.maintenance();
+        assertEquals(3, cacheBuffer.getActiveEntities());
+        when(clock.instant()).thenReturn(Instant.MAX);
+        cacheBuffer.maintenance();
+        assertEquals(0, cacheBuffer.getActiveEntities());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCacheTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCacheTests.java
@@ -1,0 +1,470 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.caching;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler.ScheduledCancellable;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao;
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+
+public class PriorityCacheTests extends ESTestCase {
+    private static final Logger LOG = LogManager.getLogger(PriorityCacheTests.class);
+
+    String modelId1, modelId2, modelId3, modelId4;
+    CacheProvider cacheProvider;
+    CheckpointDao checkpoint;
+    MemoryTracker memoryTracker;
+    ModelManager modelManager;
+    Clock clock;
+    ClusterService clusterService;
+    Settings settings;
+    ThreadPool threadPool;
+    float initialPriority;
+    CacheBuffer cacheBuffer;
+    long memoryPerEntity;
+    String detectorId, detectorId2;
+    AnomalyDetector detector, detector2;
+    double[] point;
+    String entityName;
+    int dedicatedCacheSize;
+    Duration detectorDuration;
+    int numMinSamples;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        modelId1 = "1";
+        modelId2 = "2";
+        modelId3 = "3";
+        modelId4 = "4";
+        checkpoint = mock(CheckpointDao.class);
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<Optional<Entry<EntityModel, Instant>>> listener =
+                (ActionListener<Optional<Entry<EntityModel, Instant>>>) args[1];
+            listener.onResponse(Optional.empty());
+            return null;
+        }).when(checkpoint).restoreModelCheckpoint(anyString(), any(ActionListener.class));
+
+        memoryTracker = mock(MemoryTracker.class);
+        when(memoryTracker.memoryToShed()).thenReturn(0L);
+
+        modelManager = mock(ModelManager.class);
+        doNothing().when(modelManager).processEntityCheckpoint(any(Optional.class), anyString(), anyString(), any(ModelState.class));
+
+        clock = mock(Clock.class);
+        when(clock.instant()).thenReturn(Instant.now());
+
+        clusterService = mock(ClusterService.class);
+        settings = Settings.EMPTY;
+        threadPool = mock(ThreadPool.class);
+        dedicatedCacheSize = 1;
+        numMinSamples = 3;
+
+        EntityCache cache = new PriorityCache(
+            checkpoint,
+            dedicatedCacheSize,
+            AnomalyDetectorSettings.CHECKPOINT_TTL,
+            AnomalyDetectorSettings.MAX_INACTIVE_ENTITIES,
+            memoryTracker,
+            modelManager,
+            AnomalyDetectorSettings.MULTI_ENTITY_NUM_TREES,
+            clock,
+            clusterService,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            numMinSamples,
+            settings,
+            threadPool
+        );
+
+        cacheProvider = new CacheProvider(cache);
+
+        memoryPerEntity = 81920L;
+        when(memoryTracker.estimateModelSize(any(AnomalyDetector.class), anyInt())).thenReturn(memoryPerEntity);
+        when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
+
+        detector = mock(AnomalyDetector.class);
+        detectorId = "123";
+        when(detector.getDetectorId()).thenReturn(detectorId);
+        detectorDuration = Duration.ofMinutes(5);
+        when(detector.getDetectionIntervalDuration()).thenReturn(detectorDuration);
+        when(detector.getDetectorIntervalInSeconds()).thenReturn(detectorDuration.getSeconds());
+
+        detector2 = mock(AnomalyDetector.class);
+        detectorId2 = "456";
+        when(detector2.getDetectorId()).thenReturn(detectorId2);
+        when(detector2.getDetectionIntervalDuration()).thenReturn(detectorDuration);
+        when(detector2.getDetectorIntervalInSeconds()).thenReturn(detectorDuration.getSeconds());
+
+        cacheBuffer = new CacheBuffer(
+            1,
+            1,
+            checkpoint,
+            memoryPerEntity,
+            memoryTracker,
+            clock,
+            AnomalyDetectorSettings.HOURLY_MAINTENANCE,
+            detectorId
+        );
+
+        initialPriority = cacheBuffer.getUpdatedPriority(0);
+        point = new double[] { 0.1 };
+        entityName = "1.2.3.4";
+    }
+
+    public void testCacheHit() {
+        // cache miss due to empty cache
+        assertEquals(null, cacheProvider.get(modelId1, detector, point, entityName));
+        // cache miss due to door keeper
+        assertEquals(null, cacheProvider.get(modelId1, detector, point, entityName));
+        assertEquals(1, cacheProvider.getTotalActiveEntities());
+        ModelState<EntityModel> hitState = cacheProvider.get(modelId1, detector, point, entityName);
+        assertEquals(detectorId, hitState.getDetectorId());
+        EntityModel model = hitState.getModel();
+        assertEquals(null, model.getRcf());
+        assertEquals(null, model.getThreshold());
+        assertTrue(Arrays.equals(point, model.getSamples().peek()));
+
+        ArgumentCaptor<Long> memoryConsumed = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Boolean> reserved = ArgumentCaptor.forClass(Boolean.class);
+        ArgumentCaptor<MemoryTracker.Origin> origin = ArgumentCaptor.forClass(MemoryTracker.Origin.class);
+
+        verify(memoryTracker, times(1)).consumeMemory(memoryConsumed.capture(), reserved.capture(), origin.capture());
+        assertEquals(dedicatedCacheSize * memoryPerEntity, memoryConsumed.getValue().intValue());
+        assertEquals(true, reserved.getValue().booleanValue());
+        assertEquals(MemoryTracker.Origin.MULTI_ENTITY_DETECTOR, origin.getValue());
+
+        for (int i = 0; i < 2; i++) {
+            cacheProvider.get(modelId2, detector, point, entityName);
+        }
+    }
+
+    public void testInActiveCache() {
+        // make modelId1 has enough priority
+        for (int i = 0; i < 10; i++) {
+            cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+        when(memoryTracker.canAllocate(anyLong())).thenReturn(false);
+        for (int i = 0; i < 2; i++) {
+            assertEquals(null, cacheProvider.get(modelId2, detector, point, entityName));
+        }
+        // modelId2 gets put to inactive cache due to nothing in shared cache
+        // and it cannot replace modelId1
+        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+    }
+
+    public void testSharedCache() {
+        // make modelId1 has enough priority
+        for (int i = 0; i < 10; i++) {
+            cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+        when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
+        for (int i = 0; i < 2; i++) {
+            cacheProvider.get(modelId2, detector, point, entityName);
+        }
+        // modelId2 should be in shared cache
+        assertEquals(2, cacheProvider.getActiveEntities(detectorId));
+
+        for (int i = 0; i < 10; i++) {
+            // put in dedicated cache
+            cacheProvider.get(modelId3, detector2, point, entityName);
+        }
+
+        assertEquals(1, cacheProvider.getActiveEntities(detectorId2));
+        when(memoryTracker.canAllocate(anyLong())).thenReturn(false);
+        for (int i = 0; i < 4; i++) {
+            // replace modelId2 in shared cache
+            cacheProvider.get(modelId4, detector2, point, entityName);
+        }
+        assertEquals(2, cacheProvider.getActiveEntities(detectorId2));
+        assertEquals(3, cacheProvider.getTotalActiveEntities());
+
+        when(memoryTracker.memoryToShed()).thenReturn(memoryPerEntity);
+        cacheProvider.maintenance();
+        assertEquals(2, cacheProvider.getTotalActiveEntities());
+        assertEquals(1, cacheProvider.getActiveEntities(detectorId2));
+    }
+
+    public void testReplace() {
+        for (int i = 0; i < 2; i++) {
+            cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+        when(memoryTracker.canAllocate(anyLong())).thenReturn(false);
+        ModelState<EntityModel> state = null;
+        for (int i = 0; i < 4; i++) {
+            state = cacheProvider.get(modelId2, detector, point, entityName);
+        }
+
+        // modelId2 replaced modelId1
+        assertEquals(modelId2, state.getModelId());
+        assertTrue(Arrays.equals(point, state.getModel().getSamples().peek()));
+        assertEquals(1, cacheProvider.getActiveEntities(detectorId));
+    }
+
+    public void testCannotAllocateBuffer() {
+        when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(false);
+        expectThrows(LimitExceededException.class, () -> cacheProvider.get(modelId1, detector, point, entityName));
+    }
+
+    /**
+     * Test that even though we put more and more samples, there are only numMinSamples stored
+     */
+    @SuppressWarnings("unchecked")
+    public void testTooManySamples() {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ModelState<EntityModel> state = (ModelState<EntityModel>) args[3];
+            EntityModel model = state.getModel();
+            for (int i = 0; i < 10; i++) {
+                model.addSample(point);
+            }
+            return null;
+        }).when(modelManager).processEntityCheckpoint(any(Optional.class), anyString(), anyString(), any(ModelState.class));
+
+        ModelState<EntityModel> state = null;
+        for (int i = 0; i < 10; i++) {
+            state = cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        assertEquals(numMinSamples, state.getModel().getSamples().size());
+    }
+
+    /**
+     * We should have no problem when the checkpoint index does not exist yet.
+     */
+    @SuppressWarnings("unchecked")
+    public void testIndexNotFoundException() {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<Optional<Entry<EntityModel, Instant>>> listener =
+                (ActionListener<Optional<Entry<EntityModel, Instant>>>) args[1];
+            listener.onFailure(new IndexNotFoundException("", CommonName.CHECKPOINT_INDEX_NAME));
+            return null;
+        }).when(checkpoint).restoreModelCheckpoint(anyString(), any(ActionListener.class));
+        ModelState<EntityModel> state = null;
+        for (int i = 0; i < 3; i++) {
+            state = cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        assertEquals(1, state.getModel().getSamples().size());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testThrottledRestore() {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<Optional<Entry<EntityModel, Instant>>> listener =
+                (ActionListener<Optional<Entry<EntityModel, Instant>>>) args[1];
+            listener.onFailure(new EsRejectedExecutionException("", false));
+            return null;
+        }).when(checkpoint).restoreModelCheckpoint(anyString(), any(ActionListener.class));
+        for (int i = 0; i < 3; i++) {
+            cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        for (int i = 0; i < 3; i++) {
+            cacheProvider.get(modelId2, detector, point, entityName);
+        }
+
+        // due to throttling cool down, we should only restore once
+        verify(checkpoint, times(1)).restoreModelCheckpoint(anyString(), any(ActionListener.class));
+    }
+
+    // we only log error for this
+    @SuppressWarnings("unchecked")
+    public void testUnexpectedRestoreError() {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<Optional<Entry<EntityModel, Instant>>> listener =
+                (ActionListener<Optional<Entry<EntityModel, Instant>>>) args[1];
+            listener.onFailure(new RuntimeException());
+            return null;
+        }).when(checkpoint).restoreModelCheckpoint(anyString(), any(ActionListener.class));
+        when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
+        for (int i = 0; i < 3; i++) {
+            cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        for (int i = 0; i < 3; i++) {
+            cacheProvider.get(modelId2, detector, point, entityName);
+        }
+
+        verify(checkpoint, times(2)).restoreModelCheckpoint(anyString(), any(ActionListener.class));
+    }
+
+    public void testExpiredCacheBuffer() {
+        when(clock.instant()).thenReturn(Instant.MIN);
+        when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
+        for (int i = 0; i < 3; i++) {
+            cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        for (int i = 0; i < 3; i++) {
+            cacheProvider.get(modelId2, detector, point, entityName);
+        }
+        assertEquals(2, cacheProvider.getTotalActiveEntities());
+        when(clock.instant()).thenReturn(Instant.now());
+        cacheProvider.maintenance();
+        assertEquals(0, cacheProvider.getTotalActiveEntities());
+
+        for (int i = 0; i < 2; i++) {
+            // doorkeeper should have been reset
+            assertEquals(null, cacheProvider.get(modelId2, detector, point, entityName));
+        }
+    }
+
+    public void testClear() {
+        when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
+        for (int i = 0; i < 3; i++) {
+            cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        for (int i = 0; i < 3; i++) {
+            cacheProvider.get(modelId2, detector, point, entityName);
+        }
+        assertEquals(2, cacheProvider.getTotalActiveEntities());
+        assertTrue(cacheProvider.isActive(detectorId, modelId1));
+        assertEquals(1, cacheProvider.getTotalUpdates(detectorId));
+        assertEquals(1, cacheProvider.getTotalUpdates(detectorId, modelId1));
+        cacheProvider.clear(detectorId);
+        assertEquals(0, cacheProvider.getTotalActiveEntities());
+
+        for (int i = 0; i < 2; i++) {
+            // doorkeeper should have been reset
+            assertEquals(null, cacheProvider.get(modelId2, detector, point, entityName));
+        }
+    }
+
+    class CleanRunnable implements Runnable {
+        @Override
+        public void run() {
+            cacheProvider.maintenance();
+        }
+    }
+
+    private void setUpConcurrentMaintenance() {
+        when(memoryTracker.canAllocate(anyLong())).thenReturn(true);
+        for (int i = 0; i < 2; i++) {
+            cacheProvider.get(modelId1, detector, point, entityName);
+        }
+        for (int i = 0; i < 2; i++) {
+            cacheProvider.get(modelId2, detector, point, entityName);
+        }
+        for (int i = 0; i < 2; i++) {
+            cacheProvider.get(modelId3, detector, point, entityName);
+        }
+        when(memoryTracker.memoryToShed()).thenReturn(memoryPerEntity);
+        assertEquals(3, cacheProvider.getTotalActiveEntities());
+    }
+
+    public void testSuccessfulConcurrentMaintenance() {
+        setUpConcurrentMaintenance();
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        doAnswer(invovacation -> {
+            inProgressLatch.await(100, TimeUnit.SECONDS);
+            return null;
+        }).when(memoryTracker).releaseMemory(anyLong(), anyBoolean(), any(MemoryTracker.Origin.class));
+
+        doAnswer(invocation -> {
+            inProgressLatch.countDown();
+            Object[] args = invocation.getArguments();
+            Runnable runnable = (Runnable) args[0];
+            runnable.run();
+            return mock(ScheduledCancellable.class);
+        }).when(threadPool).schedule(any(), any(), any());
+
+        // both maintenance call will be blocked until schedule gets called
+        new Thread(new CleanRunnable()).start();
+
+        cacheProvider.maintenance();
+
+        verify(threadPool, times(1)).schedule(any(), any(), any());
+    }
+
+    public void testFailedConcurrentMaintenance() {
+        setUpConcurrentMaintenance();
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        doThrow(NullPointerException.class).when(memoryTracker).releaseMemory(anyLong(), anyBoolean(), any(MemoryTracker.Origin.class));
+
+        doAnswer(invovacation -> {
+            inProgressLatch.await(100, TimeUnit.SECONDS);
+            return null;
+        }).when(memoryTracker).syncMemoryState(any(MemoryTracker.Origin.class), anyLong(), anyLong());
+
+        doAnswer(invocation -> {
+            inProgressLatch.countDown();
+            Object[] args = invocation.getArguments();
+            Runnable runnable = (Runnable) args[0];
+            runnable.run();
+            return mock(ScheduledCancellable.class);
+        }).when(threadPool).schedule(any(), any(), any());
+
+        // both maintenance call will be blocked until schedule gets called
+
+        try {
+            // both maintenance call will be blocked until schedule gets called
+            new Thread(new CleanRunnable()).start();
+
+            cacheProvider.maintenance();
+        } catch (NullPointerException e) {
+            // we should return here
+            return;
+        }
+
+        assertTrue(Boolean.FALSE);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCacheTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCacheTests.java
@@ -422,9 +422,6 @@ public class PriorityCacheTests extends ESTestCase {
 
         doAnswer(invocation -> {
             inProgressLatch.countDown();
-            Object[] args = invocation.getArguments();
-            Runnable runnable = (Runnable) args[0];
-            runnable.run();
             return mock(ScheduledCancellable.class);
         }).when(threadPool).schedule(any(), any(), any());
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCacheTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/caching/PriorityCacheTests.java
@@ -64,7 +64,7 @@ public class PriorityCacheTests extends ESTestCase {
     private static final Logger LOG = LogManager.getLogger(PriorityCacheTests.class);
 
     String modelId1, modelId2, modelId3, modelId4;
-    CacheProvider cacheProvider;
+    EntityCache cacheProvider;
     CheckpointDao checkpoint;
     MemoryTracker memoryTracker;
     ModelManager modelManager;
@@ -129,10 +129,12 @@ public class PriorityCacheTests extends ESTestCase {
             AnomalyDetectorSettings.HOURLY_MAINTENANCE,
             numMinSamples,
             settings,
-            threadPool
+            threadPool,
+            // put a large value since my tests uses a lot of permits in a burst manner
+            2000
         );
 
-        cacheProvider = new CacheProvider(cache);
+        cacheProvider = new CacheProvider(cache).get();
 
         memoryPerEntity = 81920L;
         when(memoryTracker.estimateModelSize(any(AnomalyDetector.class), anyInt())).thenReturn(memoryPerEntity);
@@ -465,6 +467,6 @@ public class PriorityCacheTests extends ESTestCase {
             return;
         }
 
-        assertTrue(Boolean.FALSE);
+        assertTrue(false);
     }
 }

--- a/src/test/java/test/com/amazon/opendistroforelasticsearch/ad/util/MLUtil.java
+++ b/src/test/java/test/com/amazon/opendistroforelasticsearch/ad/util/MLUtil.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package test.com.amazon.opendistroforelasticsearch.ad.util;
+
+import java.time.Clock;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.Random;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+
+import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.HybridThresholdingModel;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager.ModelType;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
+import com.amazon.opendistroforelasticsearch.ad.ml.ThresholdingModel;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.randomcutforest.RandomCutForest;
+
+/**
+ * Cannot use TestUtil inside ML tests since it uses com.carrotsearch.randomizedtesting.RandomizedRunner
+ * and using it causes Exception in ML tests.
+ * Most of ML tests are not a subclass if ES base test case.
+ *
+ */
+public class MLUtil {
+    private static Random random = new Random(42);
+
+    private static String randomString(int targetStringLength) {
+        int leftLimit = 97; // letter 'a'
+        int rightLimit = 122; // letter 'z'
+        Random random = new Random();
+
+        return random
+            .ints(leftLimit, rightLimit + 1)
+            .limit(targetStringLength)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
+    }
+
+    public static Queue<double[]> createQueueSamples(int size) {
+        Queue<double[]> res = new ArrayDeque<>();
+        IntStream.range(0, size).forEach(i -> res.offer(new double[] { random.nextDouble() }));
+        return res;
+    }
+
+    public static ModelState<EntityModel> randomModelState() {
+        return randomModelState(random.nextBoolean(), random.nextFloat(), randomString(15));
+    }
+
+    public static ModelState<EntityModel> randomModelState(boolean fullModel, float priority, String modelId) {
+        String detectorId = randomString(5);
+        Queue<double[]> samples = createQueueSamples(random.nextInt(128));
+        EntityModel model = null;
+        if (fullModel) {
+            RandomCutForest rcf = RandomCutForest
+                .builder()
+                .dimensions(1)
+                .sampleSize(AnomalyDetectorSettings.NUM_SAMPLES_PER_TREE)
+                .numberOfTrees(AnomalyDetectorSettings.MULTI_ENTITY_NUM_TREES)
+                .lambda(AnomalyDetectorSettings.TIME_DECAY)
+                .outputAfter(AnomalyDetectorSettings.NUM_MIN_SAMPLES)
+                .parallelExecutionEnabled(false)
+                .build();
+            int numDataPoints = random.nextInt(1000) + AnomalyDetectorSettings.NUM_MIN_SAMPLES;
+            double[] scores = new double[numDataPoints];
+            for (int j = 0; j < numDataPoints; j++) {
+                double[] dataPoint = new double[] { random.nextDouble() };
+                scores[j] = rcf.getAnomalyScore(dataPoint);
+                rcf.update(dataPoint);
+            }
+
+            double[] nonZeroScores = DoubleStream.of(scores).filter(score -> score > 0).toArray();
+            ThresholdingModel threshold = new HybridThresholdingModel(
+                AnomalyDetectorSettings.THRESHOLD_MIN_PVALUE,
+                AnomalyDetectorSettings.THRESHOLD_MAX_RANK_ERROR,
+                AnomalyDetectorSettings.THRESHOLD_MAX_SCORE,
+                AnomalyDetectorSettings.THRESHOLD_NUM_LOGNORMAL_QUANTILES,
+                AnomalyDetectorSettings.THRESHOLD_DOWNSAMPLES,
+                AnomalyDetectorSettings.THRESHOLD_MAX_SAMPLES
+            );
+            threshold.train(nonZeroScores);
+            model = new EntityModel(modelId, samples, rcf, threshold);
+        } else {
+            model = new EntityModel(modelId, samples, null, null);
+        }
+
+        return new ModelState<>(model, modelId, detectorId, ModelType.ENTITY.getName(), Clock.systemUTC(), priority);
+    }
+
+    public static ModelState<EntityModel> randomNonEmptyModelState() {
+        return randomModelState(true, random.nextFloat(), randomString(15));
+    }
+
+    public static ModelState<EntityModel> randomModelState(float priority, String modelId) {
+        return randomModelState(random.nextBoolean(), priority, modelId);
+    }
+}


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*

In a single-entity detector, the amount of memory used is proportional to the number of features and is fixed when the detector is defined. However, with the introduction of multi-entity detectors, the number of entities is not fixed, and active entities are changing. Thus, the size of the required memory may constantly change in the lifetime of a detector. Caching can accommodate such requirements without the need to pre-allocate memory for a detector in a fixed number. If the memory is enough, we create models for all entities and monitor anomalies. Otherwise, we cache hot entities in memory and make a best-effort attempt to admit other entities.

This PR adds caching for multi-entity detectors.  We have a three-level cache that stores entity states in each node. The first two levels are for active entities. The third level is for inactive entities. Each detector has its dedicated cache that stores ten (dynamically adjustable by humans) entities’ states per node. A detector’s hottest entities load their states in the dedicated cache. If more than 10 entities use the dedicated cache, the secondary cache can use the rest of the free memory available to AD. The secondary cache is a shared memory among all detectors for the long tail. The shared cache size is 10% heap minus all of the dedicated cache consumed by single-entity and multi-entity detectors. The shared cache’s size shrinks as the dedicated cache is filled up or more detectors are started.

Testing done:
1. added unit tests.
2. end-to-end testing


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
