### PR TITLE
Auto flush checkpoint queue if too many are waiting

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityResultTransportAction.java
@@ -93,7 +93,8 @@ public class EntityResultTransportAction extends HandledTransportAction<EntityRe
     @Override
     protected void doExecute(Task task, EntityResultRequest request, ActionListener<AcknowledgedResponse> listener) {
         if (adCircuitBreakerService.isOpen()) {
-            listener.onFailure(new LimitExceededException(request.getDetectorId(), CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG));
+            listener
+                .onFailure(new LimitExceededException(request.getDetectorId(), CommonErrorMessages.MEMORY_CIRCUIT_BROKEN_ERR_MSG, false));
             return;
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Our performance testing finds that our checkpoint queue can increase quickly.  This can happen during maintenance if there are a lot of entities in cache and very few cache swap outs happen in the past hour.  When an entity's state is swapped out, we try to save a checkpoint.  If we haven't done so for an entity within one hour, we put the checkpoint to a buffer and do a flush at the end of maintenance.  Since we only flush the 1st 1000 queued requeues to disk, a lot of requests may still wait in the queue until the next flush happens.  This is not ideal and can cause memory outages.

This PR triggers another flush after the previous flush finishes if there are a lot of queued requests.

This PR also corrects the LImitExceededException when a circuit breaker is open: previously, we send a LImitExceededException that stops the detector immediately, which leaves no room for the detector to recover.  This PR fixes that by changing the LImitExceededException's stop now flag to be false to give the detector a few more intervals to recover.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
