### PR TITLE
Add memory tracker

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/MemoryTracker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/MemoryTracker.java
@@ -204,7 +204,7 @@ public class MemoryTracker {
      * Bytes to remove to keep AD memory usage within the limit
      * @return bytes to remove
      */
-    public long memoryToShed() {
+    public synchronized long memoryToShed() {
         return totalMemoryBytes - heapLimitBytes;
     }
 
@@ -234,12 +234,13 @@ public class MemoryTracker {
      * @param origin Origin
      * @param totalBytes total bytes from recomputing
      * @param reservedBytes reserved bytes from recomputing
+     * @return whether memory adjusted due to mismatch
      */
-    public synchronized void syncMemoryState(Origin origin, long totalBytes, long reservedBytes) {
+    public synchronized boolean syncMemoryState(Origin origin, long totalBytes, long reservedBytes) {
         long recordedTotalBytes = totalMemoryBytesByOrigin.getOrDefault(origin, 0L);
         long recordedReservedBytes = reservedMemoryBytesByOrigin.getOrDefault(origin, 0L);
         if (totalBytes == recordedTotalBytes && reservedBytes == recordedReservedBytes) {
-            return;
+            return false;
         }
         LOG
             .info(
@@ -261,5 +262,6 @@ public class MemoryTracker {
         long totalDiff = totalBytes - recordedTotalBytes;
         totalMemoryBytesByOrigin.put(origin, totalBytes);
         totalMemoryBytes += totalDiff;
+        return true;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/MemoryTracker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/MemoryTracker.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.monitor.jvm.JvmService;
+
+import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.randomcutforest.RandomCutForest;
+
+/**
+ * Class to track AD memory usage.
+ *
+ */
+public class MemoryTracker {
+    private static final Logger LOG = LogManager.getLogger(MemoryTracker.class);
+
+    public enum Origin {
+        SINGLE_ENTITY_DETECTOR,
+        MULTI_ENTITY_DETECTOR
+    }
+
+    // memory tracker for total consumption of bytes
+    private long totalMemoryBytes;
+    private final Map<Origin, Long> totalMemoryBytesByOrigin;
+    // reserved for models. Cannot be deleted at will.
+    private long reservedMemoryBytes;
+    private final Map<Origin, Long> reservedMemoryBytesByOrigin;
+    private long heapSize;
+    private long heapLimitBytes;
+    private long desiredModelSize;
+    // we observe threshold model uses a fixed size array and the size is the same
+    private int thresholdModelBytes;
+    private int sampleSize;
+
+    /**
+     * Constructor
+     *
+     * @param jvmService Service providing jvm info
+     * @param modelMaxSizePercentage Percentage of heap for the max size of a model
+     * @param modelDesiredSizePercentage percentage of heap for the desired size of a model
+     * @param clusterService Cluster service object
+     * @param sampleSize The sample size used by stream samplers in a RCF forest
+     */
+    public MemoryTracker(
+        JvmService jvmService,
+        double modelMaxSizePercentage,
+        double modelDesiredSizePercentage,
+        ClusterService clusterService,
+        int sampleSize
+    ) {
+        this.totalMemoryBytes = 0;
+        this.totalMemoryBytesByOrigin = new EnumMap<Origin, Long>(Origin.class);
+        this.reservedMemoryBytes = 0;
+        this.reservedMemoryBytesByOrigin = new EnumMap<Origin, Long>(Origin.class);
+        this.heapSize = jvmService.info().getMem().getHeapMax().getBytes();
+        this.heapLimitBytes = (long) (heapSize * modelMaxSizePercentage);
+        this.desiredModelSize = (long) (heapSize * modelDesiredSizePercentage);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(MODEL_MAX_SIZE_PERCENTAGE, it -> this.heapLimitBytes = (long) (heapSize * it));
+        this.thresholdModelBytes = 180_000;
+        this.sampleSize = sampleSize;
+    }
+
+    public synchronized boolean isHostingAllowed(String detectorId, RandomCutForest rcf) {
+        return canAllocateReserved(detectorId, estimateModelSize(rcf));
+    }
+
+    /**
+     * @param detectorId Detector Id, used in error message
+     * @param requiredBytes required bytes in memory
+     * @return whether there is memory required for AD
+     */
+    public synchronized boolean canAllocateReserved(String detectorId, long requiredBytes) {
+        if (reservedMemoryBytes + requiredBytes <= heapLimitBytes) {
+            return true;
+        } else {
+            throw new LimitExceededException(
+                detectorId,
+                String
+                    .format(
+                        "Exceeded memory limit. New size is %d bytes and max limit is %d bytes",
+                        reservedMemoryBytes + requiredBytes,
+                        heapLimitBytes
+                    )
+            );
+        }
+    }
+
+    /**
+     * Whether allocating memory is allowed
+     * @param bytes required bytes
+     * @return true if allowed; false otherwise
+     */
+    public synchronized boolean canAllocate(long bytes) {
+        return totalMemoryBytes + bytes <= heapLimitBytes;
+    }
+
+    public synchronized void consumeMemory(long memoryToConsume, boolean reserved, Origin origin) {
+        totalMemoryBytes += memoryToConsume;
+        adjustOriginMemoryConsumption(memoryToConsume, origin, totalMemoryBytesByOrigin);
+        if (reserved) {
+            reservedMemoryBytes += memoryToConsume;
+            adjustOriginMemoryConsumption(memoryToConsume, origin, reservedMemoryBytesByOrigin);
+        }
+    }
+
+    private void adjustOriginMemoryConsumption(long memoryToConsume, Origin origin, Map<Origin, Long> mapToUpdate) {
+        Long originTotalMemoryBytes = mapToUpdate.getOrDefault(origin, 0L);
+        mapToUpdate.put(origin, originTotalMemoryBytes + memoryToConsume);
+    }
+
+    public synchronized void releaseMemory(long memoryToShed, boolean reserved, Origin origin) {
+        totalMemoryBytes -= memoryToShed;
+        adjustOriginMemoryRelease(memoryToShed, origin, totalMemoryBytesByOrigin);
+        if (reserved) {
+            reservedMemoryBytes -= memoryToShed;
+            adjustOriginMemoryRelease(memoryToShed, origin, reservedMemoryBytesByOrigin);
+        }
+    }
+
+    private void adjustOriginMemoryRelease(long memoryToConsume, Origin origin, Map<Origin, Long> mapToUpdate) {
+        Long originTotalMemoryBytes = mapToUpdate.get(origin);
+        if (originTotalMemoryBytes != null) {
+            mapToUpdate.put(origin, originTotalMemoryBytes - memoryToConsume);
+        }
+    }
+
+    /**
+     * Gets the estimated size of an entity's model.
+     *
+     * @param forest RCF forest object
+     * @return estimated model size in bytes
+     */
+    public long estimateModelSize(RandomCutForest forest) {
+        return estimateModelSize(forest.getDimensions(), forest.getNumberOfTrees(), forest.getSampleSize());
+    }
+
+    /**
+     * Gets the estimated size of an entity's model according to
+     * the detector configuration.
+     *
+     * @param detector detector config object
+     * @param numberOfTrees the number of trees in a RCF forest
+     * @return estimated model size in bytes
+     */
+    public long estimateModelSize(AnomalyDetector detector, int numberOfTrees) {
+        return estimateModelSize(detector.getEnabledFeatureIds().size() * detector.getShingleSize(), numberOfTrees, sampleSize);
+    }
+
+    /**
+     * Gets the estimated size of an entity's model.
+     * RCF size:
+     * (Num_trees * num_samples * ( (16*dimensions + 84) + (24*dimensions + 48))）
+     *
+     * (16*dimensions + 84) is for non-leaf node.  16 are for two doubles for min and max.
+     * 84 is the meta-data size we observe from jmap data.
+     * (24*dimensions + 48)) is for leaf node.  We find a leaf node has 3 vectors: leaf pointers,
+     *  min, and max arrays from jmap data.  That’s why we use 24 ( 3 doubles).  48 is the
+     *  meta-data size we observe from jmap data.
+     *
+     * Sampler size:
+     * Number_of_trees * num_samples * ( 12 (object) + 8 (subsequence) + 8 (weight) + 8 (point reference))
+     *
+     * The range of mem usage of RCF model in our test(1feature, 1 shingle) is from ~400K to ~800K.
+     * Using shingle size 1 and 1 feature (total dimension = 1), one rcf’s size is of 532 K,
+     * which lies in our range of 400~800 k.
+     *
+     * @param dimension The number of feature dimensions in RCF
+     * @param numberOfTrees The number of trees in RCF
+     * @param numSamples The number of samples in RCF
+     * @return estimated model size in bytes
+     */
+    private long estimateModelSize(int dimension, int numberOfTrees, int numSamples) {
+        long totalSamples = (long) numberOfTrees * (long) numSamples;
+        long rcfSize = totalSamples * (40 * dimension + 132);
+        long samplerSize = totalSamples * 36;
+        return rcfSize + samplerSize + thresholdModelBytes;
+    }
+
+    /**
+     * Bytes to remove to keep AD memory usage within the limit
+     * @return bytes to remove
+     */
+    public long memoryToShed() {
+        return totalMemoryBytes - heapLimitBytes;
+    }
+
+    /**
+     *
+     * @return Allowed heap usage in bytes by AD models
+     */
+    public long getHeapLimit() {
+        return heapLimitBytes;
+    }
+
+    /**
+     *
+     * @return Desired model partition size in bytes
+     */
+    public long getDesiredModelSize() {
+        return desiredModelSize;
+    }
+
+    public long getTotalMemoryBytes() {
+        return totalMemoryBytes;
+    }
+
+    /**
+     * In case of bugs/race conditions when allocating/releasing memory, sync used bytes
+     * infrequently by recomputing memory usage.
+     * @param origin Origin
+     * @param totalBytes total bytes from recomputing
+     * @param reservedBytes reserved bytes from recomputing
+     */
+    public synchronized void syncMemoryState(Origin origin, long totalBytes, long reservedBytes) {
+        long recordedTotalBytes = totalMemoryBytesByOrigin.getOrDefault(origin, 0L);
+        long recordedReservedBytes = reservedMemoryBytesByOrigin.getOrDefault(origin, 0L);
+        if (totalBytes == recordedTotalBytes && reservedBytes == recordedReservedBytes) {
+            return;
+        }
+        LOG
+            .info(
+                String
+                    .format(
+                        "Memory states do not match.  Recorded: total bytes %d, reserved bytes %d."
+                            + "Actual: total bytes %d, reserved bytes: %d",
+                        recordedTotalBytes,
+                        recordedReservedBytes,
+                        totalBytes,
+                        reservedBytes
+                    )
+            );
+        // reserved bytes mismatch
+        long reservedDiff = reservedBytes - recordedReservedBytes;
+        reservedMemoryBytesByOrigin.put(origin, reservedBytes);
+        reservedMemoryBytes += reservedDiff;
+
+        long totalDiff = totalBytes - recordedTotalBytes;
+        totalMemoryBytesByOrigin.put(origin, totalBytes);
+        totalMemoryBytes += totalDiff;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/RCFMemoryAwareConcurrentHashmap.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/RCFMemoryAwareConcurrentHashmap.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.ml;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker.Origin;
+import com.amazon.randomcutforest.RandomCutForest;
+
+public class RCFMemoryAwareConcurrentHashmap<K> extends ConcurrentHashMap<K, ModelState<RandomCutForest>> {
+    private final MemoryTracker memoryTracker;
+
+    public RCFMemoryAwareConcurrentHashmap(MemoryTracker memoryTracker) {
+        this.memoryTracker = memoryTracker;
+    }
+
+    @Override
+    public ModelState<RandomCutForest> remove(Object key) {
+        ModelState<RandomCutForest> deletedModeState = super.remove(key);
+        if (deletedModeState != null && deletedModeState.getModel() != null) {
+            long memoryToShed = memoryTracker.estimateModelSize(deletedModeState.getModel());
+            memoryTracker.releaseMemory(memoryToShed, true, Origin.SINGLE_ENTITY_DETECTOR);
+        }
+        return deletedModeState;
+    }
+
+    @Override
+    public ModelState<RandomCutForest> put(K key, ModelState<RandomCutForest> value) {
+        ModelState<RandomCutForest> previousAssociatedState = super.put(key, value);
+        if (value != null && value.getModel() != null) {
+            long memoryToShed = memoryTracker.estimateModelSize(value.getModel());
+            memoryTracker.consumeMemory(memoryToShed, true, Origin.SINGLE_ENTITY_DETECTOR);
+        }
+        return previousAssociatedState;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/RCFMemoryAwareConcurrentHashmap.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/RCFMemoryAwareConcurrentHashmap.java
@@ -39,8 +39,8 @@ public class RCFMemoryAwareConcurrentHashmap<K> extends ConcurrentHashMap<K, Mod
     public ModelState<RandomCutForest> remove(Object key) {
         ModelState<RandomCutForest> deletedModelState = super.remove(key);
         if (deletedModelState != null && deletedModelState.getModel() != null) {
-            long memoryToShed = memoryTracker.estimateModelSize(deletedModelState.getModel());
-            memoryTracker.releaseMemory(memoryToShed, true, Origin.SINGLE_ENTITY_DETECTOR);
+            long memoryToRelease = memoryTracker.estimateModelSize(deletedModelState.getModel());
+            memoryTracker.releaseMemory(memoryToRelease, true, Origin.SINGLE_ENTITY_DETECTOR);
         }
         return deletedModelState;
     }
@@ -49,8 +49,8 @@ public class RCFMemoryAwareConcurrentHashmap<K> extends ConcurrentHashMap<K, Mod
     public ModelState<RandomCutForest> put(K key, ModelState<RandomCutForest> value) {
         ModelState<RandomCutForest> previousAssociatedState = super.put(key, value);
         if (value != null && value.getModel() != null) {
-            long memoryToShed = memoryTracker.estimateModelSize(value.getModel());
-            memoryTracker.consumeMemory(memoryToShed, true, Origin.SINGLE_ENTITY_DETECTOR);
+            long memoryToConsume = memoryTracker.estimateModelSize(value.getModel());
+            memoryTracker.consumeMemory(memoryToConsume, true, Origin.SINGLE_ENTITY_DETECTOR);
         }
         return previousAssociatedState;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/RCFMemoryAwareConcurrentHashmap.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/RCFMemoryAwareConcurrentHashmap.java
@@ -21,6 +21,13 @@ import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
 import com.amazon.opendistroforelasticsearch.ad.MemoryTracker.Origin;
 import com.amazon.randomcutforest.RandomCutForest;
 
+/**
+ * A customized ConcurrentHashMap that can automatically consume and release memory.
+ * This enables minimum change to our single-entity code as we just have to replace
+ * the map implementation.
+ *
+ * Note: this is mainly used for single-entity detectors.
+ */
 public class RCFMemoryAwareConcurrentHashmap<K> extends ConcurrentHashMap<K, ModelState<RandomCutForest>> {
     private final MemoryTracker memoryTracker;
 
@@ -30,12 +37,12 @@ public class RCFMemoryAwareConcurrentHashmap<K> extends ConcurrentHashMap<K, Mod
 
     @Override
     public ModelState<RandomCutForest> remove(Object key) {
-        ModelState<RandomCutForest> deletedModeState = super.remove(key);
-        if (deletedModeState != null && deletedModeState.getModel() != null) {
-            long memoryToShed = memoryTracker.estimateModelSize(deletedModeState.getModel());
+        ModelState<RandomCutForest> deletedModelState = super.remove(key);
+        if (deletedModelState != null && deletedModelState.getModel() != null) {
+            long memoryToShed = memoryTracker.estimateModelSize(deletedModelState.getModel());
             memoryTracker.releaseMemory(memoryToShed, true, Origin.SINGLE_ENTITY_DETECTOR);
         }
-        return deletedModeState;
+        return deletedModelState;
     }
 
     @Override

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/MemoryTrackerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/MemoryTrackerTests.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.monitor.jvm.JvmInfo.Mem;
+import org.elasticsearch.monitor.jvm.JvmService;
+import org.elasticsearch.test.ESTestCase;
+
+import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.randomcutforest.RandomCutForest;
+
+public class MemoryTrackerTests extends ESTestCase {
+
+    int rcfNumFeatures;
+    int rcfSampleSize;
+    int numberOfTrees;
+    double rcfTimeDecay;
+    int numMinSamples;
+    MemoryTracker tracker;
+    long expectedModelSize;
+    String detectorId;
+    long largeHeapSize;
+    long smallHeapSize;
+    Mem mem;
+    RandomCutForest rcf;
+    float modelMaxPercen;
+    ClusterService clusterService;
+    double modelMaxSizePercentage;
+    double modelDesiredSizePercentage;
+    JvmService jvmService;
+    AnomalyDetector detector;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        rcfNumFeatures = 1;
+        rcfSampleSize = 256;
+        numberOfTrees = 10;
+        rcfTimeDecay = 0.2;
+        numMinSamples = 128;
+
+        jvmService = mock(JvmService.class);
+        JvmInfo info = mock(JvmInfo.class);
+        mem = mock(Mem.class);
+        // 800 MB is the limit
+        largeHeapSize = 800_000_000;
+        smallHeapSize = 1_000_000;
+
+        when(jvmService.info()).thenReturn(info);
+        when(info.getMem()).thenReturn(mem);
+
+        modelMaxSizePercentage = 0.1;
+        modelDesiredSizePercentage = 0.0002;
+
+        clusterService = mock(ClusterService.class);
+        modelMaxPercen = 0.1f;
+        Settings settings = Settings.builder().put(AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE.getKey(), modelMaxPercen).build();
+        ClusterSettings clusterSettings = new ClusterSettings(
+            settings,
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE)))
+        );
+        when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+
+        expectedModelSize = 712480;
+        detectorId = "123";
+
+        rcf = RandomCutForest
+            .builder()
+            .dimensions(rcfNumFeatures)
+            .sampleSize(rcfSampleSize)
+            .numberOfTrees(numberOfTrees)
+            .lambda(rcfTimeDecay)
+            .outputAfter(numMinSamples)
+            .parallelExecutionEnabled(false)
+            .build();
+
+        detector = mock(AnomalyDetector.class);
+        when(detector.getEnabledFeatureIds()).thenReturn(Collections.singletonList("a"));
+        when(detector.getShingleSize()).thenReturn(1);
+    }
+
+    private void setUpBigHeap() {
+        ByteSizeValue value = new ByteSizeValue(largeHeapSize);
+        when(mem.getHeapMax()).thenReturn(value);
+        tracker = new MemoryTracker(jvmService, modelMaxSizePercentage, modelDesiredSizePercentage, clusterService, rcfSampleSize);
+    }
+
+    private void setUpSmallHeap() {
+        ByteSizeValue value = new ByteSizeValue(smallHeapSize);
+        when(mem.getHeapMax()).thenReturn(value);
+        tracker = new MemoryTracker(jvmService, modelMaxSizePercentage, modelDesiredSizePercentage, clusterService, rcfSampleSize);
+    }
+
+    public void testEstimateModelSize() {
+        setUpBigHeap();
+
+        assertEquals(expectedModelSize, tracker.estimateModelSize(rcf));
+        assertTrue(tracker.isHostingAllowed(detectorId, rcf));
+
+        assertEquals(expectedModelSize, tracker.estimateModelSize(detector, numberOfTrees));
+    }
+
+    public void testCanAllocate() {
+        setUpBigHeap();
+
+        assertTrue(tracker.canAllocate((long) (largeHeapSize * modelMaxPercen)));
+        assertTrue(!tracker.canAllocate((long) (largeHeapSize * modelMaxPercen + 10)));
+
+        long bytesToUse = 100_000;
+        tracker.consumeMemory(bytesToUse, false, MemoryTracker.Origin.MULTI_ENTITY_DETECTOR);
+        assertTrue(!tracker.canAllocate((long) (largeHeapSize * modelMaxPercen)));
+
+        tracker.releaseMemory(bytesToUse, false, MemoryTracker.Origin.MULTI_ENTITY_DETECTOR);
+        assertTrue(tracker.canAllocate((long) (largeHeapSize * modelMaxPercen)));
+    }
+
+    public void testCannotHost() {
+        setUpSmallHeap();
+        expectThrows(LimitExceededException.class, () -> tracker.isHostingAllowed(detectorId, rcf));
+    }
+
+    public void testMemoryToShed() {
+        setUpSmallHeap();
+        long bytesToUse = 100_000;
+        assertEquals(bytesToUse, tracker.getHeapLimit());
+        assertEquals((long) (smallHeapSize * modelDesiredSizePercentage), tracker.getDesiredModelSize());
+        tracker.consumeMemory(bytesToUse, false, MemoryTracker.Origin.MULTI_ENTITY_DETECTOR);
+        tracker.consumeMemory(bytesToUse, true, MemoryTracker.Origin.MULTI_ENTITY_DETECTOR);
+        assertEquals(2 * bytesToUse, tracker.getTotalMemoryBytes());
+
+        assertEquals(bytesToUse, tracker.memoryToShed());
+        assertTrue(!tracker.syncMemoryState(MemoryTracker.Origin.MULTI_ENTITY_DETECTOR, 2 * bytesToUse, bytesToUse));
+    }
+}


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*

Previously, when creating a model, we evaluate all existing models and compare the total with the 10% heap memory limit.  If yes, we proceed to create the model.  Otherwise, we throw exceptions.  This does not work for multi-entity detectors.  First, there can be a lot of models in cache.  Reevaluating them every time we want to add a model is not efficient.  Second, we have two sources of memory usage now: single-entity and multi-entity detectors.  We need a central place to track memory usage across the board as we add more and more kinds of detectors.  This PR achieves the purpose.

This PR also updates RCF model size estimation.  Previously, we underestimated the size.

This PR also adds threshold model size estimation.  Previously, we didn't consider it.

This PR also adds a customized hashmap that can automatically consume and release memory.  This enables minimum change to our single-entity code as we just have to replace the map implementation.

Testing done:
1. added unit tests.
2. end-to-end testing pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
