### PR TITLE
Add "main" function for model training and inference

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -15,14 +15,11 @@
 
 package com.amazon.opendistroforelasticsearch.ad.ml;
 
-import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MODEL_MAX_SIZE_PERCENTAGE;
-
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -31,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -43,15 +41,14 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.monitor.jvm.JvmService;
 
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.ResourceNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
 import com.amazon.opendistroforelasticsearch.ad.ml.rcf.CombinedRcfResult;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
-import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import com.amazon.randomcutforest.RandomCutForest;
 import com.amazon.randomcutforest.returntypes.DiVector;
 import com.amazon.randomcutforest.serialize.RandomCutForestSerDe;
@@ -61,14 +58,16 @@ import com.google.gson.Gson;
  * A facade managing ML operations and models.
  */
 public class ModelManager {
-
     protected static final String DETECTOR_ID_PATTERN = "(.*)_model_.+";
-    protected static final String RCF_MODEL_ID_PATTERN = "%s_model_rcf_%d";
-    protected static final String THRESHOLD_MODEL_ID_PATTERN = "%s_model_threshold";
+
+    protected static final String ENTITY_SAMPLE = "sp";
+    protected static final String ENTITY_RCF = "rcf";
+    protected static final String ENTITY_THRESHOLD = "th";
 
     public enum ModelType {
         RCF("rcf"),
-        THRESHOLD("threshold");
+        THRESHOLD("threshold"),
+        ENTITY("entity");
 
         private String name;
 
@@ -86,12 +85,10 @@ public class ModelManager {
     private static final Logger logger = LogManager.getLogger(ModelManager.class);
 
     // states
-    private Map<String, ModelState<RandomCutForest>> forests;
+    private RCFMemoryAwareConcurrentHashmap<String> forests;
     private Map<String, ModelState<ThresholdingModel>> thresholds;
 
     // configuration
-    private final double modelDesiredSizePercentage;
-    private double modelMaxSizePercentage;
     private final int rcfNumTrees;
     private final int rcfNumSamplesInTree;
     private final double rcfTimeDecay;
@@ -108,29 +105,23 @@ public class ModelManager {
     private final Duration checkpointInterval;
 
     // dependencies
-    private final DiscoveryNodeFilterer nodeFilter;
-    private final JvmService jvmService;
     private final RandomCutForestSerDe rcfSerde;
     private final CheckpointDao checkpointDao;
     private final Gson gson;
     private final Clock clock;
+    public FeatureManager featureManager;
 
-    // A tree of N samples has 2N nodes, with one bounding box for each node.
-    private static final long BOUNDING_BOXES = 2L;
-    // A bounding box has one vector for min values and one for max.
-    private static final long VECTORS_IN_BOUNDING_BOX = 2L;
+    private EntityColdStarter entityColdStarter;
+    private ModelPartitioner modelPartitioner;
+    private MemoryTracker memoryTracker;
 
     /**
      * Constructor.
      *
-     * @param nodeFilter utility class to select nodes
-     * @param jvmService jvm info
      * @param rcfSerde RCF model serialization
      * @param checkpointDao model checkpoint storage
      * @param gson thresholding model serialization
      * @param clock clock for system time
-     * @param modelDesiredSizePercentage percentage of heap for the desired size of a model
-     * @param modelMaxSizePercentage percentage of heap for the max size of a model
      * @param rcfNumTrees number of trees used in RCF
      * @param rcfNumSamplesInTree number of samples in a RCF tree
      * @param rcfTimeDecay time decay for RCF
@@ -145,17 +136,16 @@ public class ModelManager {
      * @param minPreviewSize minimum number of data points for preview
      * @param modelTtl time to live for hosted models
      * @param checkpointInterval interval between checkpoints
-     * @param clusterService cluster service object
+     * @param entityColdStarter Used train models on input data
+     * @param modelPartitioner Used to partition RCF models
+     * @param featureManager Used to create features for models
+     * @param memoryTracker AD memory usage tracker
      */
     public ModelManager(
-        DiscoveryNodeFilterer nodeFilter,
-        JvmService jvmService,
         RandomCutForestSerDe rcfSerde,
         CheckpointDao checkpointDao,
         Gson gson,
         Clock clock,
-        double modelDesiredSizePercentage,
-        double modelMaxSizePercentage,
         int rcfNumTrees,
         int rcfNumSamplesInTree,
         double rcfTimeDecay,
@@ -170,17 +160,16 @@ public class ModelManager {
         int minPreviewSize,
         Duration modelTtl,
         Duration checkpointInterval,
-        ClusterService clusterService
+        EntityColdStarter entityColdStarter,
+        ModelPartitioner modelPartitioner,
+        FeatureManager featureManager,
+        MemoryTracker memoryTracker
     ) {
 
-        this.nodeFilter = nodeFilter;
-        this.jvmService = jvmService;
         this.rcfSerde = rcfSerde;
         this.checkpointDao = checkpointDao;
         this.gson = gson;
         this.clock = clock;
-        this.modelDesiredSizePercentage = modelDesiredSizePercentage;
-        this.modelMaxSizePercentage = modelMaxSizePercentage;
         this.rcfNumTrees = rcfNumTrees;
         this.rcfNumSamplesInTree = rcfNumSamplesInTree;
         this.rcfTimeDecay = rcfTimeDecay;
@@ -196,10 +185,13 @@ public class ModelManager {
         this.modelTtl = modelTtl;
         this.checkpointInterval = checkpointInterval;
 
-        this.forests = new ConcurrentHashMap<>();
+        this.forests = new RCFMemoryAwareConcurrentHashmap<>(memoryTracker);
         this.thresholds = new ConcurrentHashMap<>();
 
-        clusterService.getClusterSettings().addSettingsUpdateConsumer(MODEL_MAX_SIZE_PERCENTAGE, it -> this.modelMaxSizePercentage = it);
+        this.entityColdStarter = entityColdStarter;
+        this.modelPartitioner = modelPartitioner;
+        this.featureManager = featureManager;
+        this.memoryTracker = memoryTracker;
     }
 
     /**
@@ -266,87 +258,6 @@ public class ModelManager {
     }
 
     /**
-     * Partitions a RCF model by forest size.
-     *
-     * A RCF model is first partitioned into desired size based on heap.
-     * If there are more partitions than the number of nodes in the cluster,
-     * the model is partitioned by the number of nodes and verified to
-     * ensure the size of a partition does not exceed the max size limit based on heap.
-     *
-     * @param forest RCF configuration, including forest size
-     * @param detectorId ID of the detector with no effects on partitioning
-     * @return a pair of number of partitions and size of a parition (number of trees)
-     * @throws LimitExceededException when there is no sufficient resource available
-     */
-    public Entry<Integer, Integer> getPartitionedForestSizes(RandomCutForest forest, String detectorId) {
-        long totalSize = estimateModelSize(forest);
-        long heapSize = jvmService.info().getMem().getHeapMax().getBytes();
-
-        // desired partitioning
-        long partitionSize = (long) (Math.min(heapSize * modelDesiredSizePercentage, totalSize));
-        int numPartitions = (int) Math.ceil((double) totalSize / (double) partitionSize);
-        int forestSize = (int) Math.ceil((double) forest.getNumberOfTrees() / (double) numPartitions);
-
-        int numNodes = nodeFilter.getEligibleDataNodes().length;
-        if (numPartitions > numNodes) {
-            // partition by cluster size
-            partitionSize = (long) Math.ceil((double) totalSize / (double) numNodes);
-            long maxPartitionSize = (long) (heapSize * modelMaxSizePercentage);
-            // verify against max size limit
-            if (partitionSize <= maxPartitionSize) {
-                numPartitions = numNodes;
-                forestSize = (int) Math.ceil((double) forest.getNumberOfTrees() / (double) numNodes);
-            } else {
-                throw new LimitExceededException(detectorId, CommonErrorMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG);
-            }
-        }
-
-        return new SimpleImmutableEntry<>(numPartitions, forestSize);
-    }
-
-    /**
-     * Construct a RCF model and then partition it by forest size.
-     *
-     * A RCF model is constructed based on the number of input features.
-     *
-     * Then a RCF model is first partitioned into desired size based on heap.
-     * If there are more partitions than the number of nodes in the cluster,
-     * the model is partitioned by the number of nodes and verified to
-     * ensure the size of a partition does not exceed the max size limit based on heap.
-     *
-     * @param detector detector object
-     * @return a pair of number of partitions and size of a parition (number of trees)
-     * @throws LimitExceededException when there is no sufficient resource available
-     */
-    public Entry<Integer, Integer> getPartitionedForestSizes(AnomalyDetector detector) {
-        int shingleSize = detector.getShingleSize();
-        String detectorId = detector.getDetectorId();
-        int rcfNumFeatures = detector.getEnabledFeatureIds().size() * shingleSize;
-        return getPartitionedForestSizes(
-            RandomCutForest
-                .builder()
-                .dimensions(rcfNumFeatures)
-                .sampleSize(rcfNumSamplesInTree)
-                .numberOfTrees(rcfNumTrees)
-                .outputAfter(rcfNumSamplesInTree)
-                .parallelExecutionEnabled(false)
-                .build(),
-            detectorId
-        );
-    }
-
-    /**
-     * Gets the estimated size of a RCF model.
-     *
-     * @param forest RCF configuration
-     * @return estimated model size in bytes
-     */
-    public long estimateModelSize(RandomCutForest forest) {
-        return (long) forest.getNumberOfTrees() * (long) forest.getSampleSize() * BOUNDING_BOXES * VECTORS_IN_BOUNDING_BOX * forest
-            .getDimensions() * (Long.SIZE / Byte.SIZE);
-    }
-
-    /**
      * Returns to listener the RCF anomaly result using the specified model.
      *
      * @param detectorId ID of the detector
@@ -394,8 +305,8 @@ public class ModelManager {
     private Optional<ModelState<RandomCutForest>> restoreCheckpoint(Optional<String> rcfCheckpoint, String modelId, String detectorId) {
         return rcfCheckpoint
             .map(checkpoint -> AccessController.doPrivileged((PrivilegedAction<RandomCutForest>) () -> rcfSerde.fromJson(checkpoint)))
-            .filter(rcf -> isHostingAllowed(detectorId, rcf))
-            .map(rcf -> new ModelState<>(rcf, modelId, detectorId, ModelType.RCF.getName(), clock.instant()));
+            .filter(rcf -> memoryTracker.isHostingAllowed(detectorId, rcf))
+            .map(rcf -> ModelState.createSingleEntityModelState(rcf, modelId, detectorId, ModelType.RCF.getName(), clock));
     }
 
     private void processRcfCheckpoint(
@@ -469,7 +380,7 @@ public class ModelManager {
             threshold.update(score);
         }
         modelState.setLastUsedTime(clock.instant());
-        listener.onResponse(new ThresholdingResult(grade, confidence));
+        listener.onResponse(new ThresholdingResult(grade, confidence, score));
     }
 
     private void processThresholdCheckpoint(
@@ -485,7 +396,9 @@ public class ModelManager {
                 checkpoint -> AccessController
                     .doPrivileged((PrivilegedAction<ThresholdingModel>) () -> gson.fromJson(checkpoint, thresholdingModelClass))
             )
-            .map(threshold -> new ModelState<>(threshold, modelId, detectorId, ModelType.THRESHOLD.getName(), clock.instant()));
+            .map(
+                threshold -> ModelState.createSingleEntityModelState(threshold, modelId, detectorId, ModelType.THRESHOLD.getName(), clock)
+            );
         if (model.isPresent()) {
             thresholds.put(modelId, model.get());
             getThresholdingResult(model.get(), score, listener);
@@ -601,6 +514,7 @@ public class ModelManager {
         clearModels(detectorId, forests, ActionListener.wrap(r -> clearModels(detectorId, thresholds, listener), listener::onFailure));
     }
 
+    // TODO: we don't need to do iteration as this is a map.
     private void clearModels(String detectorId, Map<String, ?> models, ActionListener<Void> listener) {
         Iterator<String> id = models.keySet().iterator();
         clearModelForIterator(detectorId, models, id, listener);
@@ -659,7 +573,7 @@ public class ModelManager {
         int rcfNumFeatures = dataPoints[0].length;
 
         // Create partitioned RCF models
-        Entry<Integer, Integer> partitionResults = getPartitionedForestSizes(anomalyDetector);
+        Entry<Integer, Integer> partitionResults = modelPartitioner.getPartitionedForestSizes(anomalyDetector);
 
         int numForests = partitionResults.getKey();
         int forestSize = partitionResults.getValue();
@@ -679,7 +593,7 @@ public class ModelManager {
                 scores[j] += rcf.getAnomalyScore(dataPoints[j]);
                 rcf.update(dataPoints[j]);
             }
-            String modelId = getRcfModelId(anomalyDetector.getDetectorId(), i);
+            String modelId = modelPartitioner.getRcfModelId(anomalyDetector.getDetectorId(), i);
             String checkpoint = AccessController.doPrivileged((PrivilegedAction<String>) () -> rcfSerde.toJson(rcf));
             checkpointDao.putModelCheckpoint(modelId, checkpoint);
         }
@@ -698,7 +612,7 @@ public class ModelManager {
         threshold.train(scores);
 
         // Persist thresholding model
-        String modelId = getThresholdModelId(anomalyDetector.getDetectorId());
+        String modelId = modelPartitioner.getThresholdModelId(anomalyDetector.getDetectorId());
         String checkpoint = AccessController.doPrivileged((PrivilegedAction<String>) () -> gson.toJson(threshold));
         checkpointDao.putModelCheckpoint(modelId, checkpoint);
     }
@@ -725,17 +639,18 @@ public class ModelManager {
             int rcfNumFeatures = dataPoints[0].length;
             // creates partitioned RCF models
             try {
-                Entry<Integer, Integer> partitionResults = getPartitionedForestSizes(
-                    RandomCutForest
-                        .builder()
-                        .dimensions(rcfNumFeatures)
-                        .sampleSize(rcfNumSamplesInTree)
-                        .numberOfTrees(rcfNumTrees)
-                        .outputAfter(rcfNumSamplesInTree)
-                        .parallelExecutionEnabled(false)
-                        .build(),
-                    anomalyDetector.getDetectorId()
-                );
+                Entry<Integer, Integer> partitionResults = modelPartitioner
+                    .getPartitionedForestSizes(
+                        RandomCutForest
+                            .builder()
+                            .dimensions(rcfNumFeatures)
+                            .sampleSize(rcfNumSamplesInTree)
+                            .numberOfTrees(rcfNumTrees)
+                            .outputAfter(rcfNumSamplesInTree)
+                            .parallelExecutionEnabled(false)
+                            .build(),
+                        anomalyDetector.getDetectorId()
+                    );
                 int numForests = partitionResults.getKey();
                 int forestSize = partitionResults.getValue();
                 double[] scores = new double[dataPoints.length];
@@ -771,7 +686,7 @@ public class ModelManager {
                 scores[j] += rcf.getAnomalyScore(dataPoints[j]);
                 rcf.update(dataPoints[j]);
             }
-            String modelId = getRcfModelId(detector.getDetectorId(), step);
+            String modelId = modelPartitioner.getRcfModelId(detector.getDetectorId(), step);
             String checkpoint = AccessController.doPrivileged((PrivilegedAction<String>) () -> rcfSerde.toJson(rcf));
             checkpointDao
                 .putModelCheckpoint(
@@ -807,31 +722,10 @@ public class ModelManager {
             threshold.train(rcfScores);
 
             // Persist thresholding model
-            String modelId = getThresholdModelId(detector.getDetectorId());
+            String modelId = modelPartitioner.getThresholdModelId(detector.getDetectorId());
             String checkpoint = AccessController.doPrivileged((PrivilegedAction<String>) () -> gson.toJson(threshold));
             checkpointDao.putModelCheckpoint(modelId, checkpoint, ActionListener.wrap(r -> listener.onResponse(null), listener::onFailure));
         }
-    }
-
-    /**
-     * Returns the model ID for the RCF model partition.
-     *
-     * @param detectorId ID of the detector for which the RCF model is trained
-     * @param partitionNumber number of the partition
-     * @return ID for the RCF model partition
-     */
-    public String getRcfModelId(String detectorId, int partitionNumber) {
-        return String.format(RCF_MODEL_ID_PATTERN, detectorId, partitionNumber);
-    }
-
-    /**
-     * Returns the model ID for the thresholding model.
-     *
-     * @param detectorId ID of the detector for which the thresholding model is trained
-     * @return ID for the thresholding model
-     */
-    public String getThresholdModelId(String detectorId) {
-        return String.format(THRESHOLD_MODEL_ID_PATTERN, detectorId);
     }
 
     private void clearModels(String detectorId, Map<String, ?> models) {
@@ -839,19 +733,6 @@ public class ModelManager {
             models.remove(modelId);
             checkpointDao.deleteModelCheckpoint(modelId);
         });
-    }
-
-    private boolean isHostingAllowed(String detectorId, RandomCutForest rcf) {
-        long total = forests.values().stream().mapToLong(f -> estimateModelSize(f.getModel())).sum() + estimateModelSize(rcf);
-        double heapLimit = jvmService.info().getMem().getHeapMax().getBytes() * modelMaxSizePercentage;
-        if (total <= heapLimit) {
-            return true;
-        } else {
-            throw new LimitExceededException(
-                detectorId,
-                String.format("Exceeded memory limit. New size is %d bytes and max limit is %f bytes", total, heapLimit)
-            );
-        }
     }
 
     private String toCheckpoint(RandomCutForest forest) {
@@ -925,7 +806,7 @@ public class ModelManager {
             String modelId = modelEntry.getKey();
             ModelState<T> modelState = modelEntry.getValue();
             Instant now = clock.instant();
-            if (modelState.getLastUsedTime().plus(modelTtl).isBefore(now)) {
+            if (modelState.expired(modelTtl)) {
                 models.remove(modelId);
             }
             if (modelState.getLastCheckpointTime().plus(checkpointInterval).isBefore(now)) {
@@ -987,7 +868,7 @@ public class ModelManager {
         return Arrays.stream(dataPoints).map(point -> {
             double rcfScore = forest.getAnomalyScore(point);
             forest.update(point);
-            ThresholdingResult result = new ThresholdingResult(threshold.grade(rcfScore), threshold.confidence());
+            ThresholdingResult result = new ThresholdingResult(threshold.grade(rcfScore), threshold.confidence(), rcfScore);
             threshold.update(rcfScore);
             return result;
         }).collect(Collectors.toList());
@@ -1020,7 +901,7 @@ public class ModelManager {
             .entrySet()
             .stream()
             .filter(entry -> getDetectorIdForModelId(entry.getKey()).equals(detectorId))
-            .forEach(entry -> { res.put(entry.getKey(), estimateModelSize(entry.getValue().getModel())); });
+            .forEach(entry -> { res.put(entry.getKey(), memoryTracker.estimateModelSize(entry.getValue().getModel())); });
         thresholds
             .entrySet()
             .stream()
@@ -1046,6 +927,134 @@ public class ModelManager {
                     ActionListener.wrap(checkpoint -> processRcfCheckpoint(checkpoint, modelId, detectorId, listener), listener::onFailure)
                 );
         }
+    }
 
+    /**
+     * Compute anomaly result for the given data point
+     * @param detectorId Detector Id
+     * @param datapoint Data point
+     * @param entityName entity's name like "server_1"
+     * @param modelState the state associated with the entity
+     * @param modelId the model Id
+     * @return anomaly result, confidence, and the corresponding RCF score.
+     */
+    public ThresholdingResult getAnomalyResultForEntity(
+        String detectorId,
+        double[] datapoint,
+        String entityName,
+        ModelState<EntityModel> modelState,
+        String modelId
+    ) {
+        ThresholdingResult result = null;
+
+        if (modelState != null) {
+            EntityModel model = modelState.getModel();
+            Queue<double[]> samples = model.getSamples();
+            samples.add(datapoint);
+            if (samples.size() > this.rcfNumMinSamples) {
+                samples.remove();
+            }
+
+            result = maybeTrainBeforeScore(modelState, entityName);
+        } else {
+            result = new ThresholdingResult(0, 0, 0);
+        }
+
+        return result;
+    }
+
+    private ThresholdingResult score(Queue<double[]> samples, String modelId, ModelState<EntityModel> modelState) {
+        EntityModel model = modelState.getModel();
+        RandomCutForest rcf = model.getRcf();
+        ThresholdingModel threshold = model.getThreshold();
+
+        double lastRcfScore = 0;
+        while (samples.peek() != null) {
+            double[] feature = samples.poll();
+            lastRcfScore = rcf.getAnomalyScore(feature);
+            rcf.update(feature);
+            threshold.update(lastRcfScore);
+        }
+
+        double anomalyGrade = threshold.grade(lastRcfScore);
+        double anomalyConfidence = computeRcfConfidence(rcf) * threshold.confidence();
+        ThresholdingResult result = new ThresholdingResult(anomalyGrade, anomalyConfidence, lastRcfScore);
+
+        modelState.setLastUsedTime(clock.instant());
+        return result;
+    }
+
+    /**
+     * Create model Id out of detector Id and entity name
+     * @param detectorId Detector Id
+     * @param entityValue Entity's value
+     * @return The model Id
+     */
+    public String getEntityModelId(String detectorId, String entityValue) {
+        return detectorId + "_entity_" + entityValue;
+    }
+
+    /**
+     * Instantiate an entity state out of checkpoint.  Running cold start if the
+     * model is empty. Update models using recent samples if applicable.
+     * @param checkpoint Checkpoint loaded from index
+     * @param modelId Model Id
+     * @param entityName Entity's name
+     * @param modelState entity state to instantiate
+     */
+    public void processEntityCheckpoint(
+        Optional<Entry<EntityModel, Instant>> checkpoint,
+        String modelId,
+        String entityName,
+        ModelState<EntityModel> modelState
+    ) {
+        if (checkpoint.isPresent()) {
+            Entry<EntityModel, Instant> modelToTime = checkpoint.get();
+            EntityModel restoredModel = modelToTime.getKey();
+            combineSamples(modelState.getModel(), restoredModel);
+            modelState.setModel(restoredModel);
+            modelState.setLastCheckpointTime(modelToTime.getValue());
+        } else {
+            // the time controls whether we saves this state or not.
+            // if it is within one hour, we don't save.
+            // This branch means this is the first state in record
+            // (the checkpoint might have been deleted).
+            // we have to save.
+            modelState.setLastCheckpointTime(clock.instant().minus(checkpointInterval));
+        }
+
+        assert (modelState.getModel() != null);
+        maybeTrainBeforeScore(modelState, entityName);
+    }
+
+    private void combineSamples(EntityModel fromModel, EntityModel toModel) {
+        Queue<double[]> samples = fromModel.getSamples();
+        while (samples.peek() != null) {
+            toModel.addSample(samples.poll());
+        }
+    }
+
+    /**
+     * Infer whenever both models are not null and do cold start if one of the models is not there
+     * @param modelState Model State
+     * @param entityName The entity's name
+     * @return model inference result for the entity, return all 0 Thresholding
+     *  result if the models are not ready
+     */
+    private ThresholdingResult maybeTrainBeforeScore(ModelState<EntityModel> modelState, String entityName) {
+        EntityModel model = modelState.getModel();
+        Queue<double[]> samples = model.getSamples();
+        String modelId = model.getModelId();
+        String detectorId = modelState.getDetectorId();
+        ThresholdingResult result = null;
+        if (model.getRcf() == null || model.getThreshold() == null) {
+            entityColdStarter.trainModel(samples, modelId, entityName, detectorId, modelState);
+        }
+
+        // update models using recent samples
+        if (model.getRcf() != null && model.getThreshold() != null && result == null) {
+            return score(samples, modelId, modelState);
+        }
+        return new ThresholdingResult(0, 0, 0);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelPartitioner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelPartitioner.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.ml;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map.Entry;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
+import com.amazon.randomcutforest.RandomCutForest;
+
+/**
+ * This class breaks the circular dependency between NodeStateManager and ModelManager
+ *
+ */
+public class ModelPartitioner {
+    private static final Logger LOG = LogManager.getLogger(ModelPartitioner.class);
+    protected static final String RCF_MODEL_ID_PATTERN = "%s_model_rcf_%d";
+    protected static final String THRESHOLD_MODEL_ID_PATTERN = "%s_model_threshold";
+
+    private int rcfNumSamplesInTree;
+    private int rcfNumTrees;
+    private DiscoveryNodeFilterer nodeFilter;
+    private MemoryTracker memoryTracker;
+
+    /**
+     * Constructor
+     * @param rcfNumSamplesInTree The sample size used by stream samplers in
+     * this RCF forest
+     * @param rcfNumTrees The number of trees in this RCF forest.
+     * @param nodeFilter utility class to select nodes
+     * @param memoryTracker AD memory usage tracker
+     */
+    public ModelPartitioner(int rcfNumSamplesInTree, int rcfNumTrees, DiscoveryNodeFilterer nodeFilter, MemoryTracker memoryTracker) {
+        this.rcfNumSamplesInTree = rcfNumSamplesInTree;
+        this.rcfNumTrees = rcfNumTrees;
+        this.nodeFilter = nodeFilter;
+        this.memoryTracker = memoryTracker;
+    }
+
+    /**
+     * Construct a RCF model and then partition it by forest size.
+     *
+     * A RCF model is constructed based on the number of input features.
+     *
+     * Then a RCF model is first partitioned into desired size based on heap.
+     * If there are more partitions than the number of nodes in the cluster,
+     * the model is partitioned by the number of nodes and verified to
+     * ensure the size of a partition does not exceed the max size limit based on heap.
+     *
+     * @param detector detector object
+     * @return a pair of number of partitions and size of a parition (number of trees)
+     * @throws LimitExceededException when there is no sufficient resource available
+     */
+    public Entry<Integer, Integer> getPartitionedForestSizes(AnomalyDetector detector) {
+        int shingleSize = detector.getShingleSize();
+        String detectorId = detector.getDetectorId();
+        int rcfNumFeatures = detector.getEnabledFeatureIds().size() * shingleSize;
+        return getPartitionedForestSizes(
+            RandomCutForest
+                .builder()
+                .dimensions(rcfNumFeatures)
+                .sampleSize(rcfNumSamplesInTree)
+                .numberOfTrees(rcfNumTrees)
+                .outputAfter(rcfNumSamplesInTree)
+                .parallelExecutionEnabled(false)
+                .build(),
+            detectorId
+        );
+    }
+
+    /**
+     * Partitions a RCF model by forest size.
+     *
+     * A RCF model is first partitioned into desired size based on heap.
+     * If there are more partitions than the number of nodes in the cluster,
+     * the model is partitioned by the number of nodes and verified to
+     * ensure the size of a partition does not exceed the max size limit based on heap.
+     *
+     * @param forest RCF configuration, including forest size
+     * @param detectorId ID of the detector with no effects on partitioning
+     * @return a pair of number of partitions and size of a parition (number of trees)
+     * @throws LimitExceededException when there is no sufficient resource available
+     */
+    public Entry<Integer, Integer> getPartitionedForestSizes(RandomCutForest forest, String detectorId) {
+        long totalSize = memoryTracker.estimateModelSize(forest);
+
+        // desired partitioning
+        long partitionSize = (Math.min(memoryTracker.getDesiredModelSize(), totalSize));
+        int numPartitions = (int) Math.ceil((double) totalSize / (double) partitionSize);
+        int forestSize = (int) Math.ceil((double) forest.getNumberOfTrees() / (double) numPartitions);
+
+        int numNodes = nodeFilter.getEligibleDataNodes().length;
+        if (numPartitions > numNodes) {
+            // partition by cluster size
+            partitionSize = (long) Math.ceil((double) totalSize / (double) numNodes);
+            // verify against max size limit
+            if (partitionSize <= memoryTracker.getHeapLimit()) {
+                numPartitions = numNodes;
+                forestSize = (int) Math.ceil((double) forest.getNumberOfTrees() / (double) numNodes);
+            } else {
+                throw new LimitExceededException(detectorId, CommonErrorMessages.MEMORY_LIMIT_EXCEEDED_ERR_MSG);
+            }
+        }
+
+        return new SimpleImmutableEntry<>(numPartitions, forestSize);
+    }
+
+    /**
+     * Returns the model ID for the RCF model partition.
+     *
+     * @param detectorId ID of the detector for which the RCF model is trained
+     * @param partitionNumber number of the partition
+     * @return ID for the RCF model partition
+     */
+    public String getRcfModelId(String detectorId, int partitionNumber) {
+        return String.format(RCF_MODEL_ID_PATTERN, detectorId, partitionNumber);
+    }
+
+    /**
+     * Returns the model ID for the thresholding model.
+     *
+     * @param detectorId ID of the detector for which the thresholding model is trained
+     * @return ID for the thresholding model
+     */
+    public String getThresholdModelId(String detectorId) {
+        return String.format(THRESHOLD_MODEL_ID_PATTERN, detectorId);
+    }
+}


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*
This PR adds the "main" function for model training and inference.  If the model is in cache, the function asks the model directly for anomaly grade.  If the model is not in cache, the function triggers a cold start.

This PR also splits the model partition related functions to a separate class to break the circular dependency between ModelManager and NodeStateManager if we don't do so. This breakup also has better encapsulation as we have one class for one thing.

Testing done:
1.  Will add unit tests.
2. Manual tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
