### PR TITLE
Add state interfaces

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/CleanState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/CleanState.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+/**
+ * Represent a state organized via detectorId.  When deleting a detector's state,
+ * we can remove it from the state.
+ *
+ *
+ */
+public interface CleanState {
+    /**
+     * Remove state associated with a detector Id
+     * @param detectorId Detector Id
+     */
+    void clear(String detectorId);
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ExpiringState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ExpiringState.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Represent a state that can be expired with a duration if not accessed
+ *
+ */
+public interface ExpiringState {
+    default boolean expired(Instant lastAccessTime, Duration stateTtl, Instant now) {
+        return lastAccessTime.plus(stateTtl).isBefore(now);
+    }
+
+    boolean expired(Duration stateTtl);
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/MaintenanceState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/MaintenanceState.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Represent a state that needs to maintain its metadata regularly
+ *
+ *
+ */
+public interface MaintenanceState {
+    default <K, V extends ExpiringState> void maintenance(Map<K, V> stateToClean, Duration stateTtl) {
+        stateToClean.entrySet().stream().forEach(entry -> {
+            K detectorId = entry.getKey();
+
+            V state = entry.getValue();
+            if (state.expired(stateTtl)) {
+                stateToClean.remove(detectorId);
+            }
+
+        });
+    }
+
+    void maintenance();
+}


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*

We have different states in AD.  For better code readability and reuse, this PR adds three interfaces for our states:
* Expiring states: Represent a state that can be expired with a duration if not accessed.
* MaintenanceState: Represent a state that needs to maintain its metadata regularly
* CleanState: Represent a state organized via detectorId.  When deleting a detector's state, we can remove it from the state.

Testing done:
1. other unit tests cover them
2. end-to-end testing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
