### PR TITLE
Rename TransportState to NodeState

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
@@ -68,7 +68,6 @@ import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
-import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.AnomalyIndexHandler;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.DetectionStateHandler;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
@@ -68,7 +68,7 @@ import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
-import com.amazon.opendistroforelasticsearch.ad.transport.TransportStateManager;
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.AnomalyIndexHandler;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.DetectionStateHandler;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
@@ -152,7 +152,7 @@ public class AnomalyDetectorJobRunnerTests extends AbstractADTest {
         AnomalyDetectionIndices anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
         IndexNameExpressionResolver indexNameResolver = mock(IndexNameExpressionResolver.class);
         IndexUtils indexUtils = new IndexUtils(client, clientUtil, clusterService, indexNameResolver);
-        TransportStateManager stateManager = mock(TransportStateManager.class);
+        NodeStateManager stateManager = mock(NodeStateManager.class);
         detectorStateHandler = new DetectionStateHandler(
             client,
             settings,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/NodeStateManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/NodeStateManagerTests.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelPartitioner;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
+import com.amazon.opendistroforelasticsearch.ad.util.Throttler;
+import com.google.common.collect.ImmutableMap;
+
+public class NodeStateManagerTests extends ESTestCase {
+    private NodeStateManager stateManager;
+    private ModelPartitioner modelPartitioner;
+    private Client client;
+    private ClientUtil clientUtil;
+    private Clock clock;
+    private Duration duration;
+    private Throttler throttler;
+    private ThreadPool context;
+    private AnomalyDetector detectorToCheck;
+    private Settings settings;
+    private String adId = "123";
+
+    private GetResponse checkpointResponse;
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
+        return new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        modelPartitioner = mock(ModelPartitioner.class);
+        when(modelPartitioner.getPartitionedForestSizes(any(AnomalyDetector.class))).thenReturn(new SimpleImmutableEntry<>(2, 20));
+        client = mock(Client.class);
+        settings = Settings
+            .builder()
+            .put("opendistro.anomaly_detection.max_retry_for_unresponsive_node", 3)
+            .put("opendistro.anomaly_detection.ad_mute_minutes", TimeValue.timeValueMinutes(10))
+            .build();
+        clock = mock(Clock.class);
+        duration = Duration.ofHours(1);
+        context = TestHelpers.createThreadPool();
+        throttler = new Throttler(clock);
+
+        clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, mock(ThreadPool.class));
+        stateManager = new NodeStateManager(client, xContentRegistry(), settings, clientUtil, clock, duration, modelPartitioner);
+
+        checkpointResponse = mock(GetResponse.class);
+    }
+
+    @Override
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        stateManager = null;
+        modelPartitioner = null;
+        client = null;
+        clientUtil = null;
+        detectorToCheck = null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private String setupDetector() throws IOException {
+        detectorToCheck = TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null, true);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 2);
+
+            GetRequest request = null;
+            ActionListener<GetResponse> listener = null;
+            if (args[0] instanceof GetRequest) {
+                request = (GetRequest) args[0];
+            }
+            if (args[1] instanceof ActionListener) {
+                listener = (ActionListener<GetResponse>) args[1];
+            }
+
+            assertTrue(request != null && listener != null);
+            listener
+                .onResponse(
+                    TestHelpers.createGetResponse(detectorToCheck, detectorToCheck.getDetectorId(), AnomalyDetector.ANOMALY_DETECTORS_INDEX)
+                );
+
+            return null;
+        }).when(client).get(any(), any(ActionListener.class));
+        return detectorToCheck.getDetectorId();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupCheckpoint(boolean responseExists) throws IOException {
+        when(checkpointResponse.isExists()).thenReturn(responseExists);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            assertTrue(String.format("The size of args is %d.  Its content is %s", args.length, Arrays.toString(args)), args.length >= 2);
+
+            GetRequest request = null;
+            ActionListener<GetResponse> listener = null;
+            if (args[0] instanceof GetRequest) {
+                request = (GetRequest) args[0];
+            }
+            if (args[1] instanceof ActionListener) {
+                listener = (ActionListener<GetResponse>) args[1];
+            }
+
+            assertTrue(request != null && listener != null);
+            listener.onResponse(checkpointResponse);
+
+            return null;
+        }).when(client).get(any(), any(ActionListener.class));
+    }
+
+    public void testGetPartitionNumber() throws IOException, InterruptedException {
+        String detectorId = setupDetector();
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null);
+        for (int i = 0; i < 2; i++) {
+            // call two times should return the same result
+            int partitionNumber = stateManager.getPartitionNumber(detectorId, detector);
+            assertEquals(2, partitionNumber);
+        }
+
+        // the 2nd call should directly fetch cached result
+        verify(modelPartitioner, times(1)).getPartitionedForestSizes(any());
+    }
+
+    public void testGetLastError() throws IOException, InterruptedException {
+        String error = "blah";
+        assertEquals(NodeStateManager.NO_ERROR, stateManager.getLastDetectionError(adId));
+        stateManager.setLastDetectionError(adId, error);
+        assertEquals(error, stateManager.getLastDetectionError(adId));
+    }
+
+    public void testShouldMute() {
+        String nodeId = "123";
+        assertTrue(!stateManager.isMuted(nodeId));
+
+        when(clock.millis()).thenReturn(10000L);
+        IntStream.range(0, 4).forEach(j -> stateManager.addPressure(nodeId));
+
+        when(clock.millis()).thenReturn(20000L);
+        assertTrue(stateManager.isMuted(nodeId));
+
+        // > 15 minutes have passed, we should not mute anymore
+        when(clock.millis()).thenReturn(1000001L);
+        assertTrue(!stateManager.isMuted(nodeId));
+
+        // the backpressure counter should be reset
+        when(clock.millis()).thenReturn(100001L);
+        stateManager.resetBackpressureCounter(nodeId);
+        assertTrue(!stateManager.isMuted(nodeId));
+    }
+
+    public void testMaintenanceDoNothing() {
+        stateManager.maintenance();
+
+        verifyZeroInteractions(clock);
+    }
+
+    public void testHasRunningQuery() throws IOException {
+        stateManager = new NodeStateManager(
+            client,
+            xContentRegistry(),
+            settings,
+            new ClientUtil(settings, client, throttler, context),
+            clock,
+            duration,
+            modelPartitioner
+        );
+
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of(), null);
+        SearchRequest dummySearchRequest = new SearchRequest();
+        assertFalse(stateManager.hasRunningQuery(detector));
+        throttler.insertFilteredQuery(detector.getDetectorId(), dummySearchRequest);
+        assertTrue(stateManager.hasRunningQuery(detector));
+    }
+
+    public void testGetAnomalyDetector() throws IOException, InterruptedException {
+        String detectorId = setupDetector();
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+        stateManager.getAnomalyDetector(detectorId, ActionListener.wrap(asDetector -> {
+            assertEquals(detectorToCheck, asDetector.get());
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue(false);
+            inProgressLatch.countDown();
+        }));
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    public void getCheckpointTestTemplate(boolean exists) throws IOException {
+        setupCheckpoint(exists);
+        when(clock.instant()).thenReturn(Instant.MIN);
+        stateManager
+            .getDetectorCheckpoint(adId, ActionListener.wrap(checkpointExists -> { assertEquals(exists, checkpointExists); }, exception -> {
+                for (StackTraceElement ste : exception.getStackTrace()) {
+                    logger.info(ste);
+                }
+                assertTrue(false);
+            }));
+    }
+
+    public void testCheckpointExists() throws IOException {
+        getCheckpointTestTemplate(true);
+    }
+
+    public void testCheckpointNotExists() throws IOException {
+        getCheckpointTestTemplate(false);
+    }
+
+    public void testMaintenanceNotRemove() throws IOException {
+        setupCheckpoint(true);
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(1));
+        stateManager
+            .getDetectorCheckpoint(
+                adId,
+                ActionListener.wrap(gotCheckpoint -> { assertTrue(gotCheckpoint); }, exception -> assertTrue(false))
+            );
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(1));
+        stateManager.maintenance();
+        stateManager
+            .getDetectorCheckpoint(adId, ActionListener.wrap(gotCheckpoint -> assertTrue(gotCheckpoint), exception -> assertTrue(false)));
+        verify(client, times(1)).get(any(), any());
+    }
+
+    public void testMaintenanceRemove() throws IOException {
+        setupCheckpoint(true);
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(1));
+        stateManager
+            .getDetectorCheckpoint(
+                adId,
+                ActionListener.wrap(gotCheckpoint -> { assertTrue(gotCheckpoint); }, exception -> assertTrue(false))
+            );
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(7200L));
+        stateManager.maintenance();
+        stateManager
+            .getDetectorCheckpoint(
+                adId,
+                ActionListener.wrap(gotCheckpoint -> { assertTrue(gotCheckpoint); }, exception -> assertTrue(false))
+            );
+        verify(client, times(2)).get(any(), any());
+    }
+
+    public void testColdStartRunning() {
+        assertTrue(!stateManager.isColdStartRunning(adId));
+        stateManager.markColdStartRunning(adId);
+        assertTrue(stateManager.isColdStartRunning(adId));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/NodeStateTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/NodeStateTests.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+import org.elasticsearch.test.ESTestCase;
+
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+
+public class NodeStateTests extends ESTestCase {
+    private NodeState state;
+    private Clock clock;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        clock = mock(Clock.class);
+        state = new NodeState("123", clock);
+    }
+
+    private Duration duration = Duration.ofHours(1);
+
+    public void testMaintenanceNotRemoveSingle() throws IOException {
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(1000));
+        state.setDetectorDef(TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null));
+
+        when(clock.instant()).thenReturn(Instant.MIN);
+        assertTrue(!state.expired(duration));
+    }
+
+    public void testMaintenanceNotRemove() throws IOException {
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(1000));
+        state.setDetectorDef(TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null));
+        state.setLastDetectionError(null);
+
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(3700));
+        assertTrue(!state.expired(duration));
+    }
+
+    public void testMaintenanceRemoveLastError() throws IOException {
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(1000));
+        state
+            .setDetectorDef(
+
+                TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null)
+            );
+        state.setLastDetectionError(null);
+
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(3700));
+        assertTrue(state.expired(duration));
+    }
+
+    public void testMaintenancRemoveDetector() throws IOException {
+        when(clock.instant()).thenReturn(Instant.MIN);
+        state.setDetectorDef(TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), null));
+        when(clock.instant()).thenReturn(Instant.MAX);
+        assertTrue(state.expired(duration));
+
+    }
+
+    public void testMaintenanceFlagNotRemove() throws IOException {
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(1000));
+        state.setCheckpointExists(true);
+        when(clock.instant()).thenReturn(Instant.MIN);
+        assertTrue(!state.expired(duration));
+    }
+
+    public void testMaintenancFlagRemove() throws IOException {
+        when(clock.instant()).thenReturn(Instant.MIN);
+        state.setCheckpointExists(true);
+        when(clock.instant()).thenReturn(Instant.MIN);
+        assertTrue(!state.expired(duration));
+    }
+
+    public void testMaintenanceLastColdStartRemoved() {
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(1000));
+        state.setLastColdStartException(new AnomalyDetectionException("123", ""));
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(3700));
+        assertTrue(state.expired(duration));
+    }
+
+    public void testMaintenanceLastColdStartNotRemoved() {
+        when(clock.instant()).thenReturn(Instant.ofEpochMilli(1_000_000L));
+        state.setLastColdStartException(new AnomalyDetectionException("123", ""));
+        when(clock.instant()).thenReturn(Instant.ofEpochSecond(3700));
+        assertTrue(!state.expired(duration));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportActionTests.java
@@ -42,6 +42,8 @@ import org.junit.Before;
 import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
 
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
+import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
@@ -64,9 +66,10 @@ public class CronTransportActionTests extends AbstractADTest {
 
         TransportService transportService = mock(TransportService.class);
         ActionFilters actionFilters = mock(ActionFilters.class);
-        TransportStateManager tarnsportStatemanager = mock(TransportStateManager.class);
+        NodeStateManager tarnsportStatemanager = mock(NodeStateManager.class);
         ModelManager modelManager = mock(ModelManager.class);
         FeatureManager featureManager = mock(FeatureManager.class);
+        CacheProvider cacheProvider = mock(CacheProvider.class);
 
         action = new CronTransportAction(
             threadPool,
@@ -75,7 +78,8 @@ public class CronTransportActionTests extends AbstractADTest {
             actionFilters,
             tarnsportStatemanager,
             modelManager,
-            featureManager
+            featureManager,
+            cacheProvider
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/CronTransportActionTests.java
@@ -44,6 +44,7 @@ import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
+import com.amazon.opendistroforelasticsearch.ad.caching.EntityCache;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
@@ -70,6 +71,8 @@ public class CronTransportActionTests extends AbstractADTest {
         ModelManager modelManager = mock(ModelManager.class);
         FeatureManager featureManager = mock(FeatureManager.class);
         CacheProvider cacheProvider = mock(CacheProvider.class);
+        EntityCache entityCache = mock(EntityCache.class);
+        when(cacheProvider.get()).thenReturn(entityCache);
 
         action = new CronTransportAction(
             threadPool,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportActionTests.java
@@ -46,6 +46,8 @@ import org.junit.Before;
 import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
 
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
+import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
@@ -69,9 +71,10 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
 
         TransportService transportService = mock(TransportService.class);
         ActionFilters actionFilters = mock(ActionFilters.class);
-        TransportStateManager tarnsportStatemanager = mock(TransportStateManager.class);
+        NodeStateManager tarnsportStatemanager = mock(NodeStateManager.class);
         ModelManager modelManager = mock(ModelManager.class);
         FeatureManager featureManager = mock(FeatureManager.class);
+        CacheProvider cacheProvider = mock(CacheProvider.class);
 
         action = new DeleteModelTransportAction(
             threadPool,
@@ -80,7 +83,8 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
             actionFilters,
             tarnsportStatemanager,
             modelManager,
-            featureManager
+            featureManager,
+            cacheProvider
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteModelTransportActionTests.java
@@ -48,6 +48,7 @@ import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
+import com.amazon.opendistroforelasticsearch.ad.caching.EntityCache;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
@@ -71,17 +72,19 @@ public class DeleteModelTransportActionTests extends AbstractADTest {
 
         TransportService transportService = mock(TransportService.class);
         ActionFilters actionFilters = mock(ActionFilters.class);
-        NodeStateManager tarnsportStatemanager = mock(NodeStateManager.class);
+        NodeStateManager nodeStateManager = mock(NodeStateManager.class);
         ModelManager modelManager = mock(ModelManager.class);
         FeatureManager featureManager = mock(FeatureManager.class);
         CacheProvider cacheProvider = mock(CacheProvider.class);
+        EntityCache entityCache = mock(EntityCache.class);
+        when(cacheProvider.get()).thenReturn(entityCache);
 
         action = new DeleteModelTransportAction(
             threadPool,
             clusterService,
             transportService,
             actionFilters,
-            tarnsportStatemanager,
+            nodeStateManager,
             modelManager,
             featureManager,
             cacheProvider


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*

Previously, we have TransportState and TransportStateManager to track states used by transport layers.  Now the state is not only used by the transport layer. Methods like getDetector are used by ModelManager etc.  This PR renames the class to reflect the fact.

This PR also modifies how we track whether a cold start is running or not.  Previously, the caller had to manually set it on and off.  And we have a code everywhere.  Now, we return a Releasable object that can be called automatically.  The current way is more concise and easier to avoid bugs.

This PR also adds states to track last index throttling time as we face index rejections issues.

Testing done:
1. will add unit tests.
2. end-to-end testing pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
