### PR TITLE
set user as nested type to support exists query

### DIFF
--- a/src/main/resources/mappings/anomaly-detector-jobs.json
+++ b/src/main/resources/mappings/anomaly-detector-jobs.json
@@ -61,6 +61,7 @@
       "type": "long"
     },
     "user": {
+      "type": "nested",
       "properties": {
         "name": {
           "type": "text",

--- a/src/main/resources/mappings/anomaly-detectors.json
+++ b/src/main/resources/mappings/anomaly-detectors.json
@@ -105,6 +105,7 @@
       "enabled": false
     },
     "user": {
+      "type": "nested",
       "properties": {
         "name": {
           "type": "text",

--- a/src/main/resources/mappings/anomaly-results.json
+++ b/src/main/resources/mappings/anomaly-results.json
@@ -50,6 +50,7 @@
       "type": "text"
     },
     "user": {
+      "type": "nested",
       "properties": {
         "name": {
           "type": "text",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We need to set the user type as nested, then we can use exists query to check if `user` and `user.backend_roles` exists

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
