### PR TITLE
Add data structure for entity model

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityModel.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityModel.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.ml;
+
+import java.util.Queue;
+
+import com.amazon.randomcutforest.RandomCutForest;
+
+public class EntityModel {
+    private String modelId;
+    // TODO: sample should record timestamp
+    private Queue<double[]> samples;
+    private RandomCutForest rcf;
+    private ThresholdingModel threshold;
+
+    public EntityModel(String modelId, Queue<double[]> samples, RandomCutForest rcf, ThresholdingModel threshold) {
+        this.modelId = modelId;
+        this.samples = samples;
+        this.rcf = rcf;
+        this.threshold = threshold;
+    }
+
+    public String getModelId() {
+        return this.modelId;
+    }
+
+    public Queue<double[]> getSamples() {
+        return this.samples;
+    }
+
+    public void addSample(double[] sample) {
+        this.samples.add(sample);
+    }
+
+    public RandomCutForest getRcf() {
+        return this.rcf;
+    }
+
+    public ThresholdingModel getThreshold() {
+        return this.threshold;
+    }
+
+    public void setRcf(RandomCutForest rcf) {
+        this.rcf = rcf;
+    }
+
+    public void setThreshold(ThresholdingModel threshold) {
+        this.threshold = threshold;
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/stats/suppliers/ModelsOnNodeSupplierTests.java
@@ -56,16 +56,10 @@ public class ModelsOnNodeSupplierTests extends ESTestCase {
         expectedResults = new ArrayList<>(
             Arrays
                 .asList(
-                    new ModelState<>(rcf, "rcf-model-1", "detector-1", ModelManager.ModelType.RCF.getName(), clock.instant()),
-                    new ModelState<>(thresholdingModel, "thr-model-1", "detector-1", ModelManager.ModelType.RCF.getName(), clock.instant()),
-                    new ModelState<>(rcf, "rcf-model-2", "detector-2", ModelManager.ModelType.THRESHOLD.getName(), clock.instant()),
-                    new ModelState<>(
-                        thresholdingModel,
-                        "thr-model-2",
-                        "detector-2",
-                        ModelManager.ModelType.THRESHOLD.getName(),
-                        clock.instant()
-                    )
+                    new ModelState<>(rcf, "rcf-model-1", "detector-1", ModelManager.ModelType.RCF.getName(), clock, 0f),
+                    new ModelState<>(thresholdingModel, "thr-model-1", "detector-1", ModelManager.ModelType.RCF.getName(), clock, 0f),
+                    new ModelState<>(rcf, "rcf-model-2", "detector-2", ModelManager.ModelType.THRESHOLD.getName(), clock, 0f),
+                    new ModelState<>(thresholdingModel, "thr-model-2", "detector-2", ModelManager.ModelType.THRESHOLD.getName(), clock, 0f)
                 )
         );
 


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*
This PR adds a new kind of model state called EntityModel.  An entity state contains RCF and threshold models, priority, and recent sets of values (128 sets at most) arising at AD job run time and their start/end timestamps.

Testing done:
1. These data structures are used throughout our code.  They are covered by their callers' unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
