### PR TITLE
Move a method from FeatureManager to AnomalyDetector

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -45,16 +45,16 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import com.amazon.opendistroforelasticsearch.ad.CleanState;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.Interpolator;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
-import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
 
 /**
  * A facade managing feature data operations and buffers.
  */
-public class FeatureManager {
+public class FeatureManager implements CleanState {
 
     private static final Logger logger = LogManager.getLogger(FeatureManager.class);
 
@@ -151,7 +151,7 @@ public class FeatureManager {
             .computeIfAbsent(detector.getDetectorId(), id -> new ArrayDeque<>(shingleSize));
 
         // To allow for small time variations/delays in running the detector.
-        long maxTimeDifference = getDetectorIntervalInMilliseconds(detector) / 2;
+        long maxTimeDifference = detector.getDetectorIntervalInMilliseconds() / 2;
         Map<Long, Entry<Long, Optional<double[]>>> featuresMap = getNearbyPointsForShingle(detector, shingle, endTime, maxTimeDifference)
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
@@ -180,7 +180,7 @@ public class FeatureManager {
         Map<Long, Entry<Long, Optional<double[]>>> featuresMap,
         long endTime
     ) {
-        long intervalMilli = getDetectorIntervalInMilliseconds(detector);
+        long intervalMilli = detector.getDetectorIntervalInMilliseconds();
         int shingleSize = detector.getShingleSize();
         return getFullShingleEndTimes(endTime, intervalMilli, shingleSize)
             .filter(time -> !featuresMap.containsKey(time))
@@ -215,7 +215,7 @@ public class FeatureManager {
         ActionListener<SinglePointFeatures> listener
     ) {
         shingle.clear();
-        getFullShingleEndTimes(endTime, getDetectorIntervalInMilliseconds(detector), detector.getShingleSize())
+        getFullShingleEndTimes(endTime, detector.getDetectorIntervalInMilliseconds(), detector.getShingleSize())
             .mapToObj(time -> featuresMap.getOrDefault(time, new SimpleImmutableEntry<>(time, Optional.empty())))
             .forEach(e -> shingle.add(e));
 
@@ -250,7 +250,7 @@ public class FeatureManager {
         double[][] result = null;
         if (filteredShingle.size() >= shingleSize - getMaxMissingPoints(shingleSize)) {
             // Imputes missing data points with the values of neighboring data points.
-            long maxMillisecondsDifference = maxNeighborDistance * getDetectorIntervalInMilliseconds(detector);
+            long maxMillisecondsDifference = maxNeighborDistance * detector.getDetectorIntervalInMilliseconds();
             result = getNearbyPointsForShingle(detector, filteredShingle, endTime, maxMillisecondsDifference)
                 .map(e -> e.getValue().getValue().orElse(null))
                 .filter(d -> d != null)
@@ -279,7 +279,7 @@ public class FeatureManager {
         long endTime,
         long maxMillisecondsDifference
     ) {
-        long intervalMilli = getDetectorIntervalInMilliseconds(detector);
+        long intervalMilli = detector.getDetectorIntervalInMilliseconds();
         int shingleSize = detector.getShingleSize();
         TreeMap<Long, Optional<double[]>> search = new TreeMap<>(
             shingle.stream().collect(Collectors.toMap(Entry::getKey, Entry::getValue))
@@ -294,10 +294,6 @@ public class FeatureManager {
                 .filter(e -> Math.abs(t - e.getKey()) < maxMillisecondsDifference)
                 .map(e -> new SimpleImmutableEntry<>(t, e));
         }).filter(Optional::isPresent).map(Optional::get);
-    }
-
-    private long getDetectorIntervalInMilliseconds(AnomalyDetector detector) {
-        return ((IntervalTimeConfiguration) detector.getDetectionInterval()).toDuration().toMillis();
     }
 
     private LongStream getFullShingleEndTimes(long endTime, long intervalMilli, int shingleSize) {
@@ -411,16 +407,12 @@ public class FeatureManager {
     }
 
     private List<Entry<Long, Long>> getColdStartSampleRanges(AnomalyDetector detector, long endMillis) {
-        long interval = getDetectionIntervalInMillis(detector);
+        long interval = detector.getDetectorIntervalInMilliseconds();
         int numSamples = Math.max((int) (Duration.ofHours(this.trainSampleTimeRangeInHours).toMillis() / interval), this.minTrainSamples);
         return IntStream
             .rangeClosed(1, numSamples)
             .mapToObj(i -> new SimpleImmutableEntry<>(endMillis - (numSamples - i + 1) * interval, endMillis - (numSamples - i) * interval))
             .collect(Collectors.toList());
-    }
-
-    private long getDetectionIntervalInMillis(AnomalyDetector detector) {
-        return ((IntervalTimeConfiguration) detector.getDetectionInterval()).toDuration().toMillis();
     }
 
     /**
@@ -453,6 +445,7 @@ public class FeatureManager {
      *
      * @param detectorId ID of the detector
      */
+    @Override
     public void clear(String detectorId) {
         detectorIdsToTimeShingles.remove(detectorId);
     }
@@ -524,7 +517,7 @@ public class FeatureManager {
     private Entry<List<Entry<Long, Long>>, Integer> getSampleRanges(AnomalyDetector detector, long startMilli, long endMilli) {
         long start = truncateToMinute(startMilli);
         long end = truncateToMinute(endMilli);
-        long bucketSize = getDetectorIntervalInMilliseconds(detector);
+        long bucketSize = detector.getDetectorIntervalInMilliseconds();
         int numBuckets = (int) Math.floor((end - start) / (double) bucketSize);
         int numSamples = (int) Math.max(Math.min(numBuckets * previewSampleRate, maxPreviewSamples), 1);
         int stride = (int) Math.max(1, Math.floor((double) numBuckets / numSamples));
@@ -604,7 +597,7 @@ public class FeatureManager {
         return unprocessedAndProcessed;
     }
 
-    private double[][] transpose(double[][] matrix) {
+    public double[][] transpose(double[][] matrix) {
         return createRealMatrix(matrix).transpose().getData();
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -168,43 +168,6 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         this.categoryFields = categoryFields;
     }
 
-    // TODO: remove after complete code merges. Created to not to touch too
-    // many places in one PR.
-    public AnomalyDetector(
-        String detectorId,
-        Long version,
-        String name,
-        String description,
-        String timeField,
-        List<String> indices,
-        List<Feature> features,
-        QueryBuilder filterQuery,
-        TimeConfiguration detectionInterval,
-        TimeConfiguration windowDelay,
-        Integer shingleSize,
-        Map<String, Object> uiMetadata,
-        Integer schemaVersion,
-        Instant lastUpdateTime
-    ) {
-        this(
-            detectorId,
-            version,
-            name,
-            description,
-            timeField,
-            indices,
-            features,
-            filterQuery,
-            detectionInterval,
-            windowDelay,
-            shingleSize,
-            uiMetadata,
-            schemaVersion,
-            lastUpdateTime,
-            null
-        );
-    }
-
     public AnomalyDetector(StreamInput input) throws IOException {
         detectorId = input.readString();
         version = input.readLong();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -23,18 +23,19 @@ import java.util.Locale;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
-import org.elasticsearch.test.ESTestCase;
 
+import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-public class AnomalyDetectorTests extends ESTestCase {
+public class AnomalyDetectorTests extends AbstractADTest {
 
     public void testParseAnomalyDetector() throws IOException {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(TestHelpers.randomUiMetadata(), Instant.now());
         String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        LOG.info(detectorString);
         detectorString = detectorString
             .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
         AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
@@ -138,7 +139,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     0,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -161,7 +163,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -184,7 +187,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -207,7 +211,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -230,7 +235,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -253,7 +259,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -276,7 +283,8 @@ public class AnomalyDetectorTests extends ESTestCase {
                     AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE,
                     null,
                     1,
-                    Instant.now()
+                    Instant.now(),
+                    null
                 )
             );
     }
@@ -311,7 +319,8 @@ public class AnomalyDetectorTests extends ESTestCase {
             5,
             null,
             1,
-            Instant.now()
+            Instant.now(),
+            null
         );
         assertEquals((int) anomalyDetector.getShingleSize(), 5);
     }
@@ -331,7 +340,8 @@ public class AnomalyDetectorTests extends ESTestCase {
             null,
             null,
             1,
-            Instant.now()
+            Instant.now(),
+            null
         );
         assertEquals((int) anomalyDetector.getShingleSize(), AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE);
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -100,6 +100,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             randomIntBetween(1, 2000),
             randomUiMetadata(),
             randomInt(),
+            null,
             null
         );
 
@@ -182,7 +183,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getShingleSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
-            detector.getLastUpdateTime()
+            detector.getLastUpdateTime(),
+            null
         );
 
         updateClusterSettings(EnabledSetting.AD_PLUGIN_ENABLED, false);
@@ -242,7 +244,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector1.getShingleSize(),
             detector1.getUiMetadata(),
             detector1.getSchemaVersion(),
-            detector1.getLastUpdateTime()
+            detector1.getLastUpdateTime(),
+            null
         );
 
         TestHelpers
@@ -278,7 +281,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getShingleSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
-            Instant.now()
+            Instant.now(),
+            null
         );
 
         TestHelpers
@@ -320,7 +324,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getShingleSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
-            detector.getLastUpdateTime()
+            detector.getLastUpdateTime(),
+            null
         );
 
         deleteIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX);
@@ -702,7 +707,8 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
             detector.getShingleSize(),
             detector.getUiMetadata(),
             detector.getSchemaVersion(),
-            detector.getLastUpdateTime()
+            detector.getLastUpdateTime(),
+            null
         );
 
         TestHelpers


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*

This PR moves the getDetectorIntervalInMilliseconds method from FeatureManager to AnomalyDetector as we have other similar methods in AnomalyDetector.  Putting them in one place is easier to manage and gives better encapsulation. 

We also make transpose public since it is needed by other classes like EntityColdStarter.

Testing done:
1. Manually tested it does not break things.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
