### PR TITLE
Updating Search Detector API to reject all queries other than BoolQuery

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -517,6 +517,7 @@ public class IndexAnomalyDetectorActionHandler {
                             indexResponse.getVersion(),
                             indexResponse.getSeqNo(),
                             indexResponse.getPrimaryTerm(),
+                            detector,
                             RestStatus.CREATED
                         )
                     );

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/IndexAnomalyDetectorResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/IndexAnomalyDetectorResponse.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.RestStatus;
 
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 
 public class IndexAnomalyDetectorResponse extends ActionResponse implements ToXContentObject {
@@ -31,6 +32,7 @@ public class IndexAnomalyDetectorResponse extends ActionResponse implements ToXC
     private final long version;
     private final long seqNo;
     private final long primaryTerm;
+    private final AnomalyDetector detector;
     private final RestStatus restStatus;
 
     public IndexAnomalyDetectorResponse(StreamInput in) throws IOException {
@@ -39,14 +41,23 @@ public class IndexAnomalyDetectorResponse extends ActionResponse implements ToXC
         version = in.readLong();
         seqNo = in.readLong();
         primaryTerm = in.readLong();
+        detector = new AnomalyDetector(in);
         restStatus = in.readEnum(RestStatus.class);
     }
 
-    public IndexAnomalyDetectorResponse(String id, long version, long seqNo, long primaryTerm, RestStatus restStatus) {
+    public IndexAnomalyDetectorResponse(
+        String id,
+        long version,
+        long seqNo,
+        long primaryTerm,
+        AnomalyDetector detector,
+        RestStatus restStatus
+    ) {
         this.id = id;
         this.version = version;
         this.seqNo = seqNo;
         this.primaryTerm = primaryTerm;
+        this.detector = detector;
         this.restStatus = restStatus;
     }
 
@@ -60,6 +71,7 @@ public class IndexAnomalyDetectorResponse extends ActionResponse implements ToXC
         out.writeLong(version);
         out.writeLong(seqNo);
         out.writeLong(primaryTerm);
+        detector.writeTo(out);
         out.writeEnum(restStatus);
     }
 
@@ -70,6 +82,7 @@ public class IndexAnomalyDetectorResponse extends ActionResponse implements ToXC
             .field(RestHandlerUtils._ID, id)
             .field(RestHandlerUtils._VERSION, version)
             .field(RestHandlerUtils._SEQ_NO, seqNo)
+            .field(RestHandlerUtils.ANOMALY_DETECTOR, detector)
             .field(RestHandlerUtils._PRIMARY_TERM, primaryTerm)
             .endObject();
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorTransportAction.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -36,6 +37,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -128,11 +130,11 @@ public class SearchAnomalyDetectorTransportAction extends HandledTransportAction
 
     private void addFilter(User user, SearchSourceBuilder searchSourceBuilder, String fieldName) {
         TermsQueryBuilder filterBackendRoles = QueryBuilders.termsQuery(fieldName, user.getBackendRoles());
-        // For search detector queries, non BoolQuery is only used to find if the new detector name being created is
-        // unique, which does not need a user filter.
         if (searchSourceBuilder.query() instanceof BoolQueryBuilder) {
             BoolQueryBuilder queryBuilder = (BoolQueryBuilder) searchSourceBuilder.query();
             searchSourceBuilder.query(queryBuilder.filter(filterBackendRoles));
+        } else {
+            throw new ElasticsearchException("Search Detectors API does not support queries other than BoolQuery");
         }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/SearchAnomalyDetectorTransportAction.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/IndexAnomalyDetectorActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/IndexAnomalyDetectorActionTests.java
@@ -15,8 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
-import java.io.IOException;
-
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -35,7 +33,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(IndexAnomalyDetectorRequest.class)
+@PrepareForTest({ IndexAnomalyDetectorRequest.class, IndexAnomalyDetectorResponse.class })
 public class IndexAnomalyDetectorActionTests {
     @Before
     public void setUp() throws Exception {
@@ -69,11 +67,14 @@ public class IndexAnomalyDetectorActionTests {
     }
 
     @Test
-    public void testIndexResponse() throws IOException {
+    public void testIndexResponse() throws Exception {
         BytesStreamOutput out = new BytesStreamOutput();
-        IndexAnomalyDetectorResponse response = new IndexAnomalyDetectorResponse("1234", 56, 78, 90, RestStatus.OK);
+        AnomalyDetector detector = Mockito.mock(AnomalyDetector.class);
+        Mockito.doNothing().when(detector).writeTo(out);
+        IndexAnomalyDetectorResponse response = new IndexAnomalyDetectorResponse("1234", 56, 78, 90, detector, RestStatus.OK);
         response.writeTo(out);
         StreamInput input = out.bytes().streamInput();
+        PowerMockito.whenNew(AnomalyDetector.class).withAnyArguments().thenReturn(detector);
         IndexAnomalyDetectorResponse newResponse = new IndexAnomalyDetectorResponse(input);
         Assert.assertEquals(response.getId(), newResponse.getId());
     }


### PR DESCRIPTION
*Issue #195 *

*Description of changes:*
As count and match detectors is moved to Search Detector Info API, Search Detector API will now filter all queries with backend role filter if enabled.

Also will be making changes to Alerting plugin, where we query Detectors during create Monitor workflow. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
