### PR TITLE
suppport HC detector in profile api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -266,6 +266,12 @@ List<String> jacocoExclusions = [
         'com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultTransportAction.EntityResultListener',
         'com.amazon.opendistroforelasticsearch.ad.NodeStateManager',
         'com.amazon.opendistroforelasticsearch.ad.transport.handler.MultiEntityResultHandler',
+        'com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileTransportAction*',
+        'com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorProfileRunner',
+        'com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileResponse',
+        'com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileRequest',
+        'com.amazon.opendistroforelasticsearch.ad.util.MultiResponsesDelegateActionListener',
+        'com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorRequest',
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -120,6 +120,8 @@ import com.amazon.opendistroforelasticsearch.ad.transport.DeleteAnomalyDetectorA
 import com.amazon.opendistroforelasticsearch.ad.transport.DeleteAnomalyDetectorTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.DeleteModelAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.DeleteModelTransportAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.EntityResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.EntityResultTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorAction;
@@ -442,6 +444,14 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 StatNames.MODELS_CHECKPOINT_INDEX_STATUS.getName(),
                 new ADStat<>(true, new IndexStatusSupplier(indexUtils, CommonName.CHECKPOINT_INDEX_NAME))
             )
+            .put(
+                StatNames.ANOMALY_DETECTION_JOB_INDEX_STATUS.getName(),
+                new ADStat<>(true, new IndexStatusSupplier(indexUtils, AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX))
+            )
+            .put(
+                StatNames.ANOMALY_DETECTION_STATE_STATUS.getName(),
+                new ADStat<>(true, new IndexStatusSupplier(indexUtils, DetectorInternalState.DETECTOR_STATE_INDEX))
+            )
             .put(StatNames.DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
             .build();
 
@@ -595,7 +605,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ActionHandler<>(IndexAnomalyDetectorAction.INSTANCE, IndexAnomalyDetectorTransportAction.class),
                 new ActionHandler<>(AnomalyDetectorJobAction.INSTANCE, AnomalyDetectorJobTransportAction.class),
                 new ActionHandler<>(ADResultBulkAction.INSTANCE, ADResultBulkTransportAction.class),
-                new ActionHandler<>(EntityResultAction.INSTANCE, EntityResultTransportAction.class)
+                new ActionHandler<>(EntityResultAction.INSTANCE, EntityResultTransportAction.class),
+                new ActionHandler<>(EntityProfileAction.INSTANCE, EntityProfileTransportAction.class)
             );
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunner.java
@@ -20,6 +20,9 @@ import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob.
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.io.IOException;
+import java.security.InvalidParameterException;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
@@ -29,6 +32,7 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
@@ -37,6 +41,10 @@ import org.elasticsearch.common.xcontent.XContentParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.metrics.CardinalityAggregationBuilder;
+import org.elasticsearch.search.aggregations.metrics.InternalCardinality;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import com.amazon.opendistroforelasticsearch.ad.common.exception.ResourceNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
@@ -45,9 +53,12 @@ import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfile;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorState;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityProfile;
 import com.amazon.opendistroforelasticsearch.ad.model.InitProgressProfile;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
 import com.amazon.opendistroforelasticsearch.ad.model.ProfileName;
+import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileRequest;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileRequest;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileResponse;
@@ -65,6 +76,7 @@ public class AnomalyDetectorProfileRunner {
     private DiscoveryNodeFilterer nodeFilter;
     static String FAIL_TO_FIND_DETECTOR_MSG = "Fail to find detector with id: ";
     static String FAIL_TO_GET_PROFILE_MSG = "Fail to get profile for detector ";
+    static String FAIL_TO_GET_TOTAL_ENTITIES = "Failed to get total entities for detector ";
     private long requiredSamples;
 
     public AnomalyDetectorProfileRunner(
@@ -108,7 +120,12 @@ public class AnomalyDetectorProfileRunner {
         if (profilesToCollect.contains(ProfileName.COORDINATING_NODE)
             || profilesToCollect.contains(ProfileName.SHINGLE_SIZE)
             || profilesToCollect.contains(ProfileName.TOTAL_SIZE_IN_BYTES)
-            || profilesToCollect.contains(ProfileName.MODELS)) {
+            || profilesToCollect.contains(ProfileName.MODELS)
+            || profilesToCollect.contains(ProfileName.ACTIVE_ENTITIES)) {
+            totalListener++;
+        }
+
+        if (profilesToCollect.contains(ProfileName.TOTAL_ENTITIES)) {
             totalListener++;
         }
 
@@ -118,13 +135,14 @@ public class AnomalyDetectorProfileRunner {
             "Fail to fetch profile for " + detectorId
         );
 
-        prepareProfile(detectorId, delegateListener, profilesToCollect);
+        prepareProfile(detectorId, delegateListener, profilesToCollect, totalListener);
     }
 
     private void prepareProfile(
         String detectorId,
         MultiResponsesDelegateActionListener<DetectorProfile> listener,
-        Set<ProfileName> profilesToCollect
+        Set<ProfileName> profilesToCollect,
+        int totalListener
     ) {
         GetRequest getRequest = new GetRequest(ANOMALY_DETECTOR_JOB_INDEX, detectorId);
         client.get(getRequest, ActionListener.wrap(getResponse -> {
@@ -140,19 +158,67 @@ public class AnomalyDetectorProfileRunner {
 
                     if (profilesToCollect.contains(ProfileName.ERROR)) {
                         GetRequest getStateRequest = new GetRequest(DetectorInternalState.DETECTOR_STATE_INDEX, detectorId);
-                        client.get(getStateRequest, onGetDetectorState(listener, detectorId, enabledTimeMs));
+                        client.get(getStateRequest, onGetDetectorState(listener, detectorId, enabledTimeMs));// +1
                     }
 
-                    if (profilesToCollect.contains(ProfileName.STATE) || profilesToCollect.contains(ProfileName.INIT_PROGRESS)) {
-                        profileStateRelated(detectorId, listener, job.isEnabled(), profilesToCollect);
-                    }
+                    GetRequest getDetectorRequest = new GetRequest(ANOMALY_DETECTORS_INDEX, detectorId);
+                    client.get(getDetectorRequest, ActionListener.wrap(getDetectorResponse -> {
+                        if (getDetectorResponse != null && getDetectorResponse.isExists()) {
+                            try (
+                                XContentParser xContentParser = XContentType.JSON
+                                    .xContent()
+                                    .createParser(
+                                        xContentRegistry,
+                                        LoggingDeprecationHandler.INSTANCE,
+                                        getDetectorResponse.getSourceAsString()
+                                    )
+                            ) {
+                                ensureExpectedToken(
+                                    XContentParser.Token.START_OBJECT,
+                                    xContentParser.nextToken(),
+                                    xContentParser::getTokenLocation
+                                );
+                                AnomalyDetector detector = AnomalyDetector.parse(xContentParser, detectorId);
+                                boolean isHCDetector = isHCDetector(detector);
+                                if (profilesToCollect.contains(ProfileName.TOTAL_ENTITIES)) {
+                                    if (isHCDetector) {
+                                        profileEntityStats(listener, detector);
+                                    } else {
+                                        listener.compareAndSetMaxResponseCount(totalListener, totalListener - 1);
+                                    }
+                                }
+                                if (!isHCDetector
+                                    && (profilesToCollect.contains(ProfileName.STATE)
+                                        || profilesToCollect.contains(ProfileName.INIT_PROGRESS))) {
+                                    profileStateRelated(detector, listener, job.isEnabled(), profilesToCollect);
+                                }
 
-                    if (profilesToCollect.contains(ProfileName.COORDINATING_NODE)
-                        || profilesToCollect.contains(ProfileName.SHINGLE_SIZE)
-                        || profilesToCollect.contains(ProfileName.TOTAL_SIZE_IN_BYTES)
-                        || profilesToCollect.contains(ProfileName.MODELS)) {
-                        profileModels(detectorId, profilesToCollect, listener);
-                    }
+                                if ((profilesToCollect.contains(ProfileName.COORDINATING_NODE)
+                                    || profilesToCollect.contains(ProfileName.SHINGLE_SIZE)
+                                    || profilesToCollect.contains(ProfileName.TOTAL_SIZE_IN_BYTES)
+                                    || profilesToCollect.contains(ProfileName.MODELS)
+                                    || profilesToCollect.contains(ProfileName.ACTIVE_ENTITIES))
+                                    && (profilesToCollect.contains(ProfileName.INIT_PROGRESS) && isHCDetector)) {
+                                    listener.compareAndSetMaxResponseCount(totalListener, totalListener - 1);
+                                }
+
+                                if (profilesToCollect.contains(ProfileName.COORDINATING_NODE)
+                                    || profilesToCollect.contains(ProfileName.SHINGLE_SIZE)
+                                    || profilesToCollect.contains(ProfileName.TOTAL_SIZE_IN_BYTES)
+                                    || profilesToCollect.contains(ProfileName.MODELS)
+                                    || profilesToCollect.contains(ProfileName.ACTIVE_ENTITIES)
+                                    || (profilesToCollect.contains(ProfileName.INIT_PROGRESS) && isHCDetector)) {
+                                    profileModels(detector, profilesToCollect, job.isEnabled(), listener);
+                                }
+
+                            } catch (Exception t) {
+                                logger.error("Fail to parse detector {}", detectorId);
+                                listener.failImmediately(FAIL_TO_FIND_DETECTOR_MSG + detectorId, t);
+                            }
+                        } else {
+                            listener.failImmediately(FAIL_TO_FIND_DETECTOR_MSG + detectorId);
+                        }
+                    }, exception -> { listener.failImmediately(FAIL_TO_FIND_DETECTOR_MSG + detectorId, exception); }));
                 } catch (IOException | XContentParseException | NullPointerException e) {
                     logger.error(e);
                     listener.failImmediately(FAIL_TO_GET_PROFILE_MSG, e);
@@ -171,6 +237,71 @@ public class AnomalyDetectorProfileRunner {
                 listener.onFailure(exception);
             }
         }));
+    }
+
+    /**
+     * Get profile info of specific entity.
+     *
+     * @param detectorId detector identifier
+     * @param entityValue entity value
+     * @param listener action listener to handle exception and process entity profile response
+     */
+    public void profileEntity(String detectorId, String entityValue, ActionListener<EntityProfile> listener) {
+        GetRequest getDetectorRequest = new GetRequest(ANOMALY_DETECTORS_INDEX, detectorId);
+        client.get(getDetectorRequest, ActionListener.wrap(getResponse -> {
+            if (getResponse != null && getResponse.isExists()) {
+                try (
+                    XContentParser parser = XContentType.JSON
+                        .xContent()
+                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
+                ) {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+                    AnomalyDetector detector = AnomalyDetector.parse(parser, detectorId);
+                    List<String> categoryField = detector.getCategoryField();
+                    if (categoryField == null || categoryField.size() != 1) {
+                        listener.onResponse(new EntityProfile(categoryField.get(0), entityValue, false));
+                    } else {
+                        EntityProfileRequest request = new EntityProfileRequest(detectorId, entityValue);
+                        client
+                            .execute(
+                                EntityProfileAction.INSTANCE,
+                                request,
+                                ActionListener
+                                    .wrap(
+                                        r -> { listener.onResponse(new EntityProfile(categoryField.get(0), entityValue, r.isActive())); },
+                                        e -> { listener.onFailure(e); }
+                                    )
+                            );
+                    }
+                } catch (Exception t) {
+                    listener.onFailure(t);
+                }
+            } else {
+                listener.onFailure(new InvalidParameterException(FAIL_TO_FIND_DETECTOR_MSG + detectorId));
+            }
+        }, exception -> { listener.onFailure(exception); }));
+    }
+
+    private void profileEntityStats(MultiResponsesDelegateActionListener<DetectorProfile> listener, AnomalyDetector detector) {
+        List<String> categoryField = detector.getCategoryField();
+        if (categoryField == null || categoryField.size() != 1) {
+            listener.onResponse(new DetectorProfile.Builder().build());
+        } else {
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            CardinalityAggregationBuilder aggBuilder = new CardinalityAggregationBuilder(CommonName.TOTAL_ENTITIES);
+            aggBuilder.field(categoryField.get(0));
+            searchSourceBuilder.aggregation(aggBuilder);
+
+            SearchRequest request = new SearchRequest(detector.getIndices().toArray(new String[0]), searchSourceBuilder);
+            client.search(request, ActionListener.wrap(searchResponse -> {
+                Map<String, Aggregation> aggMap = searchResponse.getAggregations().asMap();
+                InternalCardinality totalEntities = (InternalCardinality) aggMap.get(CommonName.TOTAL_ENTITIES);
+                long value = totalEntities.getValue();
+                DetectorProfile.Builder profileBuilder = new DetectorProfile.Builder();
+                DetectorProfile profile = profileBuilder.totalEntities(value).build();
+                listener.onResponse(profile);
+            }, searchException -> { listener.failImmediately(FAIL_TO_GET_TOTAL_ENTITIES + detector.getDetectorId()); }));
+        }
     }
 
     private ActionListener<GetResponse> onGetDetectorForPrepare(
@@ -196,20 +327,20 @@ public class AnomalyDetectorProfileRunner {
      *  -Disabled: if get ad job api says the job is disabled;
      *  -Init: if rcf model's total updates is less than required
      *  -Running: if neither of the above applies and no exceptions.
-     * @param detectorId detector id
+     * @param detector anomaly detector
      * @param listener listener to process the returned state or exception
      * @param enabled whether the detector job is enabled or not
      * @param profilesToCollect target profiles to fetch
      */
     private void profileStateRelated(
-        String detectorId,
+        AnomalyDetector detector,
         MultiResponsesDelegateActionListener<DetectorProfile> listener,
         boolean enabled,
         Set<ProfileName> profilesToCollect
     ) {
         if (enabled) {
-            RCFPollingRequest request = new RCFPollingRequest(detectorId);
-            client.execute(RCFPollingAction.INSTANCE, request, onPollRCFUpdates(detectorId, profilesToCollect, listener));
+            RCFPollingRequest request = new RCFPollingRequest(detector.getDetectorId());
+            client.execute(RCFPollingAction.INSTANCE, request, onPollRCFUpdates(detector, profilesToCollect, listener));
         } else {
             if (profilesToCollect.contains(ProfileName.STATE)) {
                 listener.onResponse(new DetectorProfile.Builder().state(DetectorState.DISABLED).build());
@@ -273,39 +404,8 @@ public class AnomalyDetectorProfileRunner {
         });
     }
 
-    private ActionListener<GetResponse> onGetDetectorForInitProgress(
-        MultiResponsesDelegateActionListener<DetectorProfile> listener,
-        String detectorId,
-        Set<ProfileName> profilesToCollect,
-        long totalUpdates,
-        long requiredSamples
-    ) {
-        return ActionListener.wrap(getResponse -> {
-            if (getResponse != null && getResponse.isExists()) {
-                try (
-                    XContentParser parser = XContentType.JSON
-                        .xContent()
-                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
-                ) {
-                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
-                    AnomalyDetector detector = AnomalyDetector.parse(parser, detectorId);
-                    long intervalMins = ((IntervalTimeConfiguration) detector.getDetectionInterval()).toDuration().toMinutes();
-                    InitProgressProfile initProgress = computeInitProgressProfile(totalUpdates, intervalMins);
-
-                    listener.onResponse(new DetectorProfile.Builder().initProgress(initProgress).build());
-                } catch (Exception t) {
-                    logger.error("Fail to parse detector {}", detectorId);
-                    logger.error("Stack trace:", t);
-                    listener.failImmediately(FAIL_TO_FIND_DETECTOR_MSG + detectorId, t);
-                }
-            } else {
-                listener.failImmediately(FAIL_TO_FIND_DETECTOR_MSG + detectorId);
-            }
-        }, exception -> { listener.failImmediately(FAIL_TO_FIND_DETECTOR_MSG + detectorId, exception); });
-    }
-
     private InitProgressProfile computeInitProgressProfile(long totalUpdates, long intervalMins) {
-        float percent = (100.0f * totalUpdates) / requiredSamples;
+        float percent = Math.min((100.0f * totalUpdates) / requiredSamples, 100.0f);
         int neededPoints = (int) (requiredSamples - totalUpdates);
         return new InitProgressProfile(
             // rounding: 93.456 => 93%, 93.556 => 94%
@@ -316,20 +416,27 @@ public class AnomalyDetectorProfileRunner {
     }
 
     private void profileModels(
-        String detectorId,
+        AnomalyDetector detector,
         Set<ProfileName> profiles,
+        boolean enabled,
         MultiResponsesDelegateActionListener<DetectorProfile> listener
     ) {
         DiscoveryNode[] dataNodes = nodeFilter.getEligibleDataNodes();
-        ProfileRequest profileRequest = new ProfileRequest(detectorId, profiles, dataNodes);
-        client.execute(ProfileAction.INSTANCE, profileRequest, onModelResponse(detectorId, profiles, listener));
+        ProfileRequest profileRequest = new ProfileRequest(detector.getDetectorId(), profiles, dataNodes);
+        client.execute(ProfileAction.INSTANCE, profileRequest, onModelResponse(detector, profiles, enabled, listener));
+    }
+
+    private boolean isHCDetector(AnomalyDetector detector) {
+        return detector != null && detector.getCategoryField() != null && detector.getCategoryField().size() > 0;
     }
 
     private ActionListener<ProfileResponse> onModelResponse(
-        String detectorId,
+        AnomalyDetector detector,
         Set<ProfileName> profiles,
+        boolean enabled,
         MultiResponsesDelegateActionListener<DetectorProfile> listener
     ) {
+        boolean isHCDetector = isHCDetector(detector);
         return ActionListener.wrap(profileResponse -> {
             DetectorProfile.Builder profile = new DetectorProfile.Builder();
             if (profiles.contains(ProfileName.COORDINATING_NODE)) {
@@ -344,6 +451,26 @@ public class AnomalyDetectorProfileRunner {
             if (profiles.contains(ProfileName.MODELS)) {
                 profile.modelProfile(profileResponse.getModelProfile());
             }
+            if (isHCDetector && profiles.contains(ProfileName.ACTIVE_ENTITIES)) {
+                profile.activeEntities(profileResponse.getActiveEntities());
+            }
+            if (isHCDetector && profiles.contains(ProfileName.INIT_PROGRESS)) {
+                long totalUpdates = profileResponse.getTotalUpdates();
+                long intervalMins = totalUpdates == 0
+                    ? 0
+                    : ((IntervalTimeConfiguration) detector.getDetectionInterval()).toDuration().toMinutes();
+                InitProgressProfile initProgress = computeInitProgressProfile(totalUpdates, intervalMins);
+                profile.initProgress(initProgress);
+            }
+            if (isHCDetector && profiles.contains(ProfileName.STATE)) {
+                DetectorState state;
+                if (enabled) {
+                    state = profileResponse.getTotalUpdates() < requiredSamples ? DetectorState.INIT : DetectorState.RUNNING;
+                } else {
+                    state = DetectorState.DISABLED;
+                }
+                listener.onResponse(new DetectorProfile.Builder().state(state).build());
+            }
 
             listener.onResponse(profile.build());
         }, listener::onFailure);
@@ -351,20 +478,20 @@ public class AnomalyDetectorProfileRunner {
 
     /**
      * Listener for polling rcf updates through transport messaging
-     * @param detectorId detector Id
+     * @param detector anomaly detector
      * @param profilesToCollect profiles to collect like state
      * @param listener delegate listener
      * @return Listener for polling rcf updates through transport messaging
      */
     private ActionListener<RCFPollingResponse> onPollRCFUpdates(
-        String detectorId,
+        AnomalyDetector detector,
         Set<ProfileName> profilesToCollect,
         MultiResponsesDelegateActionListener<DetectorProfile> listener
     ) {
         return ActionListener.wrap(rcfPollResponse -> {
             long totalUpdates = rcfPollResponse.getTotalUpdates();
             if (totalUpdates < requiredSamples) {
-                processInitResponse(detectorId, profilesToCollect, listener, totalUpdates, false);
+                processInitResponse(detector, profilesToCollect, listener, totalUpdates, false);
             } else {
                 if (profilesToCollect.contains(ProfileName.STATE)) {
                     listener.onResponse(new DetectorProfile.Builder().state(DetectorState.RUNNING).build());
@@ -390,16 +517,20 @@ public class AnomalyDetectorProfileRunner {
                 // a detector before cold start finishes, where the actual
                 // initialization time may be much shorter if sufficient historical
                 // data exists.
-                processInitResponse(detectorId, profilesToCollect, listener, 0L, true);
+                processInitResponse(detector, profilesToCollect, listener, 0L, true);
             } else {
-                logger.error(new ParameterizedMessage("Fail to get init progress through messaging for {}", detectorId), exception);
-                listener.failImmediately(FAIL_TO_GET_PROFILE_MSG + detectorId, exception);
+                logger
+                    .error(
+                        new ParameterizedMessage("Fail to get init progress through messaging for {}", detector.getDetectorId()),
+                        exception
+                    );
+                listener.failImmediately(FAIL_TO_GET_PROFILE_MSG + detector.getDetectorId(), exception);
             }
         });
     }
 
     private void processInitResponse(
-        String detectorId,
+        AnomalyDetector detector,
         Set<ProfileName> profilesToCollect,
         MultiResponsesDelegateActionListener<DetectorProfile> listener,
         long totalUpdates,
@@ -414,14 +545,11 @@ public class AnomalyDetectorProfileRunner {
                 InitProgressProfile initProgress = computeInitProgressProfile(totalUpdates, 0);
                 listener.onResponse(new DetectorProfile.Builder().initProgress(initProgress).build());
             } else {
-                GetRequest getDetectorRequest = new GetRequest(ANOMALY_DETECTORS_INDEX, detectorId);
-                client
-                    .get(
-                        getDetectorRequest,
-                        onGetDetectorForInitProgress(listener, detectorId, profilesToCollect, totalUpdates, requiredSamples)
-                    );
-            }
+                long intervalMins = ((IntervalTimeConfiguration) detector.getDetectionInterval()).toDuration().toMinutes();
+                InitProgressProfile initProgress = computeInitProgressProfile(totalUpdates, intervalMins);
 
+                listener.onResponse(new DetectorProfile.Builder().initProgress(initProgress).build());
+            }
         }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/EntityCache.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/EntityCache.java
@@ -51,10 +51,10 @@ public interface EntityCache extends MaintenanceState, CleanState {
     /**
      * Whether an entity is active or not
      * @param detectorId The Id of the detector that an entity belongs to
-     * @param entityId Entity Id
+     * @param entityModelId Entity model Id
      * @return Whether an entity is active or not
      */
-    boolean isActive(String detectorId, String entityId);
+    boolean isActive(String detectorId, String entityModelId);
 
     /**
      * Get total updates of detector's most active entity's RCF model.
@@ -68,8 +68,8 @@ public interface EntityCache extends MaintenanceState, CleanState {
      * Get RCF model total updates of specific entity
      *
      * @param detectorId detector id
-     * @param entityId  entity id
+     * @param entityModelId  entity model id
      * @return RCF model total updates of specific entity
      */
-    long getTotalUpdates(String detectorId, String entityId);
+    long getTotalUpdates(String detectorId, String entityModelId);
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorProfile.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorProfile.java
@@ -37,6 +37,8 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
     private String coordinatingNode;
     private long totalSizeInBytes;
     private InitProgressProfile initProgress;
+    private Long totalEntities;
+    private Long activeEntities;
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
         return toXContent(builder, ToXContent.EMPTY_PARAMS);
@@ -62,6 +64,8 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         private String coordinatingNode = null;
         private long totalSizeInBytes = -1;
         private InitProgressProfile initProgress = null;
+        private Long totalEntities;
+        private Long activeEntities;
 
         public Builder() {}
 
@@ -100,6 +104,16 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             return this;
         }
 
+        public Builder totalEntities(Long totalEntities) {
+            this.totalEntities = totalEntities;
+            return this;
+        }
+
+        public Builder activeEntities(Long activeEntities) {
+            this.activeEntities = activeEntities;
+            return this;
+        }
+
         public DetectorProfile build() {
             DetectorProfile profile = new DetectorProfile();
             profile.state = this.state;
@@ -109,6 +123,8 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             profile.coordinatingNode = coordinatingNode;
             profile.totalSizeInBytes = totalSizeInBytes;
             profile.initProgress = initProgress;
+            profile.totalEntities = totalEntities;
+            profile.activeEntities = activeEntities;
 
             return profile;
         }
@@ -153,6 +169,12 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         }
         if (initProgress != null) {
             xContentBuilder.field(CommonName.INIT_PROGRESS, initProgress);
+        }
+        if (totalEntities != null) {
+            xContentBuilder.field(CommonName.TOTAL_ENTITIES, totalEntities);
+        }
+        if (activeEntities != null) {
+            xContentBuilder.field(CommonName.ACTIVE_ENTITIES, activeEntities);
         }
         return xContentBuilder.endObject();
     }
@@ -213,6 +235,22 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         this.initProgress = initProgress;
     }
 
+    public Long getTotalEntities() {
+        return totalEntities;
+    }
+
+    public void setTotalEntities(Long totalEntities) {
+        this.totalEntities = totalEntities;
+    }
+
+    public Long getActiveEntities() {
+        return activeEntities;
+    }
+
+    public void setActiveEntities(Long activeEntities) {
+        this.activeEntities = activeEntities;
+    }
+
     @Override
     public void merge(Mergeable other) {
         if (this == other || other == null || getClass() != other.getClass()) {
@@ -239,6 +277,12 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         }
         if (otherProfile.getInitProgress() != null) {
             this.initProgress = otherProfile.getInitProgress();
+        }
+        if (otherProfile.getTotalEntities() != null) {
+            this.totalEntities = otherProfile.getTotalEntities();
+        }
+        if (otherProfile.getActiveEntities() != null) {
+            this.activeEntities = otherProfile.getActiveEntities();
         }
     }
 
@@ -275,6 +319,12 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             if (initProgress != null) {
                 equalsBuilder.append(initProgress, other.initProgress);
             }
+            if (totalEntities != null) {
+                equalsBuilder.append(totalEntities, other.totalEntities);
+            }
+            if (activeEntities != null) {
+                equalsBuilder.append(activeEntities, other.activeEntities);
+            }
             return equalsBuilder.isEquals();
         }
         return false;
@@ -290,6 +340,8 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
             .append(coordinatingNode)
             .append(totalSizeInBytes)
             .append(initProgress)
+            .append(totalEntities)
+            .append(activeEntities)
             .toHashCode();
     }
 
@@ -317,6 +369,12 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         }
         if (initProgress != null) {
             toStringBuilder.append(CommonName.INIT_PROGRESS, initProgress);
+        }
+        if (totalEntities != null) {
+            toStringBuilder.append(CommonName.TOTAL_ENTITIES, totalEntities);
+        }
+        if (activeEntities != null) {
+            toStringBuilder.append(CommonName.ACTIVE_ENTITIES, activeEntities);
         }
         return toStringBuilder.toString();
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/EntityProfile.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/EntityProfile.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+import java.io.IOException;
+
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+/**
+ * Profile output for detector entity.
+ */
+public class EntityProfile implements Writeable, ToXContent {
+    // field name in toXContent
+    public static final String CATEGORY_FIELD = "category_field";
+    public static final String ENTITY_VALUE = "value";
+    public static final String IS_ACTIVE = "is_active";
+
+    private final String categoryField;
+    private final String value;
+    private final Boolean isActive;
+
+    public EntityProfile(String categoryField, String value, Boolean isActive) {
+        super();
+        this.categoryField = categoryField;
+        this.value = value;
+        this.isActive = isActive;
+    }
+
+    public EntityProfile(StreamInput in) throws IOException {
+        categoryField = in.readString();
+        value = in.readString();
+        isActive = in.readBoolean();
+    }
+
+    public String getCategoryField() {
+        return categoryField;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Boolean getActive() {
+        return isActive;
+    }
+
+    public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
+        return toXContent(builder, ToXContent.EMPTY_PARAMS);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(CATEGORY_FIELD, categoryField);
+        builder.field(ENTITY_VALUE, value);
+        builder.field(IS_ACTIVE, isActive);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(categoryField);
+        out.writeString(value);
+        out.writeBoolean(isActive);
+    }
+
+    @Override
+    public String toString() {
+        ToStringBuilder builder = new ToStringBuilder(this);
+        builder.append(CATEGORY_FIELD, categoryField);
+        builder.append(ENTITY_VALUE, value);
+        builder.append(IS_ACTIVE, isActive);
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        if (obj instanceof EntityProfile) {
+            EntityProfile other = (EntityProfile) obj;
+            EqualsBuilder equalsBuilder = new EqualsBuilder();
+            equalsBuilder.append(categoryField, other.categoryField);
+            equalsBuilder.append(value, other.value);
+            equalsBuilder.append(isActive, other.isActive);
+
+            return equalsBuilder.isEquals();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(categoryField).append(value).append(isActive).toHashCode();
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ProfileName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ProfileName.java
@@ -28,7 +28,9 @@ public enum ProfileName {
     SHINGLE_SIZE(CommonName.SHINGLE_SIZE),
     TOTAL_SIZE_IN_BYTES(CommonName.TOTAL_SIZE_IN_BYTES),
     MODELS(CommonName.MODELS),
-    INIT_PROGRESS(CommonName.INIT_PROGRESS);
+    INIT_PROGRESS(CommonName.INIT_PROGRESS),
+    TOTAL_ENTITIES(CommonName.TOTAL_ENTITIES),
+    ACTIVE_ENTITIES(CommonName.ACTIVE_ENTITIES);
 
     private String name;
 
@@ -61,6 +63,10 @@ public enum ProfileName {
                 return MODELS;
             case CommonName.INIT_PROGRESS:
                 return INIT_PROGRESS;
+            case CommonName.TOTAL_ENTITIES:
+                return TOTAL_ENTITIES;
+            case CommonName.ACTIVE_ENTITIES:
+                return ACTIVE_ENTITIES;
             default:
                 throw new IllegalArgumentException("Unsupported profile types");
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.ad.rest;
 
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.DETECTOR_ID;
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.ENTITY;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.PROFILE;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.TYPE;
 
@@ -60,6 +61,7 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
         }
         String detectorId = request.param(DETECTOR_ID);
         String typesStr = request.param(TYPE);
+        String entityValue = request.param(ENTITY);
         String rawPath = request.rawPath();
         boolean returnJob = request.paramAsBoolean("job", false);
         boolean all = request.paramAsBoolean("_all", false);
@@ -69,7 +71,8 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
             returnJob,
             typesStr,
             rawPath,
-            all
+            all,
+            entityValue
         );
 
         return channel -> client

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/StatNames.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/StatNames.java
@@ -28,6 +28,8 @@ public enum StatNames {
     ANOMALY_DETECTORS_INDEX_STATUS("anomaly_detectors_index_status"),
     ANOMALY_RESULTS_INDEX_STATUS("anomaly_results_index_status"),
     MODELS_CHECKPOINT_INDEX_STATUS("models_checkpoint_index_status"),
+    ANOMALY_DETECTION_JOB_INDEX_STATUS("anomaly_detection_job_index_status"),
+    ANOMALY_DETECTION_STATE_STATUS("anomaly_detection_state_status"),
     MODEL_INFORMATION("models");
 
     private String name;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileAction.java
@@ -17,19 +17,12 @@ package com.amazon.opendistroforelasticsearch.ad.transport;
 
 import org.elasticsearch.action.ActionType;
 
-/**
- * Profile transport action
- */
-public class ProfileAction extends ActionType<ProfileResponse> {
+public class EntityProfileAction extends ActionType<EntityProfileResponse> {
+    public static final EntityProfileAction INSTANCE = new EntityProfileAction();
+    public static final String NAME = "cluster:admin/opendistro/ad/detectors/profile/entity";
 
-    public static final ProfileAction INSTANCE = new ProfileAction();
-    public static final String NAME = "cluster:admin/opendistro/ad/detectors/profile";
-
-    /**
-     * Constructor
-     */
-    private ProfileAction() {
-        super(NAME, ProfileResponse::new);
+    private EntityProfileAction() {
+        super(NAME, EntityProfileResponse::new);
     }
 
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileRequest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonMessageAttributes;
+
+public class EntityProfileRequest extends ActionRequest implements ToXContentObject {
+    public static final String ENTITY = "entity";
+    private String adID;
+    private String entityValue;
+
+    public EntityProfileRequest(StreamInput in) throws IOException {
+        super(in);
+        adID = in.readString();
+        entityValue = in.readString();
+    }
+
+    public EntityProfileRequest(String adID, String entityValue) {
+        super();
+        this.adID = adID;
+        this.entityValue = entityValue;
+    }
+
+    public String getAdID() {
+        return adID;
+    }
+
+    public String getEntityValue() {
+        return entityValue;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(adID);
+        out.writeString(entityValue);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (Strings.isEmpty(adID)) {
+            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+        }
+        if (Strings.isEmpty(entityValue)) {
+            validationException = addValidationError("Entity value is missing", validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(CommonMessageAttributes.ID_JSON_KEY, adID);
+        builder.field(ENTITY, entityValue);
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileResponse.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+public class EntityProfileResponse extends ActionResponse implements ToXContentObject {
+    public static final String ACTIVE = "active";
+    private final boolean isActive;
+
+    public EntityProfileResponse(boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public EntityProfileResponse(StreamInput in) throws IOException {
+        super(in);
+        isActive = in.readBoolean();
+    }
+
+    public boolean isActive() {
+        return isActive;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(isActive);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(ACTIVE, isActive);
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileTransportAction.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportResponseHandler;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
+import com.amazon.opendistroforelasticsearch.ad.cluster.HashRing;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelPartitioner;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+
+/**
+ * Transport action to get entity profile.
+ */
+public class EntityProfileTransportAction extends HandledTransportAction<EntityProfileRequest, EntityProfileResponse> {
+
+    private static final Logger LOG = LogManager.getLogger(EntityProfileTransportAction.class);
+    public static final String NO_NODE_FOUND_MSG = "Cannot find model hosting node";
+    static final String FAIL_TO_GET_ENTITY_PROFILE_MSG = "Cannot get entity profile info";
+
+    private final TransportService transportService;
+    private final ModelManager modelManager;
+    private final ModelPartitioner modelPartitioner;
+    private final HashRing hashRing;
+    private final TransportRequestOptions option;
+    private final ClusterService clusterService;
+    private final CacheProvider cacheProvider;
+
+    @Inject
+    public EntityProfileTransportAction(
+        ActionFilters actionFilters,
+        TransportService transportService,
+        Settings settings,
+        ModelManager modelManager,
+        ModelPartitioner modelPartitioner,
+        HashRing hashRing,
+        ClusterService clusterService,
+        CacheProvider cacheProvider
+    ) {
+        super(EntityProfileAction.NAME, transportService, actionFilters, EntityProfileRequest::new);
+        this.transportService = transportService;
+        this.modelManager = modelManager;
+        this.modelPartitioner = modelPartitioner;
+        this.hashRing = hashRing;
+        this.option = TransportRequestOptions
+            .builder()
+            .withType(TransportRequestOptions.Type.REG)
+            .withTimeout(AnomalyDetectorSettings.REQUEST_TIMEOUT.get(settings))
+            .build();
+        this.clusterService = clusterService;
+        this.cacheProvider = cacheProvider;
+    }
+
+    @Override
+    protected void doExecute(Task task, EntityProfileRequest request, ActionListener<EntityProfileResponse> listener) {
+
+        String adID = request.getAdID();
+        String entityValue = request.getEntityValue();
+        String modelId = modelManager.getEntityModelId(adID, entityValue);
+        Optional<DiscoveryNode> node = hashRing.getOwningNode(modelId);
+        if (!node.isPresent()) {
+            listener.onFailure(new AnomalyDetectionException(adID, NO_NODE_FOUND_MSG));
+            return;
+        }
+
+        String nodeId = node.get().getId();
+        DiscoveryNode localNode = clusterService.localNode();
+        if (localNode.getId().equals(nodeId)) {
+            listener.onResponse(new EntityProfileResponse((cacheProvider.get().isActive(adID, modelId))));
+        } else {
+            // redirect
+            LOG.debug("Sending RCF polling request to {} for detector {}, entity {}", nodeId, adID, entityValue);
+
+            try {
+                transportService
+                    .sendRequest(
+                        node.get(),
+                        EntityProfileAction.NAME,
+                        request,
+                        option,
+                        new TransportResponseHandler<EntityProfileResponse>() {
+
+                            @Override
+                            public EntityProfileResponse read(StreamInput in) throws IOException {
+                                return new EntityProfileResponse(in);
+                            }
+
+                            @Override
+                            public void handleResponse(EntityProfileResponse response) {
+                                listener.onResponse(response);
+                            }
+
+                            @Override
+                            public void handleException(TransportException exp) {
+                                listener.onFailure(exp);
+                            }
+
+                            @Override
+                            public String executor() {
+                                return ThreadPool.Names.SAME;
+                            }
+
+                        }
+                    );
+            } catch (Exception e) {
+                LOG.error(String.format("Fail to get entity profile for detector {}, entity {}", adID, entityValue), e);
+                listener.onFailure(new AnomalyDetectionException(adID, FAIL_TO_GET_ENTITY_PROFILE_MSG, e));
+            }
+
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorRequest.java
@@ -30,6 +30,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
     private String typeStr;
     private String rawPath;
     private boolean all;
+    private String entityValue;
 
     public GetAnomalyDetectorRequest(StreamInput in) throws IOException {
         super(in);
@@ -39,9 +40,20 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         typeStr = in.readString();
         rawPath = in.readString();
         all = in.readBoolean();
+        if (in.readBoolean()) {
+            entityValue = in.readString();
+        }
     }
 
-    public GetAnomalyDetectorRequest(String detectorID, long version, boolean returnJob, String typeStr, String rawPath, boolean all)
+    public GetAnomalyDetectorRequest(
+        String detectorID,
+        long version,
+        boolean returnJob,
+        String typeStr,
+        String rawPath,
+        boolean all,
+        String entityValue
+    )
         throws IOException {
         super();
         this.detectorID = detectorID;
@@ -50,6 +62,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         this.typeStr = typeStr;
         this.rawPath = rawPath;
         this.all = all;
+        this.entityValue = entityValue;
     }
 
     public String getDetectorID() {
@@ -76,6 +89,10 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         return all;
     }
 
+    public String getEntityValue() {
+        return entityValue;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
@@ -85,6 +102,12 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         out.writeString(typeStr);
         out.writeString(rawPath);
         out.writeBoolean(all);
+        if (this.entityValue != null) {
+            out.writeBoolean(true);
+            out.writeString(entityValue);
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileNodeResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileNodeResponse.java
@@ -25,16 +25,19 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentFragment;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+
 /**
  * Profile response on a node
  */
 public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentFragment {
     // filed name in toXContent
     static final String MODEL_SIZE_IN_BYTES = "model_size_in_bytes";
-    static final String SHINGLE_SIZE = "shingle_size";
 
     private Map<String, Long> modelSize;
     private int shingleSize;
+    private long activeEntities;
+    private long totalUpdates;
 
     /**
      * Constructor
@@ -46,6 +49,8 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
         super(in);
         modelSize = in.readMap(StreamInput::readString, StreamInput::readLong);
         shingleSize = in.readInt();
+        activeEntities = in.readVLong();
+        totalUpdates = in.readVLong();
     }
 
     /**
@@ -54,11 +59,15 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
      * @param node DiscoveryNode object
      * @param modelSize Mapping of model id to its memory consumption in bytes
      * @param shingleSize shingle size
+     * @param activeEntity active entity count
+     * @param totalUpdates RCF model total updates
      */
-    public ProfileNodeResponse(DiscoveryNode node, Map<String, Long> modelSize, int shingleSize) {
+    public ProfileNodeResponse(DiscoveryNode node, Map<String, Long> modelSize, int shingleSize, long activeEntity, long totalUpdates) {
         super(node);
         this.modelSize = modelSize;
         this.shingleSize = shingleSize;
+        this.activeEntities = activeEntity;
+        this.totalUpdates = totalUpdates;
     }
 
     /**
@@ -77,6 +86,8 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
         super.writeTo(out);
         out.writeMap(modelSize, StreamOutput::writeString, StreamOutput::writeLong);
         out.writeInt(shingleSize);
+        out.writeVLong(activeEntities);
+        out.writeVLong(totalUpdates);
     }
 
     /**
@@ -95,7 +106,9 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
         }
         builder.endObject();
 
-        builder.field(SHINGLE_SIZE, shingleSize);
+        builder.field(CommonName.SHINGLE_SIZE, shingleSize);
+        builder.field(CommonName.ACTIVE_ENTITIES, activeEntities);
+        builder.field(CommonName.TOTAL_UPDATES, totalUpdates);
 
         return builder;
     }
@@ -106,5 +119,13 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
 
     public int getShingleSize() {
         return shingleSize;
+    }
+
+    public long getActiveEntities() {
+        return activeEntities;
+    }
+
+    public long getTotalUpdates() {
+        return totalUpdates;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileResponse.java
@@ -39,12 +39,16 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
     static final String COORDINATING_NODE = CommonName.COORDINATING_NODE;
     static final String SHINGLE_SIZE = CommonName.SHINGLE_SIZE;
     static final String TOTAL_SIZE = CommonName.TOTAL_SIZE_IN_BYTES;
+    static final String ACTIVE_ENTITY = CommonName.ACTIVE_ENTITIES;
     static final String MODELS = CommonName.MODELS;
+    static final String TOTAL_UPDATES = CommonName.TOTAL_UPDATES;
 
     private ModelProfile[] modelProfile;
     private int shingleSize;
     private String coordinatingNode;
     private long totalSizeInBytes;
+    private long activeEntities;
+    private long totalUpdates;
 
     /**
      * Constructor
@@ -62,6 +66,8 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
         shingleSize = in.readVInt();
         coordinatingNode = in.readString();
         totalSizeInBytes = in.readVLong();
+        activeEntities = in.readVLong();
+        totalUpdates = in.readVLong();
     }
 
     /**
@@ -74,6 +80,8 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
     public ProfileResponse(ClusterName clusterName, List<ProfileNodeResponse> nodes, List<FailedNodeException> failures) {
         super(clusterName, nodes, failures);
         totalSizeInBytes = 0L;
+        activeEntities = 0L;
+        totalUpdates = 0L;
         List<ModelProfile> modelProfileList = new ArrayList<>();
         for (ProfileNodeResponse response : nodes) {
             String curNodeId = response.getNode().getId();
@@ -85,7 +93,12 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
                 totalSizeInBytes += entry.getValue();
                 modelProfileList.add(new ModelProfile(entry.getKey(), entry.getValue(), curNodeId));
             }
-
+            if (response.getActiveEntities() > 0) {
+                activeEntities += response.getActiveEntities();
+            }
+            if (response.getTotalUpdates() > totalUpdates) {
+                totalUpdates = response.getTotalUpdates();
+            }
         }
         if (coordinatingNode == null) {
             coordinatingNode = "";
@@ -103,6 +116,8 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
         out.writeVInt(shingleSize);
         out.writeString(coordinatingNode);
         out.writeVLong(totalSizeInBytes);
+        out.writeVLong(activeEntities);
+        out.writeVLong(totalUpdates);
     }
 
     @Override
@@ -120,6 +135,8 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
         builder.field(COORDINATING_NODE, coordinatingNode);
         builder.field(SHINGLE_SIZE, shingleSize);
         builder.field(TOTAL_SIZE, totalSizeInBytes);
+        builder.field(ACTIVE_ENTITY, activeEntities);
+        builder.field(TOTAL_UPDATES, totalUpdates);
         builder.startArray(MODELS);
         for (ModelProfile profile : modelProfile) {
             profile.toXContent(builder, params);
@@ -134,6 +151,14 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
 
     public int getShingleSize() {
         return shingleSize;
+    }
+
+    public long getActiveEntities() {
+        return activeEntities;
+    }
+
+    public long getTotalUpdates() {
+        return totalUpdates;
     }
 
     public String getCoordinatingNode() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtils.java
@@ -57,6 +57,7 @@ public final class RestHandlerUtils {
     public static final String STOP_JOB = "_stop";
     public static final String PROFILE = "_profile";
     public static final String TYPE = "type";
+    public static final String ENTITY = "entity";
     public static final ToXContent.MapParams XCONTENT_WITH_TYPE = new ToXContent.MapParams(ImmutableMap.of("with_type", "true"));
 
     private static final String KIBANA_USER_AGENT = "Kibana";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunnerTests.java
@@ -504,8 +504,8 @@ public class AnomalyDetectorProfileRunnerTests extends ESTestCase {
                 }
             };
 
-            ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(discoveryNode1, modelSizeMap1, shingleSize);
-            ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(discoveryNode2, modelSizeMap2, -1);
+            ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(discoveryNode1, modelSizeMap1, shingleSize, 0L, 0L);
+            ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(discoveryNode2, modelSizeMap2, -1, 0L, 0L);
             List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1, profileNodeResponse2);
             List<FailedNodeException> failures = Collections.emptyList();
             ProfileResponse profileResponse = new ProfileResponse(new ClusterName(clusterName), profileNodeResponses, failures);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorActionTests.java
@@ -44,7 +44,7 @@ public class GetAnomalyDetectorActionTests {
     @Test
     public void testGetRequest() throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
-        GetAnomalyDetectorRequest request = new GetAnomalyDetectorRequest("1234", 4321, false, "nonempty", "", false);
+        GetAnomalyDetectorRequest request = new GetAnomalyDetectorRequest("1234", 4321, false, "nonempty", "", false, null);
         request.writeTo(out);
         StreamInput input = out.bytes().streamInput();
         GetAnomalyDetectorRequest newRequest = new GetAnomalyDetectorRequest(input);
@@ -68,6 +68,7 @@ public class GetAnomalyDetectorActionTests {
             false,
             RestStatus.OK,
             Mockito.mock(DetectorProfile.class),
+            null,
             false
         );
         response.writeTo(out);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
@@ -62,13 +62,21 @@ public class GetAnomalyDetectorTransportActionTests extends ESIntegTestCase {
     @Test
     public void testGetTransportAction() throws IOException {
         MultiGetResponse mockResponse = Mockito.mock(MultiGetResponse.class);
-        GetAnomalyDetectorRequest getAnomalyDetectorRequest = new GetAnomalyDetectorRequest("1234", 4321, false, "nonempty", "", false);
+        GetAnomalyDetectorRequest getAnomalyDetectorRequest = new GetAnomalyDetectorRequest(
+            "1234",
+            4321,
+            false,
+            "nonempty",
+            "",
+            false,
+            null
+        );
         action.doExecute(task, getAnomalyDetectorRequest, response);
     }
 
     @Test
     public void testGetTransportActionWithReturnJob() throws IOException {
-        GetAnomalyDetectorRequest getAnomalyDetectorRequest = new GetAnomalyDetectorRequest("1234", 4321, true, "", "abcd", false);
+        GetAnomalyDetectorRequest getAnomalyDetectorRequest = new GetAnomalyDetectorRequest("1234", 4321, true, "", "abcd", false, null);
         action.doExecute(task, getAnomalyDetectorRequest, response);
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileTests.java
@@ -45,6 +45,7 @@ import org.junit.Test;
 import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
 
 import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.ModelProfile;
 import com.amazon.opendistroforelasticsearch.ad.model.ProfileName;
 import com.google.gson.JsonArray;
@@ -135,7 +136,7 @@ public class ProfileTests extends ESTestCase {
     public void testProfileNodeResponse() throws IOException, JsonPathNotFoundException {
 
         // Test serialization
-        ProfileNodeResponse profileNodeResponse = new ProfileNodeResponse(discoveryNode1, modelSizeMap1, shingleSize);
+        ProfileNodeResponse profileNodeResponse = new ProfileNodeResponse(discoveryNode1, modelSizeMap1, shingleSize, 0, 0);
         BytesStreamOutput output = new BytesStreamOutput();
         profileNodeResponse.writeTo(output);
         StreamInput streamInput = output.bytes().streamInput();
@@ -156,11 +157,7 @@ public class ProfileTests extends ESTestCase {
             );
         }
 
-        assertEquals(
-            "toXContent has the wrong shingle size",
-            JsonDeserializer.getIntValue(json, ProfileNodeResponse.SHINGLE_SIZE),
-            shingleSize
-        );
+        assertEquals("toXContent has the wrong shingle size", JsonDeserializer.getIntValue(json, CommonName.SHINGLE_SIZE), shingleSize);
     }
 
     @Test
@@ -186,8 +183,8 @@ public class ProfileTests extends ESTestCase {
     @Test
     public void testProfileResponse() throws IOException, JsonPathNotFoundException {
 
-        ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(discoveryNode1, modelSizeMap1, shingleSize);
-        ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(discoveryNode2, modelSizeMap2, -1);
+        ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(discoveryNode1, modelSizeMap1, shingleSize, 0, 0);
+        ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(discoveryNode2, modelSizeMap2, -1, 0, 0);
         List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1, profileNodeResponse2);
         List<FailedNodeException> failures = Collections.emptyList();
         ProfileResponse profileResponse = new ProfileResponse(new ClusterName(clusterName), profileNodeResponses, failures);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileTransportActionTests.java
@@ -69,7 +69,8 @@ public class ProfileTransportActionTests extends ESIntegTestCase {
             mock(TransportService.class),
             mock(ActionFilters.class),
             modelManager,
-            featureManager
+            featureManager,
+            null
         );
 
         profilesToRetrieve = new HashSet<ProfileName>();
@@ -81,7 +82,7 @@ public class ProfileTransportActionTests extends ESIntegTestCase {
         DiscoveryNode node = clusterService().localNode();
         ProfileRequest profileRequest = new ProfileRequest(detectorId, profilesToRetrieve, node);
 
-        ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(node, new HashMap<>(), shingleSize);
+        ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(node, new HashMap<>(), shingleSize, 0, 0);
         List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1);
         List<FailedNodeException> failures = new ArrayList<>();
 


### PR DESCRIPTION
*Issue #, if available:*

## Description of changes:

Support high cardinality detector in profile API.
1.Total entity count
2.Active entity count
3.Profile entity status: active or not

Add job and detection state index in AD stats API

Did test by starting cluster locally for both single and HC detector.
Exclude some classes which coverage lower than our limitation. Will add more test case in another PR>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
