### PR TITLE
Fix edge case where entities found for preview is empty

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
@@ -72,6 +72,9 @@ public final class AnomalyDetectorRunner {
         if (categoryField != null && !categoryField.isEmpty()) {
             featureManager.getPreviewEntities(detector, startTime.toEpochMilli(), endTime.toEpochMilli(), ActionListener.wrap(entities -> {
 
+                if (entities == null || entities.isEmpty()) {
+                    listener.onResponse(Collections.emptyList());
+                }
                 ActionListener<EntityAnomalyResult> entityAnomalyResultListener = ActionListener
                     .wrap(
                         entityAnomalyResult -> { listener.onResponse(entityAnomalyResult.getAnomalyResults()); },

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRunner.java
@@ -73,6 +73,9 @@ public final class AnomalyDetectorRunner {
             featureManager.getPreviewEntities(detector, startTime.toEpochMilli(), endTime.toEpochMilli(), ActionListener.wrap(entities -> {
 
                 if (entities == null || entities.isEmpty()) {
+                    // TODO return exception like IllegalArgumentException to explain data is not enough for preview
+                    // This also requires front-end change to handle error message correspondingly
+                    // We return empty list for now to avoid breaking front-end
                     listener.onResponse(Collections.emptyList());
                 }
                 ActionListener<EntityAnomalyResult> entityAnomalyResultListener = ActionListener
@@ -119,6 +122,9 @@ public final class AnomalyDetectorRunner {
 
     private void onFailure(Exception e, ActionListener<List<AnomalyResult>> listener, String detectorId) {
         logger.info("Fail to preview anomaly detector " + detectorId, e);
+        // TODO return exception like IllegalArgumentException to explain data is not enough for preview
+        // This also requires front-end change to handle error message correspondingly
+        // We return empty list for now to avoid breaking front-end
         listener.onResponse(Collections.emptyList());
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix edge case where entities found for preview is empty.

Have verified on test domain that empty result is returned with this fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
