### PR TITLE
Add rcf score in ThresholdingResult

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ThresholdingResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ThresholdingResult.java
@@ -24,16 +24,21 @@ public class ThresholdingResult {
 
     private final double grade;
     private final double confidence;
+    private final double rcfScore;
 
     /**
      * Constructor with all arguments.
      *
      * @param grade anomaly grade
      * @param confidence confidence for the grade
+     * @param rcfScore rcf score associated with the grade and confidence. Used
+     *   by multi-entity detector to differentiate whether the result is worth
+     *   saving or not.
      */
-    public ThresholdingResult(double grade, double confidence) {
+    public ThresholdingResult(double grade, double confidence, double rcfScore) {
         this.grade = grade;
         this.confidence = confidence;
+        this.rcfScore = rcfScore;
     }
 
     /**
@@ -54,6 +59,10 @@ public class ThresholdingResult {
         return confidence;
     }
 
+    public double getRcfScore() {
+        return rcfScore;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -61,11 +70,13 @@ public class ThresholdingResult {
         if (o == null || getClass() != o.getClass())
             return false;
         ThresholdingResult that = (ThresholdingResult) o;
-        return Objects.equals(this.grade, that.grade) && Objects.equals(this.confidence, that.confidence);
+        return Objects.equals(this.grade, that.grade)
+            && Objects.equals(this.confidence, that.confidence)
+            && Objects.equals(this.rcfScore, that.rcfScore);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(grade, confidence);
+        return Objects.hash(grade, confidence, rcfScore);
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ThresholdingResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/ThresholdingResultTests.java
@@ -28,7 +28,9 @@ public class ThresholdingResultTests {
 
     private double grade = 1.;
     private double confidence = 0.5;
-    private ThresholdingResult thresholdingResult = new ThresholdingResult(grade, confidence);
+    double score = 1.;
+
+    private ThresholdingResult thresholdingResult = new ThresholdingResult(grade, confidence, score);
 
     @Test
     public void getters_returnExcepted() {
@@ -41,10 +43,10 @@ public class ThresholdingResultTests {
             new Object[] { thresholdingResult, null, false },
             new Object[] { thresholdingResult, thresholdingResult, true },
             new Object[] { thresholdingResult, 1, false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence), true },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence), false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence + 1), false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence + 1), false }, };
+            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence, score), true },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence, score), false },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence + 1, score), false },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence + 1, score), false }, };
     }
 
     @Test
@@ -55,10 +57,10 @@ public class ThresholdingResultTests {
 
     private Object[] hashCodeData() {
         return new Object[] {
-            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence), true },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence), false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence + 1), false },
-            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence + 1), false }, };
+            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence, score), true },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence, score), false },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade, confidence + 1, score), false },
+            new Object[] { thresholdingResult, new ThresholdingResult(grade + 1, confidence + 1, score), false }, };
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ThresholdResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ThresholdResultTests.java
@@ -68,7 +68,7 @@ public class ThresholdResultTests extends ESTestCase {
         ThresholdResultTransportAction action = new ThresholdResultTransportAction(mock(ActionFilters.class), transportService, manager);
         doAnswer(invocation -> {
             ActionListener<ThresholdingResult> listener = invocation.getArgument(3);
-            listener.onResponse(new ThresholdingResult(0, 1.0d));
+            listener.onResponse(new ThresholdingResult(0, 1.0d, 0.2));
             return null;
         }).when(manager).getThresholdingResult(any(String.class), any(String.class), anyDouble(), any(ActionListener.class));
 


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*
This PR adds an rcf score in ThresholdingResult so that we can use it when saving anomaly results.  Previously we don't need it since AnomalyResultTransportAction runs rcf first
and then threshold model. But for multi-entity result transport action, it sends the da
ta and gets back the ThresholdingResult, nothing in between.

Testing done:
1. Its callers have covered its usage in their unit tests.
2. Manual testing passes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
