### PR TITLE
Add bulk indexing to result index handler

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectionStateHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectionStateHandler.java
@@ -39,8 +39,8 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
-import com.amazon.opendistroforelasticsearch.ad.transport.TransportStateManager;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
 import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
 import com.google.common.base.Objects;
@@ -79,7 +79,7 @@ public class DetectionStateHandler extends AnomalyIndexHandler<DetectorInternalS
 
     private static final Logger LOG = LogManager.getLogger(DetectionStateHandler.class);
     private NamedXContentRegistry xContentRegistry;
-    private TransportStateManager adStateManager;
+    private NodeStateManager adStateManager;
 
     public DetectionStateHandler(
         Client client,
@@ -91,7 +91,7 @@ public class DetectionStateHandler extends AnomalyIndexHandler<DetectorInternalS
         IndexUtils indexUtils,
         ClusterService clusterService,
         NamedXContentRegistry xContentRegistry,
-        TransportStateManager adStateManager
+        NodeStateManager adStateManager
     ) {
         super(
             client,
@@ -100,11 +100,11 @@ public class DetectionStateHandler extends AnomalyIndexHandler<DetectorInternalS
             DetectorInternalState.DETECTOR_STATE_INDEX,
             createIndex,
             indexExists,
-            true,
             clientUtil,
             indexUtils,
             clusterService
         );
+        this.fixedDoc = true;
         this.xContentRegistry = xContentRegistry;
         this.adStateManager = adStateManager;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/MultiEntityResultHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/MultiEntityResultHandler.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport.handler;
+
+import java.time.Clock;
+import java.util.Locale;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADResultBulkAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADResultBulkRequest;
+import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
+import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
+import com.amazon.opendistroforelasticsearch.ad.util.ThrowingConsumerWrapper;
+
+/**
+ * EntityResultTransportAction depends on this class.  I cannot use
+ * AnomalyIndexHandler &lt; AnomalyResult &gt; . All transport actions
+ * needs dependency injection.  Guice has a hard time initializing generics class
+ * AnomalyIndexHandler &lt; AnomalyResult &gt; due to type erasure.
+ * To avoid that, I create a class with a built-in details so
+ * that Guice would be able to work out the details.
+ *
+ */
+public class MultiEntityResultHandler extends AnomalyIndexHandler<AnomalyResult> {
+    private static final Logger LOG = LogManager.getLogger(MultiEntityResultHandler.class);
+    private final NodeStateManager nodeStateManager;
+    private final Clock clock;
+
+    @Inject
+    public MultiEntityResultHandler(
+        Client client,
+        Settings settings,
+        ThreadPool threadPool,
+        AnomalyDetectionIndices anomalyDetectionIndices,
+        ClientUtil clientUtil,
+        IndexUtils indexUtils,
+        ClusterService clusterService,
+        NodeStateManager nodeStateManager,
+        Clock clock
+    ) {
+        super(
+            client,
+            settings,
+            threadPool,
+            CommonName.ANOMALY_RESULT_INDEX_ALIAS,
+            ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
+            anomalyDetectionIndices::doesAnomalyResultIndexExist,
+            clientUtil,
+            indexUtils,
+            clusterService
+        );
+        this.nodeStateManager = nodeStateManager;
+        this.clock = clock;
+    }
+
+    public void write(AnomalyResult toSave, ADResultBulkRequest currentBulkRequest) {
+        currentBulkRequest.add(toSave);
+    }
+
+    public void flush(ADResultBulkRequest currentBulkRequest, String detectorId) {
+        if (indexUtils.checkIndicesBlocked(clusterService.state(), ClusterBlockLevel.WRITE, this.indexName)) {
+            LOG.warn(String.format(Locale.ROOT, CANNOT_SAVE_ERR_MSG, detectorId));
+            return;
+        }
+
+        try {
+            if (!indexExists.getAsBoolean()) {
+                createIndex
+                    .accept(
+                        ActionListener
+                            .wrap(initResponse -> onCreateIndexResponse(initResponse, currentBulkRequest, detectorId), exception -> {
+                                if (ExceptionsHelper.unwrapCause(exception) instanceof ResourceAlreadyExistsException) {
+                                    // It is possible the index has been created while we sending the create request
+                                    bulk(currentBulkRequest, detectorId);
+                                } else {
+                                    throw new AnomalyDetectionException(
+                                        detectorId,
+                                        String.format("Unexpected error creating index %s", indexName),
+                                        exception
+                                    );
+                                }
+                            })
+                    );
+            } else {
+                bulk(currentBulkRequest, detectorId);
+            }
+        } catch (Exception e) {
+            throw new AnomalyDetectionException(
+                detectorId,
+                String.format(Locale.ROOT, "Error in bulking %s for detector %s", indexName, detectorId),
+                e
+            );
+        }
+    }
+
+    private void onCreateIndexResponse(CreateIndexResponse response, ADResultBulkRequest bulkRequest, String detectorId) {
+        if (response.isAcknowledged()) {
+            bulk(bulkRequest, detectorId);
+        } else {
+            throw new AnomalyDetectionException(detectorId, "Creating %s with mappings call not acknowledged.");
+        }
+    }
+
+    private void bulk(ADResultBulkRequest currentBulkRequest, String detectorId) {
+        if (currentBulkRequest.numberOfActions() <= 0) {
+            return;
+        }
+        client
+            .execute(
+                ADResultBulkAction.INSTANCE,
+                currentBulkRequest,
+                ActionListener.<BulkResponse>wrap(response -> LOG.debug(String.format(SUCCESS_SAVING_MSG, detectorId)), exception -> {
+                    LOG.error(String.format(FAIL_TO_SAVE_ERR_MSG, detectorId), exception);
+                    // too much indexing pressure
+                    // TODO: pause indexing a bit before trying again, ideally with randomized exponential backoff.
+                    if (exception instanceof EsRejectedExecutionException) {
+                        nodeStateManager.setLastIndexThrottledTime(clock.instant());
+                    }
+                })
+            );
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultHandlerTests.java
@@ -25,8 +25,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
@@ -53,6 +55,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
@@ -88,6 +91,12 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
     private ThreadPool context;
 
     private IndexUtils indexUtil;
+
+    @Mock
+    private NodeStateManager nodeStateManager;
+
+    @Mock
+    private Clock clock;
 
     @BeforeClass
     public static void setUpBeforeClass() {
@@ -141,7 +150,6 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -179,7 +187,6 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -199,7 +206,6 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -221,7 +227,6 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -300,7 +305,6 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
             CommonName.ANOMALY_RESULT_INDEX_ALIAS,
             ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initAnomalyResultIndexDirectly),
             anomalyDetectionIndices::doesAnomalyResultIndexExist,
-            false,
             clientUtil,
             indexUtil,
             clusterService
@@ -308,7 +312,7 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
 
         handler.index(TestHelpers.randomAnomalyDetectResult(), detectorId);
 
-        backoffLatch.await();
+        backoffLatch.await(1, TimeUnit.MINUTES);
     }
 
     @SuppressWarnings("unchecked")
@@ -324,5 +328,4 @@ public class AnomalyResultHandlerTests extends AbstractADTest {
         }).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());
         when(anomalyDetectionIndices.doesAnomalyResultIndexExist()).thenReturn(anomalyResultIndexExists);
     }
-
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectorStateHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectorStateHandlerTests.java
@@ -36,10 +36,10 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
-import com.amazon.opendistroforelasticsearch.ad.transport.TransportStateManager;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.DetectionStateHandler.ErrorStrategy;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
 import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
@@ -52,7 +52,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
     private Client client;
     private String error = "Stopped due to blah";
     private IndexUtils indexUtils;
-    private TransportStateManager stateManager;
+    private NodeStateManager stateManager;
 
     @Override
     public void setUp() throws Exception {
@@ -67,7 +67,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
         indexUtils = mock(IndexUtils.class);
         ClusterService clusterService = mock(ClusterService.class);
         ThreadPool threadPool = mock(ThreadPool.class);
-        stateManager = mock(TransportStateManager.class);
+        stateManager = mock(NodeStateManager.class);
         detectorStateHandler = new DetectionStateHandler(
             client,
             settings,
@@ -145,7 +145,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
     }
 
     public void testUpdateWithFirstChange() {
-        when(stateManager.getLastDetectionError(anyString())).thenReturn(TransportStateManager.NO_ERROR);
+        when(stateManager.getLastDetectionError(anyString())).thenReturn(NodeStateManager.NO_ERROR);
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();
             @SuppressWarnings("unchecked")


### PR DESCRIPTION
Note: since there are a lot of dependencies, I only list the main class and test code to save reviewers' time. The build will fail due to missing dependencies. I will use that PR just for review. will not merge it. Will have a big one in the end and merge once after all review PRs get approved.

*Issue #, if available:*

*Description of changes:*
For multi-entities' results, we bulk indexing entities’ anomaly results of a detector instead of doing it one entity by another. Bulk requests will yield much better performance than single-document index requests.

This PR implements bulk indexing logic in MultiEntityResultHandler.

Testing done:
1. Will add unit tests.
2. Manual testing passes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
