### PR TITLE
Adding new Search Detector Info API 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,6 +259,7 @@ List<String> jacocoExclusions = [
         'com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorResponse',
         'com.amazon.opendistroforelasticsearch.ad.transport.IndexAnomalyDetectorRequest',
         'com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultTransportAction*',
+        'com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorInfoTransportAction*',
 
         // TODO: hc caused coverage to drop
         //'com.amazon.opendistroforelasticsearch.ad.ml.ModelManager',

--- a/docs/high-cardinality-rfc.md
+++ b/docs/high-cardinality-rfc.md
@@ -24,4 +24,4 @@ Supporting high cardinality with multiple entities definitely takes more resourc
 
 ## Providing Feedback
 
-If you have comments or feedback on our plans for Multi Entity support for Anomaly Detection, please comment on the [original GitHub issue](https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/xxx) in this project to discuss.
+If you have comments or feedback on our plans for Multi Entity support for Anomaly Detection, please comment on the [original GitHub issue](https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/282) in this project to discuss.

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -99,6 +99,7 @@ import com.amazon.opendistroforelasticsearch.ad.rest.RestExecuteAnomalyDetectorA
 import com.amazon.opendistroforelasticsearch.ad.rest.RestGetAnomalyDetectorAction;
 import com.amazon.opendistroforelasticsearch.ad.rest.RestIndexAnomalyDetectorAction;
 import com.amazon.opendistroforelasticsearch.ad.rest.RestSearchAnomalyDetectorAction;
+import com.amazon.opendistroforelasticsearch.ad.rest.RestSearchAnomalyDetectorInfoAction;
 import com.amazon.opendistroforelasticsearch.ad.rest.RestSearchAnomalyResultAction;
 import com.amazon.opendistroforelasticsearch.ad.rest.RestStatsAnomalyDetectorAction;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
@@ -139,6 +140,8 @@ import com.amazon.opendistroforelasticsearch.ad.transport.RCFPollingTransportAct
 import com.amazon.opendistroforelasticsearch.ad.transport.RCFResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.RCFResultTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorInfoAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorInfoTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultTransportAction;
@@ -241,6 +244,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         );
         RestStatsAnomalyDetectorAction statsAnomalyDetectorAction = new RestStatsAnomalyDetectorAction(adStats, this.nodeFilter);
         RestAnomalyDetectorJobAction anomalyDetectorJobAction = new RestAnomalyDetectorJobAction(settings, clusterService);
+        RestSearchAnomalyDetectorInfoAction searchAnomalyDetectorInfoAction = new RestSearchAnomalyDetectorInfoAction();
 
         return ImmutableList
             .of(
@@ -251,7 +255,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 deleteAnomalyDetectorAction,
                 executeAnomalyDetectorAction,
                 anomalyDetectorJobAction,
-                statsAnomalyDetectorAction
+                statsAnomalyDetectorAction,
+                searchAnomalyDetectorInfoAction
             );
     }
 
@@ -621,7 +626,8 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ActionHandler<>(AnomalyDetectorJobAction.INSTANCE, AnomalyDetectorJobTransportAction.class),
                 new ActionHandler<>(ADResultBulkAction.INSTANCE, ADResultBulkTransportAction.class),
                 new ActionHandler<>(EntityResultAction.INSTANCE, EntityResultTransportAction.class),
-                new ActionHandler<>(EntityProfileAction.INSTANCE, EntityProfileTransportAction.class)
+                new ActionHandler<>(EntityProfileAction.INSTANCE, EntityProfileTransportAction.class),
+                new ActionHandler<>(SearchAnomalyDetectorInfoAction.INSTANCE, SearchAnomalyDetectorInfoTransportAction.class)
             );
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestSearchAnomalyDetectorInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestSearchAnomalyDetectorInfoAction.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.rest;
+
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.COUNT;
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.MATCH;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.settings.EnabledSetting;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorInfoAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorInfoRequest;
+import com.google.common.collect.ImmutableList;
+
+public class RestSearchAnomalyDetectorInfoAction extends BaseRestHandler {
+
+    public static final String SEARCH_ANOMALY_DETECTOR_INFO_ACTION = "search_anomaly_detector_info";
+
+    private static final Logger logger = LogManager.getLogger(RestSearchAnomalyDetectorInfoAction.class);
+
+    public RestSearchAnomalyDetectorInfoAction() {}
+
+    @Override
+    public String getName() {
+        return SEARCH_ANOMALY_DETECTOR_INFO_ACTION;
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, org.elasticsearch.client.node.NodeClient client) throws IOException {
+        if (!EnabledSetting.isADPluginEnabled()) {
+            throw new IllegalStateException(CommonErrorMessages.DISABLED_ERR_MSG);
+        }
+
+        String detectorName = request.param("name", null);
+        String rawPath = request.rawPath();
+
+        SearchAnomalyDetectorInfoRequest searchAnomalyDetectorInfoRequest = new SearchAnomalyDetectorInfoRequest(detectorName, rawPath);
+        return channel -> client
+            .execute(SearchAnomalyDetectorInfoAction.INSTANCE, searchAnomalyDetectorInfoRequest, new RestToXContentListener<>(channel));
+    }
+
+    @Override
+    public List<RestHandler.Route> routes() {
+        return ImmutableList
+            .of(
+                // get the count of number of detectors
+                new RestHandler.Route(
+                    RestRequest.Method.GET,
+                    String.format(Locale.ROOT, "%s/%s", AnomalyDetectorPlugin.AD_BASE_DETECTORS_URI, COUNT)
+                ),
+                // get if a detector name exists with name
+                new RestHandler.Route(RestRequest.Method.GET, String.format("%s/%s", AnomalyDetectorPlugin.AD_BASE_DETECTORS_URI, MATCH))
+            );
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoAction.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+
+public class SearchAnomalyDetectorInfoAction extends ActionType<SearchAnomalyDetectorInfoResponse> {
+    public static final SearchAnomalyDetectorInfoAction INSTANCE = new SearchAnomalyDetectorInfoAction();
+    public static final String NAME = "cluster:admin/opendistro/ad/detector/info";
+
+    private SearchAnomalyDetectorInfoAction() {
+        super(NAME, SearchAnomalyDetectorInfoResponse::new);
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoAction.java
@@ -17,9 +17,12 @@ package com.amazon.opendistroforelasticsearch.ad.transport;
 
 import org.elasticsearch.action.ActionType;
 
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
+
 public class SearchAnomalyDetectorInfoAction extends ActionType<SearchAnomalyDetectorInfoResponse> {
+    // External Action which used for public facing RestAPIs.
+    public static final String NAME = CommonValue.EXTERNAL_ACTION_PREFIX + "detector/info";
     public static final SearchAnomalyDetectorInfoAction INSTANCE = new SearchAnomalyDetectorInfoAction();
-    public static final String NAME = "cluster:admin/opendistro/ad/detector/info";
 
     private SearchAnomalyDetectorInfoAction() {
         super(NAME, SearchAnomalyDetectorInfoResponse::new);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+public class SearchAnomalyDetectorInfoRequest extends ActionRequest {
+
+    private String name;
+    private String rawPath;
+
+    public SearchAnomalyDetectorInfoRequest(StreamInput in) throws IOException {
+        super(in);
+        name = in.readOptionalString();
+        rawPath = in.readString();
+    }
+
+    public SearchAnomalyDetectorInfoRequest(String name, String rawPath) throws IOException {
+        super();
+        this.name = name;
+        this.rawPath = rawPath;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getRawPath() {
+        return rawPath;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(name);
+        out.writeString(rawPath);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoResponse.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
+
+public class SearchAnomalyDetectorInfoResponse extends ActionResponse implements ToXContentObject {
+    private long count;
+    private boolean nameExists;
+
+    public SearchAnomalyDetectorInfoResponse(StreamInput in) throws IOException {
+        super(in);
+        count = in.readLong();
+        nameExists = in.readBoolean();
+    }
+
+    public SearchAnomalyDetectorInfoResponse(long count, boolean nameExists) {
+        this.count = count;
+        this.nameExists = nameExists;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public boolean isNameExists() {
+        return nameExists;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLong(count);
+        out.writeBoolean(nameExists);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field(RestHandlerUtils.COUNT, count);
+        builder.field(RestHandlerUtils.MATCH, nameExists);
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoTransportAction.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
+
+public class SearchAnomalyDetectorInfoTransportAction extends
+    HandledTransportAction<SearchAnomalyDetectorInfoRequest, SearchAnomalyDetectorInfoResponse> {
+    private static final Logger LOG = LogManager.getLogger(SearchAnomalyDetectorInfoTransportAction.class);
+    private final Client client;
+    private final ClusterService clusterService;
+
+    @Inject
+    public SearchAnomalyDetectorInfoTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        ClusterService clusterService
+    ) {
+        super(SearchAnomalyDetectorInfoAction.NAME, transportService, actionFilters, SearchAnomalyDetectorInfoRequest::new);
+        this.client = client;
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    protected void doExecute(
+        Task task,
+        SearchAnomalyDetectorInfoRequest request,
+        ActionListener<SearchAnomalyDetectorInfoResponse> listener
+    ) {
+        String name = request.getName();
+        String rawPath = request.getRawPath();
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            SearchRequest searchRequest = new SearchRequest().indices(ANOMALY_DETECTORS_INDEX);
+            if (rawPath.endsWith(RestHandlerUtils.COUNT)) {
+                // Count detectors
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+                searchRequest.source(searchSourceBuilder);
+                client.search(searchRequest, new ActionListener<SearchResponse>() {
+
+                    @Override
+                    public void onResponse(SearchResponse searchResponse) {
+                        SearchAnomalyDetectorInfoResponse response = new SearchAnomalyDetectorInfoResponse(
+                            searchResponse.getHits().getTotalHits().value,
+                            false
+                        );
+                        listener.onResponse(response);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        listener.onFailure(e);
+                    }
+                });
+            } else {
+                // Match name with existing detectors
+                TermsQueryBuilder query = QueryBuilders.termsQuery("name.keyword", name);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().query(query);
+                searchRequest.source(searchSourceBuilder);
+                client.search(searchRequest, new ActionListener<SearchResponse>() {
+
+                    @Override
+                    public void onResponse(SearchResponse searchResponse) {
+                        boolean nameExists = false;
+                        if (searchResponse.getHits().getTotalHits().value > 0) {
+                            nameExists = true;
+                        } else {
+                            nameExists = false;
+                        }
+                        SearchAnomalyDetectorInfoResponse response = new SearchAnomalyDetectorInfoResponse(0, nameExists);
+                        listener.onResponse(response);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        listener.onFailure(e);
+                    }
+                });
+            }
+        } catch (Exception e) {
+            LOG.error(e);
+            listener.onFailure(e);
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtils.java
@@ -63,6 +63,8 @@ public final class RestHandlerUtils {
     public static final String PROFILE = "_profile";
     public static final String TYPE = "type";
     public static final String ENTITY = "entity";
+    public static final String COUNT = "count";
+    public static final String MATCH = "match";
     public static final ToXContent.MapParams XCONTENT_WITH_TYPE = new ToXContent.MapParams(ImmutableMap.of("with_type", "true"));
 
     private static final String KIBANA_USER_AGENT = "Kibana";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
@@ -242,25 +242,25 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
 
     public Response getSearchDetectorCount() throws IOException {
         return TestHelpers
-                .makeRequest(
-                        client(),
-                        "GET",
-                        TestHelpers.AD_BASE_DETECTORS_URI + "/" + RestHandlerUtils.COUNT,
-                        null,
-                        "",
-                        ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
-                );
+            .makeRequest(
+                client(),
+                "GET",
+                TestHelpers.AD_BASE_DETECTORS_URI + "/" + RestHandlerUtils.COUNT,
+                null,
+                "",
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            );
     }
 
     public Response getSearchDetectorMatch(String name) throws IOException {
         return TestHelpers
-                .makeRequest(
-                        client(),
-                        "GET",
-                        TestHelpers.AD_BASE_DETECTORS_URI + "/" + RestHandlerUtils.MATCH,
-                        ImmutableMap.of("name",name),
-                        "",
-                        ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
-                );
+            .makeRequest(
+                client(),
+                "GET",
+                TestHelpers.AD_BASE_DETECTORS_URI + "/" + RestHandlerUtils.MATCH,
+                ImmutableMap.of("name", name),
+                "",
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            );
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
@@ -239,4 +239,28 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
     public Response getDetectorProfile(String detectorId, boolean all) throws IOException {
         return getDetectorProfile(detectorId, all, "");
     }
+
+    public Response getSearchDetectorCount() throws IOException {
+        return TestHelpers
+                .makeRequest(
+                        client(),
+                        "GET",
+                        TestHelpers.AD_BASE_DETECTORS_URI + "/" + RestHandlerUtils.COUNT,
+                        null,
+                        "",
+                        ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+                );
+    }
+
+    public Response getSearchDetectorMatch(String name) throws IOException {
+        return TestHelpers
+                .makeRequest(
+                        client(),
+                        "GET",
+                        TestHelpers.AD_BASE_DETECTORS_URI + "/" + RestHandlerUtils.MATCH,
+                        ImmutableMap.of("name",name),
+                        "",
+                        ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+                );
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -1041,12 +1041,26 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         assertEquals("Incorrect profile status", RestStatus.OK, restStatus(profileResponse));
     }
 
+    public void testSearchAnomalyDetectorCountNoIndex() throws Exception {
+        Response countResponse = getSearchDetectorCount();
+        Map<String, Object> responseMap = entityAsMap(countResponse);
+        Integer count = (Integer) responseMap.get("count");
+        assertEquals((long) count, 0);
+    }
+
     public void testSearchAnomalyDetectorCount() throws Exception {
         AnomalyDetector detector = createRandomAnomalyDetector(true, true);
         Response countResponse = getSearchDetectorCount();
         Map<String, Object> responseMap = entityAsMap(countResponse);
         Integer count = (Integer) responseMap.get("count");
         assertEquals((long) count, 1);
+    }
+
+    public void testSearchAnomalyDetectorMatchNoIndex() throws Exception {
+        Response matchResponse = getSearchDetectorMatch("name");
+        Map<String, Object> responseMap = entityAsMap(matchResponse);
+        boolean nameExists = (boolean) responseMap.get("match");
+        assertEquals(nameExists, false);
     }
 
     public void testSearchAnomalyDetectorNoMatch() throws Exception {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -1040,4 +1040,28 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         Response profileResponse = getDetectorProfile(detector.getDetectorId(), true, "/models/");
         assertEquals("Incorrect profile status", RestStatus.OK, restStatus(profileResponse));
     }
+
+    public void testSearchAnomalyDetectorCount() throws Exception {
+        AnomalyDetector detector = createRandomAnomalyDetector(true, true);
+        Response countResponse = getSearchDetectorCount();
+        Map<String, Object> responseMap = entityAsMap(countResponse);
+        Integer count = (Integer) responseMap.get("count");
+        assertEquals((long) count, 1);
+    }
+
+    public void testSearchAnomalyDetectorNoMatch() throws Exception {
+        AnomalyDetector detector = createRandomAnomalyDetector(true, true);
+        Response matchResponse = getSearchDetectorMatch(detector.getName());
+        Map<String, Object> responseMap = entityAsMap(matchResponse);
+        boolean nameExists = (boolean) responseMap.get("match");
+        assertEquals(nameExists, true);
+    }
+
+    public void testSearchAnomalyDetectorMatch() throws Exception {
+        AnomalyDetector detector = createRandomAnomalyDetector(true, true);
+        Response matchResponse = getSearchDetectorMatch(detector.getName() + "newDetector");
+        Map<String, Object> responseMap = entityAsMap(matchResponse);
+        boolean nameExists = (boolean) responseMap.get("match");
+        assertEquals(nameExists, false);
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 
-import org.apache.lucene.index.IndexNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -54,26 +53,27 @@ public class SearchAnomalyDetectorInfoActionTests extends ESIntegTestCase {
         response = new ActionListener<SearchAnomalyDetectorInfoResponse>() {
             @Override
             public void onResponse(SearchAnomalyDetectorInfoResponse response) {
-                Assert.assertTrue(true);
+                Assert.assertEquals(response.getCount(), 0);
+                Assert.assertEquals(response.isNameExists(), false);
             }
 
             @Override
             public void onFailure(Exception e) {
-                Assert.assertFalse(IndexNotFoundException.class == e.getClass());
+                Assert.assertTrue(true);
             }
         };
     }
 
     @Test
     public void testSearchCount() throws IOException {
-        // Anomaly Detectors index will not exist, onFailure will be called
+        // Anomaly Detectors index will not exist, onResponse will be called
         SearchAnomalyDetectorInfoRequest request = new SearchAnomalyDetectorInfoRequest(null, "count");
         action.doExecute(task, request, response);
     }
 
     @Test
     public void testSearchMatch() throws IOException {
-        // Anomaly Detectors index will not exist, onFailure will be called
+        // Anomaly Detectors index will not exist, onResponse will be called
         SearchAnomalyDetectorInfoRequest request = new SearchAnomalyDetectorInfoRequest("testDetector", "match");
         action.doExecute(task, request, response);
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+
+import org.apache.lucene.index.IndexNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+
+public class SearchAnomalyDetectorInfoActionTests extends ESIntegTestCase {
+    private SearchAnomalyDetectorInfoRequest request;
+    private ActionListener<SearchAnomalyDetectorInfoResponse> response;
+    private SearchAnomalyDetectorInfoTransportAction action;
+    private Task task;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        action = new SearchAnomalyDetectorInfoTransportAction(
+            mock(TransportService.class),
+            mock(ActionFilters.class),
+            client(),
+            clusterService()
+        );
+        task = mock(Task.class);
+        response = new ActionListener<SearchAnomalyDetectorInfoResponse>() {
+            @Override
+            public void onResponse(SearchAnomalyDetectorInfoResponse response) {
+                Assert.assertTrue(true);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Assert.assertFalse(IndexNotFoundException.class == e.getClass());
+            }
+        };
+    }
+
+    @Test
+    public void testSearchCount() throws IOException {
+        // Anomaly Detectors index will not exist, onFailure will be called
+        SearchAnomalyDetectorInfoRequest request = new SearchAnomalyDetectorInfoRequest(null, "count");
+        action.doExecute(task, request, response);
+    }
+
+    @Test
+    public void testSearchMatch() throws IOException {
+        // Anomaly Detectors index will not exist, onFailure will be called
+        SearchAnomalyDetectorInfoRequest request = new SearchAnomalyDetectorInfoRequest("testDetector", "match");
+        action.doExecute(task, request, response);
+    }
+
+    @Test
+    public void testSearchCountWithIndex() throws IOException {
+
+    }
+
+    @Test
+    public void testSearchInfoAction() {
+        Assert.assertNotNull(SearchAnomalyDetectorInfoAction.INSTANCE.name());
+        Assert.assertEquals(SearchAnomalyDetectorInfoAction.INSTANCE.name(), SearchAnomalyDetectorInfoAction.NAME);
+    }
+
+    @Test
+    public void testSearchInfoRequest() throws IOException {
+        SearchAnomalyDetectorInfoRequest request = new SearchAnomalyDetectorInfoRequest("testDetector", "match");
+        BytesStreamOutput out = new BytesStreamOutput();
+        request.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        SearchAnomalyDetectorInfoRequest newRequest = new SearchAnomalyDetectorInfoRequest(input);
+        Assert.assertEquals(request.getName(), newRequest.getName());
+        Assert.assertEquals(request.getRawPath(), newRequest.getRawPath());
+        Assert.assertNull(newRequest.validate());
+    }
+
+    @Test
+    public void testSearchInfoResponse() throws IOException {
+        SearchAnomalyDetectorInfoResponse response = new SearchAnomalyDetectorInfoResponse(1, true);
+        BytesStreamOutput out = new BytesStreamOutput();
+        response.writeTo(out);
+        StreamInput input = out.bytes().streamInput();
+        SearchAnomalyDetectorInfoResponse newResponse = new SearchAnomalyDetectorInfoResponse(input);
+        Assert.assertEquals(response.getCount(), newResponse.getCount());
+        Assert.assertEquals(response.isNameExists(), newResponse.isNameExists());
+        Assert.assertNotNull(response.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorInfoActionTests.java
@@ -79,11 +79,6 @@ public class SearchAnomalyDetectorInfoActionTests extends ESIntegTestCase {
     }
 
     @Test
-    public void testSearchCountWithIndex() throws IOException {
-
-    }
-
-    @Test
     public void testSearchInfoAction() {
         Assert.assertNotNull(SearchAnomalyDetectorInfoAction.INSTANCE.name());
         Assert.assertEquals(SearchAnomalyDetectorInfoAction.INSTANCE.name(), SearchAnomalyDetectorInfoAction.NAME);


### PR DESCRIPTION
*Issue #195 *

*Description of changes:*
Adding new Search Detector Info API to query total number of detectors and match name with existing detectors.
This API will search across all the detectors in detector index irrespective of User context.

Count Request: 
`GET _opendistro/_anomaly_detection/detectors/count`
Response: 
`{
  "count" : 4,
  "match" : false
}`

Match Request:
`GET _opendistro/_anomaly_detection/detectors/match?name=opendistro_ad`
Response:
`{
  "count" : 0,
  "match" : false
}`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
