### PR TITLE
Improve profile API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,8 +250,9 @@ List<String> jacocoExclusions = [
         'com.amazon.opendistroforelasticsearch.ad.transport.CronRequest',
         'com.amazon.opendistroforelasticsearch.ad.transport.ADStatsNodesAction',
         'com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorRunner',
-        'com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices',
         'com.amazon.opendistroforelasticsearch.ad.util.ParseUtils',
+
+        // related to transport actions added for security
         'com.amazon.opendistroforelasticsearch.ad.transport.StatsAnomalyDetectorTransportAction',
         'com.amazon.opendistroforelasticsearch.ad.transport.DeleteAnomalyDetectorTransportAction*',
         'com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorTransportAction*',
@@ -260,19 +261,15 @@ List<String> jacocoExclusions = [
         'com.amazon.opendistroforelasticsearch.ad.transport.IndexAnomalyDetectorRequest',
         'com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyResultTransportAction*',
         'com.amazon.opendistroforelasticsearch.ad.transport.SearchAnomalyDetectorInfoTransportAction*',
+        'com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorRequest',
+        'com.amazon.opendistroforelasticsearch.ad.transport.IndexAnomalyDetectorResponse',
+        'com.amazon.opendistroforelasticsearch.ad.transport.IndexAnomalyDetectorTransportAction',
 
         // TODO: hc caused coverage to drop
         'com.amazon.opendistroforelasticsearch.ad.NodeStateManager',
+        'com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices',
         'com.amazon.opendistroforelasticsearch.ad.transport.handler.MultiEntityResultHandler',
-        'com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileTransportAction*',
-        'com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorProfileRunner',
-        'com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileResponse',
-        'com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileRequest',
-        'com.amazon.opendistroforelasticsearch.ad.util.MultiResponsesDelegateActionListener',
-        'com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorRequest',
         'com.amazon.opendistroforelasticsearch.ad.util.ThrowingSupplierWrapper',
-        'com.amazon.opendistroforelasticsearch.ad.transport.IndexAnomalyDetectorResponse',
-        'com.amazon.opendistroforelasticsearch.ad.transport.IndexAnomalyDetectorTransportAction',
 ]
 
 jacocoTestCoverageVerification {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AbstractProfileRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AbstractProfileRunner.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import com.amazon.opendistroforelasticsearch.ad.model.InitProgressProfile;
+
+public abstract class AbstractProfileRunner {
+    protected long requiredSamples;
+
+    public AbstractProfileRunner(long requiredSamples) {
+        this.requiredSamples = requiredSamples;
+    }
+
+    protected InitProgressProfile computeInitProgressProfile(long totalUpdates, long intervalMins) {
+        float percent = Math.min((100.0f * totalUpdates) / requiredSamples, 100.0f);
+        int neededPoints = (int) (requiredSamples - totalUpdates);
+        return new InitProgressProfile(
+            // rounding: 93.456 => 93%, 93.556 => 94%
+            String.format("%.0f%%", percent),
+            intervalMins * neededPoints,
+            neededPoints
+        );
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/DetectorModelSize.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/DetectorModelSize.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import java.util.Map;
+
+public interface DetectorModelSize {
+    /**
+     * Gets all of a detector's model sizes hosted on a node
+     *
+     * @param detectorId Detector Id
+     * @return a map of model id to its memory size
+     */
+    Map<String, Long> getModelSize(String detectorId);
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/EntityModelSize.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/EntityModelSize.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+public interface EntityModelSize {
+    /**
+     * Gets an entity's model sizes
+     *
+     * @param detectorId Detector Id
+     * @param entityModelId Entity's model Id
+     * @return the entity's memory size
+     */
+    long getModelSize(String detectorId, String entityModelId);
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/EntityProfileRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/EntityProfileRunner.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.CATEGORY_FIELD_LIMIT;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+import java.security.InvalidParameterException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentParseException;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.NestedQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityProfile;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityProfileName;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityState;
+import com.amazon.opendistroforelasticsearch.ad.model.InitProgressProfile;
+import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
+import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileRequest;
+import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileResponse;
+import com.amazon.opendistroforelasticsearch.ad.util.MultiResponsesDelegateActionListener;
+import com.amazon.opendistroforelasticsearch.ad.util.ParseUtils;
+
+public class EntityProfileRunner extends AbstractProfileRunner {
+    private final Logger logger = LogManager.getLogger(EntityProfileRunner.class);
+
+    static final String NOT_HC_DETECTOR_ERR_MSG = "This is not a high cardinality detector";
+    private Client client;
+    private NamedXContentRegistry xContentRegistry;
+
+    public EntityProfileRunner(Client client, NamedXContentRegistry xContentRegistry, long requiredSamples) {
+        super(requiredSamples);
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+    }
+
+    /**
+     * Get profile info of specific entity.
+     *
+     * @param detectorId detector identifier
+     * @param entityValue entity value
+     * @param profilesToCollect profiles to collect
+     * @param listener action listener to handle exception and process entity profile response
+     */
+    public void profile(
+        String detectorId,
+        String entityValue,
+        Set<EntityProfileName> profilesToCollect,
+        ActionListener<EntityProfile> listener
+    ) {
+        if (profilesToCollect == null || profilesToCollect.size() == 0) {
+            listener.onFailure(new InvalidParameterException(CommonErrorMessages.EMPTY_PROFILES_COLLECT));
+            return;
+        }
+        GetRequest getDetectorRequest = new GetRequest(ANOMALY_DETECTORS_INDEX, detectorId);
+
+        client.get(getDetectorRequest, ActionListener.wrap(getResponse -> {
+            if (getResponse != null && getResponse.isExists()) {
+                try (
+                    XContentParser parser = XContentType.JSON
+                        .xContent()
+                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
+                ) {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+                    AnomalyDetector detector = AnomalyDetector.parse(parser, detectorId);
+                    List<String> categoryField = detector.getCategoryField();
+                    if (categoryField == null || categoryField.size() == 0) {
+                        listener.onFailure(new InvalidParameterException(NOT_HC_DETECTOR_ERR_MSG));
+                    } else if (categoryField.size() > CATEGORY_FIELD_LIMIT) {
+                        listener
+                            .onFailure(
+                                new InvalidParameterException(CommonErrorMessages.CATEGORICAL_FIELD_NUMBER_SURPASSED + CATEGORY_FIELD_LIMIT)
+                            );
+                    } else {
+                        int totalResponsesToWait = 0;
+                        if (profilesToCollect.contains(EntityProfileName.INIT_PROGRESS)
+                            || profilesToCollect.contains(EntityProfileName.STATE)) {
+                            totalResponsesToWait++;
+                        }
+                        if (profilesToCollect.contains(EntityProfileName.ENTITY_INFO)) {
+                            totalResponsesToWait++;
+                        }
+                        if (profilesToCollect.contains(EntityProfileName.MODELS)) {
+                            totalResponsesToWait++;
+                        }
+                        MultiResponsesDelegateActionListener<EntityProfile> delegateListener =
+                            new MultiResponsesDelegateActionListener<EntityProfile>(
+                                listener,
+                                totalResponsesToWait,
+                                "Fail to fetch profile for " + entityValue + " of detector " + detectorId,
+                                false
+                            );
+                        prepareEntityProfile(delegateListener, detectorId, entityValue, profilesToCollect, detector, categoryField.get(0));
+                    }
+                } catch (Exception t) {
+                    listener.onFailure(t);
+                }
+            } else {
+                listener.onFailure(new InvalidParameterException(CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG + detectorId));
+            }
+        }, listener::onFailure));
+    }
+
+    private void prepareEntityProfile(
+        MultiResponsesDelegateActionListener<EntityProfile> delegateListener,
+        String detectorId,
+        String entityValue,
+        Set<EntityProfileName> profilesToCollect,
+        AnomalyDetector detector,
+        String categoryField
+    ) {
+        EntityProfileRequest request = new EntityProfileRequest(detectorId, entityValue, profilesToCollect);
+
+        client
+            .execute(
+                EntityProfileAction.INSTANCE,
+                request,
+                ActionListener
+                    .wrap(
+                        r -> getJob(detectorId, categoryField, entityValue, profilesToCollect, detector, r, delegateListener),
+                        delegateListener::failImmediately
+                    )
+            );
+    }
+
+    private void getJob(
+        String detectorId,
+        String categoryField,
+        String entityValue,
+        Set<EntityProfileName> profilesToCollect,
+        AnomalyDetector detector,
+        EntityProfileResponse entityProfileResponse,
+        MultiResponsesDelegateActionListener<EntityProfile> delegateListener
+    ) {
+        GetRequest getRequest = new GetRequest(ANOMALY_DETECTOR_JOB_INDEX, detectorId);
+        client.get(getRequest, ActionListener.wrap(getResponse -> {
+            if (getResponse != null && getResponse.isExists()) {
+                try (
+                    XContentParser parser = XContentType.JSON
+                        .xContent()
+                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, getResponse.getSourceAsString())
+                ) {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser::getTokenLocation);
+                    AnomalyDetectorJob job = AnomalyDetectorJob.parse(parser);
+
+                    if (profilesToCollect.contains(EntityProfileName.MODELS)) {
+                        EntityProfile.Builder builder = new EntityProfile.Builder(categoryField, entityValue);
+                        if (false == job.isEnabled()) {
+                            delegateListener.onResponse(builder.build());
+                        } else {
+                            delegateListener.onResponse(builder.modelProfile(entityProfileResponse.getModelProfile()).build());
+                        }
+                    }
+
+                    if (profilesToCollect.contains(EntityProfileName.INIT_PROGRESS)
+                        || profilesToCollect.contains(EntityProfileName.STATE)) {
+                        profileStateRelated(
+                            entityProfileResponse.getTotalUpdates(),
+                            detectorId,
+                            categoryField,
+                            entityValue,
+                            profilesToCollect,
+                            detector,
+                            job,
+                            delegateListener
+                        );
+                    }
+
+                    if (profilesToCollect.contains(EntityProfileName.ENTITY_INFO)) {
+                        long enabledTimeMs = job.getEnabledTime().toEpochMilli();
+                        SearchRequest lastSampleTimeRequest = createLastSampleTimeRequest(detectorId, enabledTimeMs, entityValue);
+
+                        EntityProfile.Builder builder = new EntityProfile.Builder(categoryField, entityValue);
+
+                        Optional<Boolean> isActiveOp = entityProfileResponse.isActive();
+                        if (isActiveOp.isPresent()) {
+                            builder.isActive(isActiveOp.get());
+                        }
+                        builder.lastActiveTimestampMs(entityProfileResponse.getLastActiveMs());
+
+                        client.search(lastSampleTimeRequest, ActionListener.wrap(searchResponse -> {
+                            Optional<Long> latestSampleTimeMs = ParseUtils.getLatestDataTime(searchResponse);
+
+                            if (latestSampleTimeMs.isPresent()) {
+                                builder.lastSampleTimestampMs(latestSampleTimeMs.get());
+                            }
+
+                            delegateListener.onResponse(builder.build());
+                        }, exception -> {
+                            logger.warn("fail to get last sample time", exception);
+                            // sth wrong like result index not created. Return what we have
+                            delegateListener.onResponse(builder.build());
+                        }));
+                    }
+                } catch (IOException | XContentParseException | NullPointerException e) {
+                    logger.error(e);
+                    delegateListener.failImmediately(CommonErrorMessages.FAIL_TO_GET_PROFILE_MSG, e);
+                }
+            } else {
+                sendUnknownState(profilesToCollect, categoryField, entityValue, true, delegateListener);
+            }
+        }, exception -> {
+            if (exception instanceof IndexNotFoundException) {
+                logger.info(exception.getMessage());
+                sendUnknownState(profilesToCollect, categoryField, entityValue, true, delegateListener);
+            } else {
+                logger.error(CommonErrorMessages.FAIL_TO_GET_PROFILE_MSG + detectorId, exception);
+                delegateListener.failImmediately(exception);
+            }
+        }));
+    }
+
+    private void profileStateRelated(
+        long totalUpdates,
+        String detectorId,
+        String categoryField,
+        String entityValue,
+        Set<EntityProfileName> profilesToCollect,
+        AnomalyDetector detector,
+        AnomalyDetectorJob job,
+        MultiResponsesDelegateActionListener<EntityProfile> delegateListener
+    ) {
+        if (totalUpdates == 0) {
+            sendUnknownState(profilesToCollect, categoryField, entityValue, false, delegateListener);
+        } else if (false == job.isEnabled()) {
+            sendUnknownState(profilesToCollect, categoryField, entityValue, false, delegateListener);
+        } else if (totalUpdates >= requiredSamples) {
+            sendRunningState(profilesToCollect, categoryField, entityValue, delegateListener);
+        } else {
+            sendInitState(profilesToCollect, categoryField, entityValue, detector, totalUpdates, delegateListener);
+        }
+    }
+
+    /**
+     * Send unknown state back
+     * @param profilesToCollect Profiles to Collect
+     * @param categoryField Category field
+     * @param entityValue Entity value
+     * @param immediate whether we should terminate workflow and respond immediately
+     * @param delegateListener Delegate listener
+     */
+    private void sendUnknownState(
+        Set<EntityProfileName> profilesToCollect,
+        String categoryField,
+        String entityValue,
+        boolean immediate,
+        MultiResponsesDelegateActionListener<EntityProfile> delegateListener
+    ) {
+        EntityProfile.Builder builder = new EntityProfile.Builder(categoryField, entityValue);
+        if (profilesToCollect.contains(EntityProfileName.STATE)) {
+            builder.state(EntityState.UNKNOWN);
+        }
+        if (immediate) {
+            delegateListener.respondImmediately(builder.build());
+        } else {
+            delegateListener.onResponse(builder.build());
+        }
+    }
+
+    private void sendRunningState(
+        Set<EntityProfileName> profilesToCollect,
+        String categoryField,
+        String entityValue,
+        MultiResponsesDelegateActionListener<EntityProfile> delegateListener
+    ) {
+        EntityProfile.Builder builder = new EntityProfile.Builder(categoryField, entityValue);
+        if (profilesToCollect.contains(EntityProfileName.STATE)) {
+            builder.state(EntityState.RUNNING);
+        }
+        if (profilesToCollect.contains(EntityProfileName.INIT_PROGRESS)) {
+            InitProgressProfile initProgress = new InitProgressProfile("100%", 0, 0);
+            builder.initProgress(initProgress);
+        }
+        delegateListener.onResponse(builder.build());
+    }
+
+    private void sendInitState(
+        Set<EntityProfileName> profilesToCollect,
+        String categoryField,
+        String entityValue,
+        AnomalyDetector detector,
+        long updates,
+        MultiResponsesDelegateActionListener<EntityProfile> delegateListener
+    ) {
+        EntityProfile.Builder builder = new EntityProfile.Builder(categoryField, entityValue);
+        if (profilesToCollect.contains(EntityProfileName.STATE)) {
+            builder.state(EntityState.INIT);
+        }
+        if (profilesToCollect.contains(EntityProfileName.INIT_PROGRESS)) {
+            long intervalMins = ((IntervalTimeConfiguration) detector.getDetectionInterval()).toDuration().toMinutes();
+            InitProgressProfile initProgress = computeInitProgressProfile(updates, intervalMins);
+            builder.initProgress(initProgress);
+        }
+        delegateListener.onResponse(builder.build());
+    }
+
+    private SearchRequest createLastSampleTimeRequest(String detectorId, long enabledTime, String entityValue) {
+        BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
+
+        String path = "entity";
+        String entityValueFieldName = path + ".value";
+        TermQueryBuilder entityValueFilterQuery = QueryBuilders.termQuery(entityValueFieldName, entityValue);
+        NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder(path, entityValueFilterQuery, ScoreMode.None);
+        boolQueryBuilder.filter(nestedQueryBuilder);
+
+        boolQueryBuilder.filter(QueryBuilders.termQuery(AnomalyResult.DETECTOR_ID_FIELD, detectorId));
+
+        boolQueryBuilder.filter(QueryBuilders.rangeQuery(AnomalyResult.EXECUTION_END_TIME_FIELD).gte(enabledTime));
+
+        SearchSourceBuilder source = new SearchSourceBuilder()
+            .query(boolQueryBuilder)
+            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX).field(AnomalyResult.EXECUTION_END_TIME_FIELD))
+            .trackTotalHits(false)
+            .size(0);
+
+        SearchRequest request = new SearchRequest(CommonName.ANOMALY_RESULT_INDEX_ALIAS);
+        request.source(source);
+        return request;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/MemoryTracker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/MemoryTracker.java
@@ -264,4 +264,8 @@ public class MemoryTracker {
         totalMemoryBytes += totalDiff;
         return true;
     }
+
+    public int getThresholdModelBytes() {
+        return thresholdModelBytes;
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/Name.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/Name.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * A super type for enum types returning names
+ *
+ */
+public interface Name {
+    String getName();
+
+    static <T extends Name> Set<T> getNameFromCollection(Collection<String> names, Function<String, T> getName) {
+        Set<T> res = new HashSet<>();
+        for (String name : names) {
+            res.add(getName.apply(name));
+        }
+        return res;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBuffer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/CacheBuffer.java
@@ -54,6 +54,12 @@ import com.amazon.opendistroforelasticsearch.ad.model.InitProgressProfile;
  * heap minus all of the dedicated cache consumed by single-entity and multi-entity
  * detectors.  The shared cache’s size shrinks as the dedicated cache is filled
  * up or more detectors are started.
+ *
+ * Implementation-wise, both dedicated cache and shared cache are stored in items
+ * and minimumCapacity controls the boundary. If items size is equals to or less
+ * than minimumCapacity, consider items as dedicated cache; otherwise, consider
+ * top minimumCapacity active entities (last X entities in priorityList) as in dedicated
+ * cache and all others in shared cache.
  */
 public class CacheBuffer implements ExpiringState, MaintenanceState {
     private static final Logger LOG = LogManager.getLogger(CacheBuffer.class);
@@ -299,8 +305,10 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
 
     /**
      * remove the smallest priority item.
+     * @return the associated ModelState associated with the key, or null if there
+     * is no associated ModelState for the key
      */
-    public void remove() {
+    public ModelState<EntityModel> remove() {
         // race conditions can happen between the put and one of the following operations:
         // remove from other threads: not a problem. If they remove the same item,
         // our method is idempotent. If they remove two different items,
@@ -313,8 +321,9 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
         // put: not a problem as it is unlikely we are removing and putting the same thing
         PriorityNode smallest = priorityList.first();
         if (smallest != null) {
-            remove(smallest.key);
+            return remove(smallest.key);
         }
+        return null;
     }
 
     /**
@@ -339,6 +348,11 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
                 memoryTracker.releaseMemory(memoryConsumptionPerEntity, false, Origin.MULTI_ENTITY_DETECTOR);
             }
             checkpointDao.write(valueRemoved, keyToRemove);
+        }
+
+        EntityModel modelRemoved = valueRemoved.getModel();
+        if (modelRemoved != null) {
+            modelRemoved.clear();
         }
 
         return valueRemoved;
@@ -384,10 +398,13 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
      * Replace the smallest priority entity with the input entity
      * @param entityModelId the Model Id
      * @param value the model State
+     * @return the associated ModelState associated with the key, or null if there
+     * is no associated ModelState for the key
      */
-    public void replace(String entityModelId, ModelState<EntityModel> value) {
-        remove();
+    public ModelState<EntityModel> replace(String entityModelId, ModelState<EntityModel> value) {
+        ModelState<EntityModel> replaced = remove();
         put(entityModelId, value);
+        return replaced;
     }
 
     @Override
@@ -439,6 +456,19 @@ public class CacheBuffer implements ExpiringState, MaintenanceState {
      */
     public boolean isActive(String entityModelId) {
         return items.containsKey(entityModelId);
+    }
+
+    /**
+     *
+     * @param entityModelId Model Id
+     * @return Last used time of the model
+     */
+    public long getLastUsedTime(String entityModelId) {
+        ModelState<EntityModel> state = items.get(entityModelId);
+        if (state != null) {
+            return state.getLastUsedTime().toEpochMilli();
+        }
+        return -1;
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/EntityCache.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/caching/EntityCache.java
@@ -18,12 +18,14 @@ package com.amazon.opendistroforelasticsearch.ad.caching;
 import java.util.List;
 
 import com.amazon.opendistroforelasticsearch.ad.CleanState;
+import com.amazon.opendistroforelasticsearch.ad.DetectorModelSize;
+import com.amazon.opendistroforelasticsearch.ad.EntityModelSize;
 import com.amazon.opendistroforelasticsearch.ad.MaintenanceState;
 import com.amazon.opendistroforelasticsearch.ad.ml.EntityModel;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelState;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 
-public interface EntityCache extends MaintenanceState, CleanState {
+public interface EntityCache extends MaintenanceState, CleanState, DetectorModelSize, EntityModelSize {
     /**
      * Get the ModelState associated with the entity.  May or may not load the
      * ModelState depending on the underlying cache's eviction policy.
@@ -62,7 +64,7 @@ public interface EntityCache extends MaintenanceState, CleanState {
      * Get total updates of detector's most active entity's RCF model.
      *
      * @param detectorId detector id
-     * @return RCF model total updates of most active entity
+     * @return RCF model total updates of most active entity.
      */
     long getTotalUpdates(String detectorId);
 
@@ -71,7 +73,7 @@ public interface EntityCache extends MaintenanceState, CleanState {
      *
      * @param detectorId detector id
      * @param entityModelId  entity model id
-     * @return RCF model total updates of specific entity
+     * @return RCF model total updates of specific entity.
      */
     long getTotalUpdates(String detectorId, String entityModelId);
 
@@ -81,4 +83,19 @@ public interface EntityCache extends MaintenanceState, CleanState {
      * @return list of modelStates
      */
     List<ModelState<?>> getAllModels();
+
+    /**
+     * Return when the last active time of an entity's state.
+     *
+     * If the entity's state is active in the cache, the value indicates when the cache
+     * is lastly accessed (get/put).  If the entity's state is inactive in the cache,
+     * the value indicates when the cache state is created or when the entity is evicted
+     * from active entity cache.
+     *
+     * @param detectorId The Id of the detector that an entity belongs to
+     * @param entityModelId Entity's Model Id
+     * @return if the entity is in the cache, return the timestamp in epoch
+     * milliseconds when the entity's state is lastly used.  Otherwise, return -1.
+     */
+    long getLastActiveMs(String detectorId, String entityModelId);
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java
@@ -29,4 +29,9 @@ public class CommonErrorMessages {
     public static final String ALL_FEATURES_DISABLED_ERR_MSG =
         "Having trouble querying data because all of your features have been disabled.";
     public static final String INVALID_TIMESTAMP_ERR_MSG = "timestamp is invalid";
+    public static String FAIL_TO_FIND_DETECTOR_MSG = "Fail to find detector with id: ";
+    public static String FAIL_TO_GET_PROFILE_MSG = "Fail to get profile for detector ";
+    public static String FAIL_TO_GET_TOTAL_ENTITIES = "Failed to get total entities for detector ";
+    public static String CATEGORICAL_FIELD_NUMBER_SURPASSED = "We don't support categorical fields more than ";
+    public static String EMPTY_PROFILES_COLLECT = "profiles to collect are missing or invalid";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
@@ -57,22 +57,31 @@ public class CommonName {
     public static final String SHINGLE_SIZE = "shingle_size";
     public static final String TOTAL_SIZE_IN_BYTES = "total_size_in_bytes";
     public static final String MODELS = "models";
+    public static final String MODEL = "model";
     public static final String INIT_PROGRESS = "init_progress";
 
     public static final String TOTAL_ENTITIES = "total_entities";
     public static final String ACTIVE_ENTITIES = "active_entities";
+    public static final String ENTITY_INFO = "entity_info";
+    public static final String TOTAL_UPDATES = "total_updates";
 
+    // ======================================
+    // Index mapping
+    // ======================================
     // Elastic mapping type
     public static final String MAPPING_TYPE = "_doc";
 
     // Used to fetch mapping
     public static final String TYPE = "type";
-
     public static final String KEYWORD_TYPE = "keyword";
-
     public static final String IP_TYPE = "ip";
 
-    public static final String TOTAL_UPDATES = "total_updates";
-
+    // used for updating mapping
     public static final String SCHEMA_VERSION_FIELD = "schema_version";
+
+    // ======================================
+    // Query
+    // ======================================
+    // Used in finding the max timestamp
+    public static final String AGG_NAME_MAX = "max_timefield";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityModel.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityModel.java
@@ -62,4 +62,10 @@ public class EntityModel {
     public void setThreshold(ThresholdingModel threshold) {
         this.threshold = threshold;
     }
+
+    public void clear() {
+        samples.clear();
+        rcf = null;
+        threshold = null;
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/ModelManager.java
@@ -43,6 +43,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 
+import com.amazon.opendistroforelasticsearch.ad.DetectorModelSize;
 import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.ResourceNotFoundException;
@@ -58,7 +59,7 @@ import com.google.gson.Gson;
 /**
  * A facade managing ML operations and models.
  */
-public class ModelManager {
+public class ModelManager implements DetectorModelSize {
     protected static final String DETECTOR_ID_PATTERN = "(.*)_model_.+";
 
     protected static final String ENTITY_SAMPLE = "sp";
@@ -895,6 +896,7 @@ public class ModelManager {
      * @param detectorId detector id
      * @return a map of model id to its memory size
      */
+    @Override
     public Map<String, Long> getModelSize(String detectorId) {
         Map<String, Long> res = new HashMap<>();
         forests
@@ -906,7 +908,7 @@ public class ModelManager {
             .entrySet()
             .stream()
             .filter(entry -> getDetectorIdForModelId(entry.getKey()).equals(detectorId))
-            .forEach(entry -> { res.put(entry.getKey(), 0L); });
+            .forEach(entry -> { res.put(entry.getKey(), (long) memoryTracker.getThresholdModelBytes()); });
         return res;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -47,6 +47,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import com.amazon.opendistroforelasticsearch.ad.annotation.Generated;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
 import com.amazon.opendistroforelasticsearch.ad.util.ParseUtils;
@@ -155,7 +156,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
             throw new IllegalArgumentException("Shingle size must be a positive integer");
         }
         if (categoryFields != null && categoryFields.size() > CATEGORY_FIELD_LIMIT) {
-            throw new IllegalArgumentException("We only support filtering data by one categorical variable");
+            throw new IllegalArgumentException(CommonErrorMessages.CATEGORICAL_FIELD_NUMBER_SURPASSED + CATEGORY_FIELD_LIMIT);
         }
         this.detectorId = detectorId;
         this.version = version;
@@ -535,6 +536,10 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     /**
      * If the given shingle size is null, return default based on the kind of detector;
      * otherwise, return the given shingle size.
+     *
+     * TODO: need to deal with the case where customers start with single-entity detector, we set it to 8 by default;
+     * then cx update it to multi-entity detector, we would still use 8 in this case.  Kibana needs to change to
+     * give the correct shingle size.
      * @param customShingleSize Given shingle size
      * @param categoryField Used to verify if this is a multi-entity or single-entity detector
      * @return Shingle size
@@ -579,5 +584,9 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public boolean isMultientityDetector() {
+        return getCategoryField() != null && getCategoryField().size() > 0;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorProfile.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorProfile.java
@@ -161,7 +161,7 @@ public class DetectorProfile implements Writeable, ToXContentObject, Mergeable {
         if (shingleSize != -1) {
             xContentBuilder.field(CommonName.SHINGLE_SIZE, shingleSize);
         }
-        if (coordinatingNode != null) {
+        if (coordinatingNode != null && !coordinatingNode.isEmpty()) {
             xContentBuilder.field(CommonName.COORDINATING_NODE, coordinatingNode);
         }
         if (totalSizeInBytes != -1) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorProfileName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorProfileName.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+import java.util.Collection;
+import java.util.Set;
+
+import com.amazon.opendistroforelasticsearch.ad.Name;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+
+public enum DetectorProfileName implements Name {
+    STATE(CommonName.STATE),
+    ERROR(CommonName.ERROR),
+    COORDINATING_NODE(CommonName.COORDINATING_NODE),
+    SHINGLE_SIZE(CommonName.SHINGLE_SIZE),
+    TOTAL_SIZE_IN_BYTES(CommonName.TOTAL_SIZE_IN_BYTES),
+    MODELS(CommonName.MODELS),
+    INIT_PROGRESS(CommonName.INIT_PROGRESS),
+    TOTAL_ENTITIES(CommonName.TOTAL_ENTITIES),
+    ACTIVE_ENTITIES(CommonName.ACTIVE_ENTITIES);
+
+    private String name;
+
+    DetectorProfileName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Get profile name
+     *
+     * @return name
+     */
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public static DetectorProfileName getName(String name) {
+        switch (name) {
+            case CommonName.STATE:
+                return STATE;
+            case CommonName.ERROR:
+                return ERROR;
+            case CommonName.COORDINATING_NODE:
+                return COORDINATING_NODE;
+            case CommonName.SHINGLE_SIZE:
+                return SHINGLE_SIZE;
+            case CommonName.TOTAL_SIZE_IN_BYTES:
+                return TOTAL_SIZE_IN_BYTES;
+            case CommonName.MODELS:
+                return MODELS;
+            case CommonName.INIT_PROGRESS:
+                return INIT_PROGRESS;
+            case CommonName.TOTAL_ENTITIES:
+                return TOTAL_ENTITIES;
+            case CommonName.ACTIVE_ENTITIES:
+                return ACTIVE_ENTITIES;
+            default:
+                throw new IllegalArgumentException("Unsupported profile types");
+        }
+    }
+
+    public static Set<DetectorProfileName> getNames(Collection<String> names) {
+        return Name.getNameFromCollection(names, DetectorProfileName::getName);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/EntityProfile.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/EntityProfile.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.ad.model;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -26,30 +27,121 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+
 /**
  * Profile output for detector entity.
  */
-public class EntityProfile implements Writeable, ToXContent {
+public class EntityProfile implements Writeable, ToXContent, Mergeable {
     // field name in toXContent
     public static final String CATEGORY_FIELD = "category_field";
     public static final String ENTITY_VALUE = "value";
     public static final String IS_ACTIVE = "is_active";
+    public static final String LAST_ACTIVE_TIMESTAMP = "last_active_timestamp";
+    public static final String LAST_SAMPLE_TIMESTAMP = "last_sample_timestamp";
 
     private final String categoryField;
     private final String value;
-    private final Boolean isActive;
+    private Boolean isActive;
+    private long lastActiveTimestampMs;
+    private long lastSampleTimestampMs;
+    private InitProgressProfile initProgress;
+    private ModelProfile modelProfile;
+    private EntityState state;
 
-    public EntityProfile(String categoryField, String value, Boolean isActive) {
+    public EntityProfile(
+        String categoryField,
+        String value,
+        Boolean isActive,
+        long lastActiveTimeStamp,
+        long lastSampleTimestamp,
+        InitProgressProfile initProgress,
+        ModelProfile modelProfile,
+        EntityState state
+    ) {
         super();
         this.categoryField = categoryField;
         this.value = value;
         this.isActive = isActive;
+        this.lastActiveTimestampMs = lastActiveTimeStamp;
+        this.lastSampleTimestampMs = lastSampleTimestamp;
+        this.initProgress = initProgress;
+        this.modelProfile = modelProfile;
+        this.state = state;
+    }
+
+    public static class Builder {
+        private final String categoryField;
+        private final String value;
+        private Boolean isActive = null;
+        private long lastActiveTimestampMs = -1L;
+        private long lastSampleTimestampMs = -1L;
+        private InitProgressProfile initProgress = null;
+        private ModelProfile modelProfile = null;
+        private EntityState state = EntityState.UNKNOWN;
+
+        public Builder(String categoryField, String value) {
+            this.categoryField = categoryField;
+            this.value = value;
+        }
+
+        public Builder isActive(Boolean isActive) {
+            this.isActive = isActive;
+            return this;
+        }
+
+        public Builder lastActiveTimestampMs(long lastActiveTimestampMs) {
+            this.lastActiveTimestampMs = lastActiveTimestampMs;
+            return this;
+        }
+
+        public Builder lastSampleTimestampMs(long lastSampleTimestampMs) {
+            this.lastSampleTimestampMs = lastSampleTimestampMs;
+            return this;
+        }
+
+        public Builder initProgress(InitProgressProfile initProgress) {
+            this.initProgress = initProgress;
+            return this;
+        }
+
+        public Builder modelProfile(ModelProfile modelProfile) {
+            this.modelProfile = modelProfile;
+            return this;
+        }
+
+        public Builder state(EntityState state) {
+            this.state = state;
+            return this;
+        }
+
+        public EntityProfile build() {
+            return new EntityProfile(
+                categoryField,
+                value,
+                isActive,
+                lastActiveTimestampMs,
+                lastSampleTimestampMs,
+                initProgress,
+                modelProfile,
+                state
+            );
+        }
     }
 
     public EntityProfile(StreamInput in) throws IOException {
-        categoryField = in.readString();
-        value = in.readString();
-        isActive = in.readBoolean();
+        this.categoryField = in.readString();
+        this.value = in.readString();
+        this.isActive = in.readOptionalBoolean();
+        this.lastActiveTimestampMs = in.readLong();
+        this.lastSampleTimestampMs = in.readLong();
+        if (in.readBoolean()) {
+            this.initProgress = new InitProgressProfile(in);
+        }
+        if (in.readBoolean()) {
+            this.modelProfile = new ModelProfile(in);
+        }
+        this.state = in.readEnum(EntityState.class);
     }
 
     public String getCategoryField() {
@@ -60,8 +152,42 @@ public class EntityProfile implements Writeable, ToXContent {
         return value;
     }
 
-    public Boolean getActive() {
-        return isActive;
+    public Optional<Boolean> getActive() {
+        return Optional.ofNullable(isActive);
+    }
+
+    /**
+    * Return the last active time of an entity's state.
+    *
+    * If the entity's state is active in the cache, the value indicates when the cache
+    * is lastly accessed (get/put).  If the entity's state is inactive in the cache,
+    * the value indicates when the cache state is created or when the entity is evicted
+    * from active entity cache.
+    *
+    * @return the last active time of an entity's state
+    */
+    public Long getLastActiveTimestamp() {
+        return lastActiveTimestampMs;
+    }
+
+    /**
+     *
+     * @return last document's timestamp belonging to an entity
+     */
+    public Long getLastSampleTimestamp() {
+        return lastSampleTimestampMs;
+    }
+
+    public InitProgressProfile getInitProgress() {
+        return initProgress;
+    }
+
+    public ModelProfile getModelProfile() {
+        return modelProfile;
+    }
+
+    public EntityState getState() {
+        return state;
     }
 
     public XContentBuilder toXContent(XContentBuilder builder) throws IOException {
@@ -73,7 +199,24 @@ public class EntityProfile implements Writeable, ToXContent {
         builder.startObject();
         builder.field(CATEGORY_FIELD, categoryField);
         builder.field(ENTITY_VALUE, value);
-        builder.field(IS_ACTIVE, isActive);
+        if (isActive != null) {
+            builder.field(IS_ACTIVE, isActive);
+        }
+        if (lastActiveTimestampMs > 0) {
+            builder.field(LAST_ACTIVE_TIMESTAMP, lastActiveTimestampMs);
+        }
+        if (lastSampleTimestampMs > 0) {
+            builder.field(LAST_SAMPLE_TIMESTAMP, lastSampleTimestampMs);
+        }
+        if (initProgress != null) {
+            builder.field(CommonName.INIT_PROGRESS, initProgress);
+        }
+        if (modelProfile != null) {
+            builder.field(CommonName.MODEL, modelProfile);
+        }
+        if (state != null) {
+            builder.field(CommonName.STATE, state);
+        }
         builder.endObject();
         return builder;
     }
@@ -82,7 +225,22 @@ public class EntityProfile implements Writeable, ToXContent {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(categoryField);
         out.writeString(value);
-        out.writeBoolean(isActive);
+        out.writeOptionalBoolean(isActive);
+        out.writeLong(lastActiveTimestampMs);
+        out.writeLong(lastSampleTimestampMs);
+        if (initProgress != null) {
+            out.writeBoolean(true);
+            initProgress.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        if (modelProfile != null) {
+            out.writeBoolean(true);
+            modelProfile.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeEnum(state);
     }
 
     @Override
@@ -90,7 +248,24 @@ public class EntityProfile implements Writeable, ToXContent {
         ToStringBuilder builder = new ToStringBuilder(this);
         builder.append(CATEGORY_FIELD, categoryField);
         builder.append(ENTITY_VALUE, value);
-        builder.append(IS_ACTIVE, isActive);
+        if (isActive != null) {
+            builder.append(IS_ACTIVE, isActive);
+        }
+        if (lastActiveTimestampMs > 0) {
+            builder.append(LAST_ACTIVE_TIMESTAMP, lastActiveTimestampMs);
+        }
+        if (lastSampleTimestampMs > 0) {
+            builder.append(LAST_SAMPLE_TIMESTAMP, lastSampleTimestampMs);
+        }
+        if (initProgress != null) {
+            builder.append(CommonName.INIT_PROGRESS, initProgress);
+        }
+        if (modelProfile != null) {
+            builder.append(CommonName.MODELS, modelProfile);
+        }
+        if (state != null) {
+            builder.append(CommonName.STATE, state);
+        }
         return builder.toString();
     }
 
@@ -108,6 +283,11 @@ public class EntityProfile implements Writeable, ToXContent {
             equalsBuilder.append(categoryField, other.categoryField);
             equalsBuilder.append(value, other.value);
             equalsBuilder.append(isActive, other.isActive);
+            equalsBuilder.append(lastActiveTimestampMs, other.lastActiveTimestampMs);
+            equalsBuilder.append(lastSampleTimestampMs, other.lastSampleTimestampMs);
+            equalsBuilder.append(initProgress, other.initProgress);
+            equalsBuilder.append(modelProfile, other.modelProfile);
+            equalsBuilder.append(state, other.state);
 
             return equalsBuilder.isEquals();
         }
@@ -116,6 +296,42 @@ public class EntityProfile implements Writeable, ToXContent {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(categoryField).append(value).append(isActive).toHashCode();
+        return new HashCodeBuilder()
+            .append(categoryField)
+            .append(value)
+            .append(isActive)
+            .append(lastActiveTimestampMs)
+            .append(lastSampleTimestampMs)
+            .append(initProgress)
+            .append(modelProfile)
+            .append(state)
+            .toHashCode();
+    }
+
+    @Override
+    public void merge(Mergeable other) {
+        if (this == other || other == null || getClass() != other.getClass()) {
+            return;
+        }
+        EntityProfile otherProfile = (EntityProfile) other;
+
+        if (otherProfile.getInitProgress() != null) {
+            this.initProgress = otherProfile.getInitProgress();
+        }
+        if (otherProfile.isActive != null) {
+            this.isActive = otherProfile.isActive;
+        }
+        if (otherProfile.lastActiveTimestampMs > 0) {
+            this.lastActiveTimestampMs = otherProfile.lastActiveTimestampMs;
+        }
+        if (otherProfile.lastSampleTimestampMs > 0) {
+            this.lastSampleTimestampMs = otherProfile.lastSampleTimestampMs;
+        }
+        if (otherProfile.modelProfile != null) {
+            this.modelProfile = otherProfile.modelProfile;
+        }
+        if (otherProfile.getState() != null) {
+            this.state = otherProfile.getState();
+        }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/EntityProfileName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/EntityProfileName.java
@@ -16,25 +16,20 @@
 package com.amazon.opendistroforelasticsearch.ad.model;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 
+import com.amazon.opendistroforelasticsearch.ad.Name;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 
-public enum ProfileName {
-    STATE(CommonName.STATE),
-    ERROR(CommonName.ERROR),
-    COORDINATING_NODE(CommonName.COORDINATING_NODE),
-    SHINGLE_SIZE(CommonName.SHINGLE_SIZE),
-    TOTAL_SIZE_IN_BYTES(CommonName.TOTAL_SIZE_IN_BYTES),
-    MODELS(CommonName.MODELS),
+public enum EntityProfileName implements Name {
     INIT_PROGRESS(CommonName.INIT_PROGRESS),
-    TOTAL_ENTITIES(CommonName.TOTAL_ENTITIES),
-    ACTIVE_ENTITIES(CommonName.ACTIVE_ENTITIES);
+    ENTITY_INFO(CommonName.ENTITY_INFO),
+    STATE(CommonName.STATE),
+    MODELS(CommonName.MODELS);
 
     private String name;
 
-    ProfileName(String name) {
+    EntityProfileName(String name) {
         this.name = name;
     }
 
@@ -43,40 +38,27 @@ public enum ProfileName {
      *
      * @return name
      */
+    @Override
     public String getName() {
         return name;
     }
 
-    public static ProfileName getName(String name) {
+    public static EntityProfileName getName(String name) {
         switch (name) {
-            case CommonName.STATE:
-                return STATE;
-            case CommonName.ERROR:
-                return ERROR;
-            case CommonName.COORDINATING_NODE:
-                return COORDINATING_NODE;
-            case CommonName.SHINGLE_SIZE:
-                return SHINGLE_SIZE;
-            case CommonName.TOTAL_SIZE_IN_BYTES:
-                return TOTAL_SIZE_IN_BYTES;
-            case CommonName.MODELS:
-                return MODELS;
             case CommonName.INIT_PROGRESS:
                 return INIT_PROGRESS;
-            case CommonName.TOTAL_ENTITIES:
-                return TOTAL_ENTITIES;
-            case CommonName.ACTIVE_ENTITIES:
-                return ACTIVE_ENTITIES;
+            case CommonName.ENTITY_INFO:
+                return ENTITY_INFO;
+            case CommonName.STATE:
+                return STATE;
+            case CommonName.MODELS:
+                return MODELS;
             default:
                 throw new IllegalArgumentException("Unsupported profile types");
         }
     }
 
-    public static Set<ProfileName> getNames(Collection<String> names) {
-        Set<ProfileName> res = new HashSet<>();
-        for (String name : names) {
-            res.add(getName(name));
-        }
-        return res;
+    public static Set<EntityProfileName> getNames(Collection<String> names) {
+        return Name.getNameFromCollection(names, EntityProfileName::getName);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/EntityState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/EntityState.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+public enum EntityState {
+    UNKNOWN,
+    INIT,
+    RUNNING
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ModelProfile.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ModelProfile.java
@@ -32,6 +32,8 @@ package com.amazon.opendistroforelasticsearch.ad.model;
 
 import java.io.IOException;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -58,7 +60,7 @@ public class ModelProfile implements Writeable, ToXContent {
 
     public ModelProfile(StreamInput in) throws IOException {
         modelId = in.readString();
-        modelSizeInBytes = in.readVLong();
+        modelSizeInBytes = in.readLong();
         nodeId = in.readString();
     }
 
@@ -89,8 +91,33 @@ public class ModelProfile implements Writeable, ToXContent {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(modelId);
-        out.writeVLong(modelSizeInBytes);
+        out.writeLong(modelSizeInBytes);
         out.writeString(nodeId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        if (obj instanceof ModelProfile) {
+            ModelProfile other = (ModelProfile) obj;
+            EqualsBuilder equalsBuilder = new EqualsBuilder();
+            equalsBuilder.append(modelId, other.modelId);
+            equalsBuilder.append(modelSizeInBytes, other.modelSizeInBytes);
+            equalsBuilder.append(nodeId, other.nodeId);
+
+            return equalsBuilder.isEquals();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(modelId).append(modelSizeInBytes).append(nodeId).toHashCode();
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -111,7 +111,9 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
             if (response.getResult() == DocWriteResponse.Result.DELETED || response.getResult() == DocWriteResponse.Result.NOT_FOUND) {
                 deleteDetectorStateDoc(detectorId, listener);
             } else {
-                LOG.error("Fail to delete anomaly detector job {}", detectorId);
+                String message = "Fail to delete anomaly detector job " + detectorId;
+                LOG.error(message);
+                listener.onFailure(new ElasticsearchStatusException(message, RestStatus.INTERNAL_SERVER_ERROR));
             }
         }, exception -> {
             if (exception instanceof IndexNotFoundException) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileRequest.java
@@ -18,6 +18,8 @@ package com.amazon.opendistroforelasticsearch.ad.transport;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -29,22 +31,33 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonMessageAttributes;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityProfileName;
 
 public class EntityProfileRequest extends ActionRequest implements ToXContentObject {
     public static final String ENTITY = "entity";
+    public static final String PROFILES = "profiles";
     private String adID;
     private String entityValue;
+    private Set<EntityProfileName> profilesToCollect;
 
     public EntityProfileRequest(StreamInput in) throws IOException {
         super(in);
         adID = in.readString();
         entityValue = in.readString();
+        int size = in.readVInt();
+        profilesToCollect = new HashSet<EntityProfileName>();
+        if (size != 0) {
+            for (int i = 0; i < size; i++) {
+                profilesToCollect.add(in.readEnum(EntityProfileName.class));
+            }
+        }
     }
 
-    public EntityProfileRequest(String adID, String entityValue) {
+    public EntityProfileRequest(String adID, String entityValue, Set<EntityProfileName> profilesToCollect) {
         super();
         this.adID = adID;
         this.entityValue = entityValue;
+        this.profilesToCollect = profilesToCollect;
     }
 
     public String getAdID() {
@@ -55,11 +68,19 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
         return entityValue;
     }
 
+    public Set<EntityProfileName> getProfilesToCollect() {
+        return profilesToCollect;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(adID);
         out.writeString(entityValue);
+        out.writeVInt(profilesToCollect.size());
+        for (EntityProfileName profile : profilesToCollect) {
+            out.writeEnum(profile);
+        }
     }
 
     @Override
@@ -71,6 +92,9 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
         if (Strings.isEmpty(entityValue)) {
             validationException = addValidationError("Entity value is missing", validationException);
         }
+        if (profilesToCollect == null || profilesToCollect.isEmpty()) {
+            validationException = addValidationError(CommonErrorMessages.EMPTY_PROFILES_COLLECT, validationException);
+        }
         return validationException;
     }
 
@@ -79,6 +103,7 @@ public class EntityProfileRequest extends ActionRequest implements ToXContentObj
         builder.startObject();
         builder.field(CommonMessageAttributes.ID_JSON_KEY, adID);
         builder.field(ENTITY, entityValue);
+        builder.field(PROFILES, profilesToCollect);
         builder.endObject();
         return builder;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileResponse.java
@@ -16,40 +16,163 @@
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
 import java.io.IOException;
+import java.util.Optional;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.model.ModelProfile;
+
 public class EntityProfileResponse extends ActionResponse implements ToXContentObject {
     public static final String ACTIVE = "active";
-    private final boolean isActive;
+    public static final String LAST_ACTIVE_TS = "last_active_timestamp";
+    public static final String TOTAL_UPDATES = "total_updates";
+    private final Boolean isActive;
+    private final long lastActiveMs;
+    private final long totalUpdates;
+    private final ModelProfile modelProfile;
 
-    public EntityProfileResponse(boolean isActive) {
+    public static class Builder {
+        private Boolean isActive = null;
+        private long lastActiveMs = -1L;
+        private long totalUpdates = -1L;
+        private ModelProfile modelProfile = null;
+
+        public Builder() {}
+
+        public Builder setActive(Boolean isActive) {
+            this.isActive = isActive;
+            return this;
+        }
+
+        public Builder setLastActiveMs(long lastActiveMs) {
+            this.lastActiveMs = lastActiveMs;
+            return this;
+        }
+
+        public Builder setTotalUpdates(long totalUpdates) {
+            this.totalUpdates = totalUpdates;
+            return this;
+        }
+
+        public Builder setModelProfile(ModelProfile modelProfile) {
+            this.modelProfile = modelProfile;
+            return this;
+        }
+
+        public EntityProfileResponse build() {
+            return new EntityProfileResponse(isActive, lastActiveMs, totalUpdates, modelProfile);
+        }
+    }
+
+    public EntityProfileResponse(Boolean isActive, long lastActiveTimeMs, long totalUpdates, ModelProfile modelProfile) {
         this.isActive = isActive;
+        this.lastActiveMs = lastActiveTimeMs;
+        this.totalUpdates = totalUpdates;
+        this.modelProfile = modelProfile;
     }
 
     public EntityProfileResponse(StreamInput in) throws IOException {
         super(in);
-        isActive = in.readBoolean();
+        isActive = in.readOptionalBoolean();
+        lastActiveMs = in.readLong();
+        totalUpdates = in.readLong();
+        if (in.readBoolean()) {
+            modelProfile = new ModelProfile(in);
+        } else {
+            modelProfile = null;
+        }
     }
 
-    public boolean isActive() {
-        return isActive;
+    public Optional<Boolean> isActive() {
+        return Optional.ofNullable(isActive);
+    }
+
+    public long getLastActiveMs() {
+        return lastActiveMs;
+    }
+
+    public long getTotalUpdates() {
+        return totalUpdates;
+    }
+
+    public ModelProfile getModelProfile() {
+        return modelProfile;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeBoolean(isActive);
+        out.writeOptionalBoolean(isActive);
+        out.writeLong(lastActiveMs);
+        out.writeLong(totalUpdates);
+        if (modelProfile != null) {
+            out.writeBoolean(true);
+            modelProfile.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(ACTIVE, isActive);
+        if (isActive != null) {
+            builder.field(ACTIVE, isActive);
+        }
+        if (lastActiveMs >= 0) {
+            builder.field(LAST_ACTIVE_TS, lastActiveMs);
+        }
+        if (totalUpdates >= 0) {
+            builder.field(TOTAL_UPDATES, totalUpdates);
+        }
+        if (modelProfile != null) {
+            builder.field(CommonName.MODEL, modelProfile);
+        }
         builder.endObject();
         return builder;
+    }
+
+    @Override
+    public String toString() {
+        ToStringBuilder builder = new ToStringBuilder(this);
+        builder.append(ACTIVE, isActive);
+        builder.append(LAST_ACTIVE_TS, lastActiveMs);
+        builder.append(TOTAL_UPDATES, totalUpdates);
+        builder.append(CommonName.MODEL, modelProfile);
+
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        if (obj instanceof EntityProfileResponse) {
+            EntityProfileResponse other = (EntityProfileResponse) obj;
+            EqualsBuilder equalsBuilder = new EqualsBuilder();
+            equalsBuilder.append(isActive, other.isActive);
+            equalsBuilder.append(lastActiveMs, other.lastActiveMs);
+            equalsBuilder.append(totalUpdates, other.totalUpdates);
+            equalsBuilder.append(modelProfile, other.modelProfile);
+
+            return equalsBuilder.isEquals();
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().append(isActive).append(lastActiveMs).append(totalUpdates).append(modelProfile).toHashCode();
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -21,6 +21,7 @@ import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.PRO
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -42,17 +43,18 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
-import org.elasticsearch.rest.BytesRestResponse;
-import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorProfileRunner;
+import com.amazon.opendistroforelasticsearch.ad.EntityProfileRunner;
+import com.amazon.opendistroforelasticsearch.ad.Name;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfile;
-import com.amazon.opendistroforelasticsearch.ad.model.ProfileName;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfileName;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityProfileName;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
@@ -63,11 +65,15 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
     private static final Logger LOG = LogManager.getLogger(GetAnomalyDetectorTransportAction.class);
 
     private final Client client;
-    private final AnomalyDetectorProfileRunner profileRunner;
+
     private final Set<String> allProfileTypeStrs;
-    private final Set<ProfileName> allProfileTypes;
-    private final Set<ProfileName> defaultProfileTypes;
+    private final Set<DetectorProfileName> allProfileTypes;
+    private final Set<DetectorProfileName> defaultDetectorProfileTypes;
+    private final Set<String> allEntityProfileTypeStrs;
+    private final Set<EntityProfileName> allEntityProfileTypes;
+    private final Set<EntityProfileName> defaultEntityProfileTypes;
     private final NamedXContentRegistry xContentRegistry;
+    private final DiscoveryNodeFilterer nodeFilter;
 
     @Inject
     public GetAnomalyDetectorTransportAction(
@@ -79,19 +85,21 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
     ) {
         super(GetAnomalyDetectorAction.NAME, transportService, actionFilters, GetAnomalyDetectorRequest::new);
         this.client = client;
-        List<ProfileName> allProfiles = Arrays.asList(ProfileName.values());
-        this.allProfileTypes = new HashSet<ProfileName>(allProfiles);
-        this.allProfileTypeStrs = getProfileListStrs(allProfiles);
 
-        List<ProfileName> defaultProfiles = Arrays.asList(ProfileName.ERROR, ProfileName.STATE);
-        this.defaultProfileTypes = new HashSet<ProfileName>(defaultProfiles);
+        List<DetectorProfileName> allProfiles = Arrays.asList(DetectorProfileName.values());
+        this.allProfileTypes = EnumSet.copyOf(allProfiles);
+        this.allProfileTypeStrs = getProfileListStrs(allProfiles);
+        List<DetectorProfileName> defaultProfiles = Arrays.asList(DetectorProfileName.ERROR, DetectorProfileName.STATE);
+        this.defaultDetectorProfileTypes = new HashSet<DetectorProfileName>(defaultProfiles);
+
+        List<EntityProfileName> allEntityProfiles = Arrays.asList(EntityProfileName.values());
+        this.allEntityProfileTypes = EnumSet.copyOf(allEntityProfiles);
+        this.allEntityProfileTypeStrs = getProfileListStrs(allEntityProfiles);
+        List<EntityProfileName> defaultEntityProfiles = Arrays.asList(EntityProfileName.STATE);
+        this.defaultEntityProfileTypes = new HashSet<EntityProfileName>(defaultEntityProfiles);
+
         this.xContentRegistry = xContentRegistry;
-        this.profileRunner = new AnomalyDetectorProfileRunner(
-            client,
-            xContentRegistry,
-            nodeFilter,
-            AnomalyDetectorSettings.NUM_MIN_SAMPLES
-        );
+        this.nodeFilter = nodeFilter;
     }
 
     @Override
@@ -107,10 +115,17 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             if (!Strings.isEmpty(typesStr) || rawPath.endsWith(PROFILE) || rawPath.endsWith(PROFILE + "/")) {
                 if (entityValue != null) {
+                    Set<EntityProfileName> entityProfilesToCollect = getEntityProfilesToCollect(typesStr, all);
+                    EntityProfileRunner profileRunner = new EntityProfileRunner(
+                        client,
+                        xContentRegistry,
+                        AnomalyDetectorSettings.NUM_MIN_SAMPLES
+                    );
                     profileRunner
-                        .profileEntity(
+                        .profile(
                             detectorID,
                             entityValue,
+                            entityProfilesToCollect,
                             ActionListener
                                 .wrap(
                                     profile -> {
@@ -123,7 +138,14 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                                 )
                         );
                 } else {
-                    profileRunner.profile(detectorID, getProfileActionListener(listener, detectorID), getProfilesToCollect(typesStr, all));
+                    Set<DetectorProfileName> profilesToCollect = getProfilesToCollect(typesStr, all);
+                    AnomalyDetectorProfileRunner profileRunner = new AnomalyDetectorProfileRunner(
+                        client,
+                        xContentRegistry,
+                        nodeFilter,
+                        AnomalyDetectorSettings.NUM_MIN_SAMPLES
+                    );
+                    profileRunner.profile(detectorID, getProfileActionListener(listener, detectorID), profilesToCollect);
                 }
             } else {
                 MultiGetRequest.Item adItem = new MultiGetRequest.Item(ANOMALY_DETECTORS_INDEX, detectorID).version(version);
@@ -178,7 +200,8 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                                 detector = parser.namedObject(AnomalyDetector.class, AnomalyDetector.PARSE_FIELD_NAME, null);
                             } catch (Exception e) {
                                 String message = "Failed to parse detector job " + detectorId;
-                                LOG.error(message, e);
+                                listener.onFailure(buildInternalServerErrorResponse(e, message));
+                                return;
                             }
                         }
                     }
@@ -195,7 +218,8 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                                 adJob = AnomalyDetectorJob.parse(parser);
                             } catch (Exception e) {
                                 String message = "Failed to parse detector job " + detectorId;
-                                LOG.error(message, e);
+                                listener.onFailure(buildInternalServerErrorResponse(e, message));
+                                return;
                             }
                         }
                     }
@@ -237,23 +261,48 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         }, exception -> { listener.onFailure(exception); });
     }
 
-    private RestResponse buildInternalServerErrorResponse(Exception e, String errorMsg) {
+    private ElasticsearchStatusException buildInternalServerErrorResponse(Exception e, String errorMsg) {
         LOG.error(errorMsg, e);
-        return new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, errorMsg);
+        return new ElasticsearchStatusException(errorMsg, RestStatus.INTERNAL_SERVER_ERROR);
     }
 
-    private Set<ProfileName> getProfilesToCollect(String typesStr, boolean all) {
+    /**
+    *
+    * @param typesStr a list of input profile types separated by comma
+    * @param all whether we should return all profile in the response
+    * @return profiles to collect for a detector
+    */
+    private Set<DetectorProfileName> getProfilesToCollect(String typesStr, boolean all) {
         if (all) {
             return this.allProfileTypes;
         } else if (Strings.isEmpty(typesStr)) {
-            return this.defaultProfileTypes;
+            return this.defaultDetectorProfileTypes;
         } else {
+            // Filter out unsupported types
             Set<String> typesInRequest = new HashSet<>(Arrays.asList(typesStr.split(",")));
-            return ProfileName.getNames(Sets.intersection(this.allProfileTypeStrs, typesInRequest));
+            return DetectorProfileName.getNames(Sets.intersection(allProfileTypeStrs, typesInRequest));
         }
     }
 
-    private Set<String> getProfileListStrs(List<ProfileName> profileList) {
+    /**
+     *
+     * @param typesStr a list of input profile types separated by comma
+     * @param all whether we should return all profile in the response
+     * @return profiles to collect for an entity
+     */
+    private Set<EntityProfileName> getEntityProfilesToCollect(String typesStr, boolean all) {
+        if (all) {
+            return this.allEntityProfileTypes;
+        } else if (Strings.isEmpty(typesStr)) {
+            return this.defaultEntityProfileTypes;
+        } else {
+            // Filter out unsupported types
+            Set<String> typesInRequest = new HashSet<>(Arrays.asList(typesStr.split(",")));
+            return EntityProfileName.getNames(Sets.intersection(allEntityProfileTypeStrs, typesInRequest));
+        }
+    }
+
+    private Set<String> getProfileListStrs(List<? extends Name> profileList) {
         return profileList.stream().map(profile -> profile.getName()).collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileNodeRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileNodeRequest.java
@@ -22,7 +22,7 @@ import org.elasticsearch.action.support.nodes.BaseNodeRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import com.amazon.opendistroforelasticsearch.ad.model.ProfileName;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfileName;
 
 /**
  *  Class representing a nodes's profile request
@@ -53,8 +53,16 @@ public class ProfileNodeRequest extends BaseNodeRequest {
      *
      * @return the set that contains the profile names marked for retrieval
      */
-    public Set<ProfileName> getProfilesToBeRetrieved() {
+    public Set<DetectorProfileName> getProfilesToBeRetrieved() {
         return request.getProfilesToBeRetrieved();
+    }
+
+    /**
+    *
+    * @return Whether this is about a multi-entity detector or not
+    */
+    public boolean isForMultiEntityDetector() {
+        return request.isForMultiEntityDetector();
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileNodeResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileNodeResponse.java
@@ -47,7 +47,9 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
      */
     public ProfileNodeResponse(StreamInput in) throws IOException {
         super(in);
-        modelSize = in.readMap(StreamInput::readString, StreamInput::readLong);
+        if (in.readBoolean()) {
+            modelSize = in.readMap(StreamInput::readString, StreamInput::readLong);
+        }
         shingleSize = in.readInt();
         activeEntities = in.readVLong();
         totalUpdates = in.readVLong();
@@ -84,7 +86,13 @@ public class ProfileNodeResponse extends BaseNodeResponse implements ToXContentF
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeMap(modelSize, StreamOutput::writeString, StreamOutput::writeLong);
+        if (modelSize != null) {
+            out.writeBoolean(true);
+            out.writeMap(modelSize, StreamOutput::writeString, StreamOutput::writeLong);
+        } else {
+            out.writeBoolean(false);
+        }
+
         out.writeInt(shingleSize);
         out.writeVLong(activeEntities);
         out.writeVLong(totalUpdates);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileResponse.java
@@ -63,7 +63,7 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
         for (int i = 0; i < size; i++) {
             modelProfile[i] = new ModelProfile(in);
         }
-        shingleSize = in.readVInt();
+        shingleSize = in.readInt();
         coordinatingNode = in.readString();
         totalSizeInBytes = in.readVLong();
         activeEntities = in.readVLong();
@@ -82,6 +82,7 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
         totalSizeInBytes = 0L;
         activeEntities = 0L;
         totalUpdates = 0L;
+        shingleSize = -1;
         List<ModelProfile> modelProfileList = new ArrayList<>();
         for (ProfileNodeResponse response : nodes) {
             String curNodeId = response.getNode().getId();
@@ -89,10 +90,13 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
                 coordinatingNode = curNodeId;
                 shingleSize = response.getShingleSize();
             }
-            for (Map.Entry<String, Long> entry : response.getModelSize().entrySet()) {
-                totalSizeInBytes += entry.getValue();
-                modelProfileList.add(new ModelProfile(entry.getKey(), entry.getValue(), curNodeId));
+            if (response.getModelSize() != null) {
+                for (Map.Entry<String, Long> entry : response.getModelSize().entrySet()) {
+                    totalSizeInBytes += entry.getValue();
+                    modelProfileList.add(new ModelProfile(entry.getKey(), entry.getValue(), curNodeId));
+                }
             }
+
             if (response.getActiveEntities() > 0) {
                 activeEntities += response.getActiveEntities();
             }
@@ -113,7 +117,7 @@ public class ProfileResponse extends BaseNodesResponse<ProfileNodeResponse> impl
         for (ModelProfile profile : modelProfile) {
             profile.writeTo(out);
         }
-        out.writeVInt(shingleSize);
+        out.writeInt(shingleSize);
         out.writeString(coordinatingNode);
         out.writeVLong(totalSizeInBytes);
         out.writeVLong(activeEntities);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/MultiResponsesDelegateActionListener.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/MultiResponsesDelegateActionListener.java
@@ -125,8 +125,4 @@ public class MultiResponsesDelegateActionListener<T extends Mergeable> implement
     public void respondImmediately(T o) {
         this.delegate.onResponse(o);
     }
-
-    public void compareAndSetMaxResponseCount(int oldValue, int newValue) {
-        this.maxResponseCount.compareAndSet(oldValue, newValue);
-    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AbstractADTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AbstractADTest.java
@@ -242,7 +242,7 @@ public class AbstractADTest extends ESTestCase {
         String msg
     ) {
         Exception e = expectThrows(exceptionType, () -> listener.actionGet(20_000));
-        assertThat(e.getMessage(), containsString(msg));
+        assertThat("actual message: " + e.getMessage(), e.getMessage(), containsString(msg));
     }
 
     @Override

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/EntityProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/EntityProfileRunnerTests.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
+import static java.util.Collections.emptyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchResponseSections;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.metrics.InternalMax;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityProfile;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityProfileName;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityState;
+import com.amazon.opendistroforelasticsearch.ad.model.InitProgressProfile;
+import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
+import com.amazon.opendistroforelasticsearch.ad.model.ModelProfile;
+import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileResponse;
+
+public class EntityProfileRunnerTests extends AbstractADTest {
+    private AnomalyDetector detector;
+    private int detectorIntervalMin;
+    private Client client;
+    private EntityProfileRunner runner;
+    private Set<EntityProfileName> state;
+    private Set<EntityProfileName> initNInfo;
+    private Set<EntityProfileName> model;
+    private String detectorId;
+    private String entityValue;
+    private int requiredSamples;
+    private AnomalyDetectorJob job;
+
+    private int smallUpdates;
+    private String categoryField;
+    private long latestSampleTimestamp;
+    private long latestActiveTimestamp;
+    private Boolean isActive;
+    private String modelId;
+    private long modelSize;
+    private String nodeId;
+
+    enum InittedEverResultStatus {
+        UNKNOWN,
+        INITTED,
+        NOT_INITTED,
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        detectorIntervalMin = 3;
+
+        state = new HashSet<EntityProfileName>();
+        state.add(EntityProfileName.STATE);
+
+        initNInfo = new HashSet<EntityProfileName>();
+        initNInfo.add(EntityProfileName.INIT_PROGRESS);
+        initNInfo.add(EntityProfileName.ENTITY_INFO);
+
+        model = new HashSet<EntityProfileName>();
+        model.add(EntityProfileName.MODELS);
+
+        detectorId = "A69pa3UBHuCbh-emo9oR";
+        entityValue = "app-0";
+
+        requiredSamples = 128;
+        client = mock(Client.class);
+
+        runner = new EntityProfileRunner(client, xContentRegistry(), requiredSamples);
+
+        categoryField = "a";
+        detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList(categoryField));
+        job = TestHelpers.randomAnomalyDetectorJob(true);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            GetRequest request = (GetRequest) args[0];
+            ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
+
+            String indexName = request.index();
+            if (indexName.equals(ANOMALY_DETECTORS_INDEX)) {
+                listener
+                    .onResponse(TestHelpers.createGetResponse(detector, detector.getDetectorId(), AnomalyDetector.ANOMALY_DETECTORS_INDEX));
+            } else if (indexName.equals(ANOMALY_DETECTOR_JOB_INDEX)) {
+                listener
+                    .onResponse(
+                        TestHelpers.createGetResponse(job, detector.getDetectorId(), AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)
+                    );
+            }
+
+            return null;
+        }).when(client).get(any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setUpSearch() {
+        latestSampleTimestamp = 1_603_989_830_158L;
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            SearchRequest request = (SearchRequest) args[0];
+            String indexName = request.indices()[0];
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
+            if (indexName.equals(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
+                InternalMax maxAgg = new InternalMax(CommonName.AGG_NAME_MAX, latestSampleTimestamp, DocValueFormat.RAW, emptyMap());
+                InternalAggregations internalAggregations = InternalAggregations.from(Collections.singletonList(maxAgg));
+
+                SearchHits hits = new SearchHits(new SearchHit[] {}, null, Float.NaN);
+                SearchResponseSections searchSections = new SearchResponseSections(hits, internalAggregations, null, false, false, null, 1);
+
+                SearchResponse searchResponse = new SearchResponse(
+                    searchSections,
+                    null,
+                    1,
+                    1,
+                    0,
+                    30,
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponse.Clusters.EMPTY
+                );
+
+                listener.onResponse(searchResponse);
+            }
+            return null;
+        }).when(client).search(any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setUpExecuteEntityProfileAction(InittedEverResultStatus initted) {
+        smallUpdates = 1;
+        latestActiveTimestamp = 1603999189758L;
+        isActive = Boolean.TRUE;
+        modelId = "T4c3dXUBj-2IZN7itix__entity_app_6";
+        modelSize = 712480L;
+        nodeId = "g6pmr547QR-CfpEvO67M4g";
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<EntityProfileResponse> listener = (ActionListener<EntityProfileResponse>) args[2];
+
+            EntityProfileResponse.Builder profileResponseBuilder = new EntityProfileResponse.Builder();
+            if (InittedEverResultStatus.UNKNOWN == initted) {
+                profileResponseBuilder.setTotalUpdates(0L);
+            } else if (InittedEverResultStatus.NOT_INITTED == initted) {
+                profileResponseBuilder.setTotalUpdates(smallUpdates);
+                profileResponseBuilder.setLastActiveMs(latestActiveTimestamp);
+                profileResponseBuilder.setActive(isActive);
+            } else {
+                profileResponseBuilder.setTotalUpdates(requiredSamples + 1);
+                ModelProfile model = new ModelProfile(modelId, modelSize, nodeId);
+                profileResponseBuilder.setModelProfile(model);
+            }
+
+            listener.onResponse(profileResponseBuilder.build());
+
+            return null;
+        }).when(client).execute(any(EntityProfileAction.class), any(), any());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testNotMultiEntityDetector() throws IOException, InterruptedException {
+        detector = TestHelpers.randomAnomalyDetectorWithInterval(new IntervalTimeConfiguration(detectorIntervalMin, ChronoUnit.MINUTES));
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            GetRequest request = (GetRequest) args[0];
+            ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
+
+            String indexName = request.index();
+            if (indexName.equals(ANOMALY_DETECTORS_INDEX)) {
+                listener
+                    .onResponse(TestHelpers.createGetResponse(detector, detector.getDetectorId(), AnomalyDetector.ANOMALY_DETECTORS_INDEX));
+            }
+
+            return null;
+        }).when(client).get(any(), any());
+
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        runner.profile(detectorId, entityValue, state, ActionListener.wrap(response -> {
+            assertTrue("Should not reach here", false);
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue(exception.getMessage().contains(EntityProfileRunner.NOT_HC_DETECTOR_ERR_MSG));
+            inProgressLatch.countDown();
+        }));
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    public void stateTestTemplate(InittedEverResultStatus returnedState, EntityState expectedState) throws InterruptedException {
+        setUpExecuteEntityProfileAction(returnedState);
+
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        runner.profile(detectorId, entityValue, state, ActionListener.wrap(response -> {
+            assertEquals(expectedState, response.getState());
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue("Should not reach here", false);
+            inProgressLatch.countDown();
+        }));
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    public void testUnknownState() throws InterruptedException {
+        stateTestTemplate(InittedEverResultStatus.UNKNOWN, EntityState.UNKNOWN);
+    }
+
+    public void testInitState() throws InterruptedException {
+        stateTestTemplate(InittedEverResultStatus.NOT_INITTED, EntityState.INIT);
+    }
+
+    public void testRunningState() throws InterruptedException {
+        stateTestTemplate(InittedEverResultStatus.INITTED, EntityState.RUNNING);
+    }
+
+    public void testInitNInfo() throws InterruptedException {
+        setUpExecuteEntityProfileAction(InittedEverResultStatus.NOT_INITTED);
+        setUpSearch();
+
+        EntityProfile.Builder expectedProfile = new EntityProfile.Builder(categoryField, entityValue);
+
+        // 1 / 128 rounded to 1%
+        int neededSamples = requiredSamples - smallUpdates;
+        InitProgressProfile profile = new InitProgressProfile(
+            "1%",
+            neededSamples * detector.getDetectorIntervalInSeconds() / 60,
+            neededSamples
+        );
+        expectedProfile.initProgress(profile);
+        expectedProfile.isActive(isActive);
+        expectedProfile.lastActiveTimestampMs(latestActiveTimestamp);
+        expectedProfile.lastSampleTimestampMs(latestSampleTimestamp);
+
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        runner.profile(detectorId, entityValue, initNInfo, ActionListener.wrap(response -> {
+            assertEquals(expectedProfile.build(), response);
+            inProgressLatch.countDown();
+        }, exception -> {
+            LOG.error("Unexpected error", exception);
+            assertTrue("Should not reach here", false);
+            inProgressLatch.countDown();
+        }));
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    public void testEmptyProfile() throws InterruptedException {
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        runner.profile(detectorId, entityValue, new HashSet<>(), ActionListener.wrap(response -> {
+            assertTrue("Should not reach here", false);
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue(exception.getMessage().contains(CommonErrorMessages.EMPTY_PROFILES_COLLECT));
+            inProgressLatch.countDown();
+        }));
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    public void testModel() throws InterruptedException {
+        setUpExecuteEntityProfileAction(InittedEverResultStatus.INITTED);
+
+        EntityProfile.Builder expectedProfile = new EntityProfile.Builder(categoryField, entityValue);
+        ModelProfile modelProfile = new ModelProfile(modelId, modelSize, nodeId);
+        expectedProfile.modelProfile(modelProfile);
+
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        runner.profile(detectorId, entityValue, model, ActionListener.wrap(response -> {
+            assertEquals(expectedProfile.build(), response);
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue("Should not reach here", false);
+            inProgressLatch.countDown();
+        }));
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testJobIndexNotFound() throws InterruptedException {
+        setUpExecuteEntityProfileAction(InittedEverResultStatus.INITTED);
+
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            GetRequest request = (GetRequest) args[0];
+            ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
+
+            String indexName = request.index();
+            if (indexName.equals(ANOMALY_DETECTORS_INDEX)) {
+                listener
+                    .onResponse(TestHelpers.createGetResponse(detector, detector.getDetectorId(), AnomalyDetector.ANOMALY_DETECTORS_INDEX));
+            } else if (indexName.equals(ANOMALY_DETECTOR_JOB_INDEX)) {
+                listener.onFailure(new IndexNotFoundException(ANOMALY_DETECTOR_JOB_INDEX));
+            }
+
+            return null;
+        }).when(client).get(any(), any());
+
+        EntityProfile expectedProfile = new EntityProfile.Builder(categoryField, entityValue).build();
+
+        runner.profile(detectorId, entityValue, initNInfo, ActionListener.wrap(response -> {
+            assertEquals(expectedProfile, response);
+            inProgressLatch.countDown();
+        }, exception -> {
+            LOG.error("Unexpected error", exception);
+            assertTrue("Should not reach here", false);
+            inProgressLatch.countDown();
+        }));
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/MultiEntityProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/MultiEntityProfileRunnerTests.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfile;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfileName;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorState;
+import com.amazon.opendistroforelasticsearch.ad.transport.ProfileAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ProfileNodeResponse;
+import com.amazon.opendistroforelasticsearch.ad.transport.ProfileResponse;
+import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
+
+public class MultiEntityProfileRunnerTests extends AbstractADTest {
+    private AnomalyDetectorProfileRunner runner;
+    private Client client;
+    private DiscoveryNodeFilterer nodeFilter;
+    private int requiredSamples;
+    private AnomalyDetector detector;
+    private String detectorId;
+    private Set<DetectorProfileName> stateNError;
+    private DetectorInternalState.Builder result;
+    private String node1;
+    private String nodeName1;
+    private DiscoveryNode discoveryNode1;
+
+    private String node2;
+    private String nodeName2;
+    private DiscoveryNode discoveryNode2;
+
+    private long modelSize;
+    private String model1Id;
+    private String model0Id;
+
+    private int shingleSize;
+    private AnomalyDetectorJob job;
+
+    enum InittedEverResultStatus {
+        INITTED,
+        NOT_INITTED,
+    }
+
+    @SuppressWarnings("unchecked")
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        client = mock(Client.class);
+        nodeFilter = mock(DiscoveryNodeFilterer.class);
+        requiredSamples = 128;
+
+        detectorId = "A69pa3UBHuCbh-emo9oR";
+        detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList("a"));
+        result = new DetectorInternalState.Builder().lastUpdateTime(Instant.now());
+        job = TestHelpers.randomAnomalyDetectorJob(true);
+
+        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            GetRequest request = (GetRequest) args[0];
+            ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
+
+            String indexName = request.index();
+            if (indexName.equals(ANOMALY_DETECTORS_INDEX)) {
+                listener
+                    .onResponse(TestHelpers.createGetResponse(detector, detector.getDetectorId(), AnomalyDetector.ANOMALY_DETECTORS_INDEX));
+            } else if (indexName.equals(DetectorInternalState.DETECTOR_STATE_INDEX)) {
+                listener
+                    .onResponse(
+                        TestHelpers.createGetResponse(result.build(), detector.getDetectorId(), DetectorInternalState.DETECTOR_STATE_INDEX)
+                    );
+            } else if (indexName.equals(ANOMALY_DETECTOR_JOB_INDEX)) {
+                listener
+                    .onResponse(
+                        TestHelpers.createGetResponse(job, detector.getDetectorId(), AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)
+                    );
+            }
+
+            return null;
+        }).when(client).get(any(), any());
+
+        stateNError = new HashSet<DetectorProfileName>();
+        stateNError.add(DetectorProfileName.ERROR);
+        stateNError.add(DetectorProfileName.STATE);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setUpClientExecuteProfileAction(InittedEverResultStatus initted) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            ActionListener<ProfileResponse> listener = (ActionListener<ProfileResponse>) args[2];
+
+            node1 = "node1";
+            nodeName1 = "nodename1";
+            discoveryNode1 = new DiscoveryNode(
+                nodeName1,
+                node1,
+                new TransportAddress(TransportAddress.META_ADDRESS, 9300),
+                emptyMap(),
+                emptySet(),
+                Version.CURRENT
+            );
+
+            node2 = "node2";
+            nodeName2 = "nodename2";
+            discoveryNode2 = new DiscoveryNode(
+                nodeName2,
+                node2,
+                new TransportAddress(TransportAddress.META_ADDRESS, 9301),
+                emptyMap(),
+                emptySet(),
+                Version.CURRENT
+            );
+
+            modelSize = 712480L;
+            model1Id = "A69pa3UBHuCbh-emo9oR_entity_host1";
+            model0Id = "A69pa3UBHuCbh-emo9oR_entity_host0";
+
+            shingleSize = -1;
+
+            String clusterName = "test-cluster-name";
+
+            Map<String, Long> modelSizeMap1 = new HashMap<String, Long>() {
+                {
+                    put(model1Id, modelSize);
+                }
+            };
+
+            Map<String, Long> modelSizeMap2 = new HashMap<String, Long>() {
+                {
+                    put(model0Id, modelSize);
+                }
+            };
+
+            // one model in each node; all fully initialized
+            long updates = requiredSamples - 1;
+            if (InittedEverResultStatus.INITTED == initted) {
+                updates = requiredSamples + 1;
+            }
+            ProfileNodeResponse profileNodeResponse1 = new ProfileNodeResponse(discoveryNode1, modelSizeMap1, shingleSize, 1L, updates);
+            ProfileNodeResponse profileNodeResponse2 = new ProfileNodeResponse(discoveryNode2, modelSizeMap2, shingleSize, 1L, updates);
+            List<ProfileNodeResponse> profileNodeResponses = Arrays.asList(profileNodeResponse1, profileNodeResponse2);
+            List<FailedNodeException> failures = Collections.emptyList();
+            ProfileResponse profileResponse = new ProfileResponse(new ClusterName(clusterName), profileNodeResponses, failures);
+
+            listener.onResponse(profileResponse);
+
+            return null;
+        }).when(client).execute(any(ProfileAction.class), any(), any());
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setUpClientSearch(InittedEverResultStatus inittedEverResultStatus) {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            SearchRequest request = (SearchRequest) args[0];
+            ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
+
+            AnomalyResult result = null;
+            if (request.source().query().toString().contains(AnomalyResult.ANOMALY_SCORE_FIELD)) {
+                switch (inittedEverResultStatus) {
+                    case INITTED:
+                        result = TestHelpers.randomAnomalyDetectResult(0.87);
+                        listener.onResponse(TestHelpers.createSearchResponse(result));
+                        break;
+                    case NOT_INITTED:
+                        listener.onResponse(TestHelpers.createEmptySearchResponse());
+                        break;
+                    default:
+                        assertTrue("should not reach here", false);
+                        break;
+                }
+            }
+
+            return null;
+        }).when(client).search(any(), any());
+    }
+
+    public void testInit() throws InterruptedException {
+        setUpClientExecuteProfileAction(InittedEverResultStatus.NOT_INITTED);
+        setUpClientSearch(InittedEverResultStatus.NOT_INITTED);
+
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        DetectorProfile expectedProfile = new DetectorProfile.Builder().state(DetectorState.INIT).build();
+        runner.profile(detectorId, ActionListener.wrap(response -> {
+            assertEquals(expectedProfile, response);
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue("Should not reach here", false);
+            inProgressLatch.countDown();
+        }), stateNError);
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    public void testRunning() throws InterruptedException {
+        setUpClientExecuteProfileAction(InittedEverResultStatus.INITTED);
+        setUpClientSearch(InittedEverResultStatus.INITTED);
+
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        DetectorProfile expectedProfile = new DetectorProfile.Builder().state(DetectorState.RUNNING).build();
+        runner.profile(detectorId, ActionListener.wrap(response -> {
+            assertEquals(expectedProfile, response);
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue("Should not reach here", false);
+            inProgressLatch.countDown();
+        }), stateNError);
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+
+    /**
+     * Although profile action results indicate initted, we trust what result index tells us
+     * @throws InterruptedException if CountDownLatch is interrupted while waiting
+     */
+    public void testResultIndexFinalTruth() throws InterruptedException {
+        setUpClientExecuteProfileAction(InittedEverResultStatus.NOT_INITTED);
+        setUpClientSearch(InittedEverResultStatus.INITTED);
+
+        final CountDownLatch inProgressLatch = new CountDownLatch(1);
+
+        DetectorProfile expectedProfile = new DetectorProfile.Builder().state(DetectorState.RUNNING).build();
+        runner.profile(detectorId, ActionListener.wrap(response -> {
+            assertEquals(expectedProfile, response);
+            inProgressLatch.countDown();
+        }, exception -> {
+            assertTrue("Should not reach here", false);
+            inProgressLatch.countDown();
+        }), stateNError);
+        assertTrue(inProgressLatch.await(100, TimeUnit.SECONDS));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
@@ -122,6 +122,7 @@ import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.Interpolator;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.LinearUniformInterpolator;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.SingleFeatureLinearUniformInterpolator;
@@ -236,7 +237,7 @@ public class SearchFeatureDaoTests {
         aggsMap = new HashMap<>();
         // aggsList = new ArrayList<>();
 
-        when(max.getName()).thenReturn(SearchFeatureDao.AGG_NAME_MAX);
+        when(max.getName()).thenReturn(CommonName.AGG_NAME_MAX);
         List<Aggregation> list = new ArrayList<>();
         list.add(max);
         Aggregations aggregations = new Aggregations(list);
@@ -275,12 +276,12 @@ public class SearchFeatureDaoTests {
     public void test_getLatestDataTime_returnExpectedTime_givenData() {
         // pre-conditions
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .aggregation(AggregationBuilders.max(SearchFeatureDao.AGG_NAME_MAX).field(detector.getTimeField()))
+            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX).field(detector.getTimeField()))
             .size(0);
         searchRequest.source(searchSourceBuilder);
 
         long epochTime = 100L;
-        aggsMap.put(SearchFeatureDao.AGG_NAME_MAX, max);
+        aggsMap.put(CommonName.AGG_NAME_MAX, max);
         when(max.getValue()).thenReturn((double) epochTime);
 
         // test
@@ -294,7 +295,7 @@ public class SearchFeatureDaoTests {
     public void test_getLatestDataTime_returnEmpty_givenNoData() {
         // pre-conditions
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .aggregation(AggregationBuilders.max(SearchFeatureDao.AGG_NAME_MAX).field(detector.getTimeField()))
+            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX).field(detector.getTimeField()))
             .size(0);
         searchRequest.source(searchSourceBuilder);
 
@@ -311,11 +312,11 @@ public class SearchFeatureDaoTests {
     @SuppressWarnings("unchecked")
     public void getLatestDataTime_returnExpectedToListener() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .aggregation(AggregationBuilders.max(SearchFeatureDao.AGG_NAME_MAX).field(detector.getTimeField()))
+            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX).field(detector.getTimeField()))
             .size(0);
         searchRequest.source(searchSourceBuilder);
         long epochTime = 100L;
-        aggsMap.put(SearchFeatureDao.AGG_NAME_MAX, max);
+        aggsMap.put(CommonName.AGG_NAME_MAX, max);
         when(max.getValue()).thenReturn((double) epochTime);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
@@ -323,6 +324,7 @@ public class SearchFeatureDaoTests {
             return null;
         }).when(client).search(eq(searchRequest), any(ActionListener.class));
 
+        when(ParseUtils.getLatestDataTime(eq(searchResponse))).thenReturn(Optional.of(epochTime));
         ActionListener<Optional<Long>> listener = mock(ActionListener.class);
         searchFeatureDao.getLatestDataTime(detector, listener);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/EntityProfileTests.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.ConnectTransportException;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportException;
+import org.elasticsearch.transport.TransportInterceptor;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
+import org.elasticsearch.transport.TransportService;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import test.com.amazon.opendistroforelasticsearch.ad.util.FakeNode;
+import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
+
+import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.caching.CacheProvider;
+import com.amazon.opendistroforelasticsearch.ad.caching.EntityCache;
+import com.amazon.opendistroforelasticsearch.ad.cluster.HashRing;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
+import com.amazon.opendistroforelasticsearch.ad.model.EntityProfileName;
+import com.amazon.opendistroforelasticsearch.ad.model.ModelProfile;
+
+public class EntityProfileTests extends AbstractADTest {
+    private String detectorId = "yecrdnUBqurvo9uKU_d8";
+    private String entityValue = "app_0";
+    private String nodeId = "abc";
+    private Set<EntityProfileName> state;
+    private Set<EntityProfileName> all;
+    private Set<EntityProfileName> model;
+    private HashRing hashRing;
+    private ActionFilters actionFilters;
+    private TransportService transportService;
+    private Settings settings;
+    private ModelManager modelManager;
+    private ClusterService clusterService;
+    private CacheProvider cacheProvider;
+    private EntityProfileTransportAction action;
+    private Task task;
+    private PlainActionFuture<EntityProfileResponse> future;
+    private TransportAddress transportAddress1;
+    private long updates;
+    private EntityProfileRequest request;
+    private String modelId;
+    private long lastActiveTimestamp = 1603989830158L;
+    private long modelSize = 712480L;
+    private boolean isActive = Boolean.TRUE;
+    private TransportInterceptor normalTransportInterceptor, failureTransportInterceptor;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        setUpThreadPool(EntityProfileTests.class.getSimpleName());
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        tearDownThreadPool();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        state = new HashSet<EntityProfileName>();
+        state.add(EntityProfileName.STATE);
+
+        all = new HashSet<EntityProfileName>();
+        all.add(EntityProfileName.INIT_PROGRESS);
+        all.add(EntityProfileName.ENTITY_INFO);
+        all.add(EntityProfileName.MODELS);
+
+        model = new HashSet<EntityProfileName>();
+        model.add(EntityProfileName.MODELS);
+
+        hashRing = mock(HashRing.class);
+        actionFilters = mock(ActionFilters.class);
+        transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            null,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet()
+        );
+        settings = Settings.EMPTY;
+
+        modelManager = mock(ModelManager.class);
+        modelId = "yecrdnUBqurvo9uKU_d8_entity_app_0";
+        when(modelManager.getEntityModelId(anyString(), anyString())).thenReturn(modelId);
+
+        clusterService = mock(ClusterService.class);
+
+        cacheProvider = mock(CacheProvider.class);
+        EntityCache cache = mock(EntityCache.class);
+        updates = 1L;
+        when(cache.getTotalUpdates(anyString(), anyString())).thenReturn(updates);
+        when(cache.isActive(anyString(), anyString())).thenReturn(isActive);
+        when(cache.getLastActiveMs(anyString(), anyString())).thenReturn(lastActiveTimestamp);
+        when(cache.getModelSize(anyString(), anyString())).thenReturn(modelSize);
+        when(cacheProvider.get()).thenReturn(cache);
+
+        action = new EntityProfileTransportAction(
+            actionFilters,
+            transportService,
+            settings,
+            modelManager,
+            hashRing,
+            clusterService,
+            cacheProvider
+        );
+
+        future = new PlainActionFuture<>();
+        transportAddress1 = new TransportAddress(new InetSocketAddress(InetAddress.getByName("1.2.3.4"), 9300));
+
+        request = new EntityProfileRequest(detectorId, entityValue, state);
+
+        normalTransportInterceptor = new TransportInterceptor() {
+            @Override
+            public AsyncSender interceptSender(AsyncSender sender) {
+                return new AsyncSender() {
+                    @Override
+                    public <T extends TransportResponse> void sendRequest(
+                        Transport.Connection connection,
+                        String action,
+                        TransportRequest request,
+                        TransportRequestOptions options,
+                        TransportResponseHandler<T> handler
+                    ) {
+                        if (EntityProfileAction.NAME.equals(action)) {
+                            sender.sendRequest(connection, action, request, options, entityProfileHandler(handler));
+                        } else {
+                            sender.sendRequest(connection, action, request, options, handler);
+                        }
+                    }
+                };
+            }
+        };
+
+        failureTransportInterceptor = new TransportInterceptor() {
+            @Override
+            public AsyncSender interceptSender(AsyncSender sender) {
+                return new AsyncSender() {
+                    @Override
+                    public <T extends TransportResponse> void sendRequest(
+                        Transport.Connection connection,
+                        String action,
+                        TransportRequest request,
+                        TransportRequestOptions options,
+                        TransportResponseHandler<T> handler
+                    ) {
+                        if (EntityProfileAction.NAME.equals(action)) {
+                            sender.sendRequest(connection, action, request, options, entityFailureProfileandler(handler));
+                        } else {
+                            sender.sendRequest(connection, action, request, options, handler);
+                        }
+                    }
+                };
+            }
+        };
+    }
+
+    private <T extends TransportResponse> TransportResponseHandler<T> entityProfileHandler(TransportResponseHandler<T> handler) {
+        return new TransportResponseHandler<T>() {
+            @Override
+            public T read(StreamInput in) throws IOException {
+                return handler.read(in);
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public void handleResponse(T response) {
+                handler.handleResponse((T) new EntityProfileResponse.Builder().setTotalUpdates(updates).build());
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                handler.handleException(exp);
+            }
+
+            @Override
+            public String executor() {
+                return handler.executor();
+            }
+        };
+    }
+
+    private <T extends TransportResponse> TransportResponseHandler<T> entityFailureProfileandler(TransportResponseHandler<T> handler) {
+        return new TransportResponseHandler<T>() {
+            @Override
+            public T read(StreamInput in) throws IOException {
+                return handler.read(in);
+            }
+
+            @Override
+            public void handleResponse(T response) {
+                handler
+                    .handleException(
+                        new ConnectTransportException(
+                            new DiscoveryNode(nodeId, transportAddress1, Version.CURRENT.minimumCompatibilityVersion()),
+                            EntityProfileAction.NAME
+                        )
+                    );
+            }
+
+            @Override
+            public void handleException(TransportException exp) {
+                handler.handleException(exp);
+            }
+
+            @Override
+            public String executor() {
+                return handler.executor();
+            }
+        };
+    }
+
+    private void registerHandler(FakeNode node) {
+        new EntityProfileTransportAction(
+            new ActionFilters(Collections.emptySet()),
+            node.transportService,
+            Settings.EMPTY,
+            modelManager,
+            hashRing,
+            node.clusterService,
+            cacheProvider
+        );
+    }
+
+    public void testInvalidRequest() {
+        when(hashRing.getOwningNode(anyString())).thenReturn(Optional.empty());
+        action.doExecute(task, request, future);
+
+        assertException(future, AnomalyDetectionException.class, EntityProfileTransportAction.NO_NODE_FOUND_MSG);
+    }
+
+    public void testLocalNodeHit() {
+        DiscoveryNode localNode = new DiscoveryNode(nodeId, transportAddress1, Version.CURRENT.minimumCompatibilityVersion());
+        when(hashRing.getOwningNode(anyString())).thenReturn(Optional.of(localNode));
+        when(clusterService.localNode()).thenReturn(localNode);
+
+        action.doExecute(task, request, future);
+        EntityProfileResponse response = future.actionGet(20_000);
+        assertEquals(updates, response.getTotalUpdates());
+    }
+
+    public void testAllHit() {
+        DiscoveryNode localNode = new DiscoveryNode(nodeId, transportAddress1, Version.CURRENT.minimumCompatibilityVersion());
+        when(hashRing.getOwningNode(anyString())).thenReturn(Optional.of(localNode));
+        when(clusterService.localNode()).thenReturn(localNode);
+
+        request = new EntityProfileRequest(detectorId, entityValue, all);
+        action.doExecute(task, request, future);
+
+        EntityProfileResponse expectedResponse = new EntityProfileResponse(
+            isActive,
+            lastActiveTimestamp,
+            updates,
+            new ModelProfile(modelId, modelSize, nodeId)
+        );
+        EntityProfileResponse response = future.actionGet(20_000);
+        assertEquals(expectedResponse, response);
+    }
+
+    public void testGetRemoteUpdateResponse() {
+        setupTestNodes(Settings.EMPTY, normalTransportInterceptor);
+        try {
+            TransportService realTransportService = testNodes[0].transportService;
+            clusterService = testNodes[0].clusterService;
+
+            action = new EntityProfileTransportAction(
+                actionFilters,
+                realTransportService,
+                settings,
+                modelManager,
+                hashRing,
+                clusterService,
+                cacheProvider
+            );
+
+            when(hashRing.getOwningNode(any(String.class))).thenReturn(Optional.of(testNodes[1].discoveryNode()));
+            registerHandler(testNodes[1]);
+
+            action.doExecute(null, request, future);
+
+            EntityProfileResponse expectedResponse = new EntityProfileResponse(null, -1L, updates, null);
+
+            EntityProfileResponse response = future.actionGet(10_000);
+            assertEquals(expectedResponse, response);
+        } finally {
+            tearDownTestNodes();
+        }
+    }
+
+    public void testGetRemoteFailureResponse() {
+        setupTestNodes(Settings.EMPTY, failureTransportInterceptor);
+        try {
+            TransportService realTransportService = testNodes[0].transportService;
+            clusterService = testNodes[0].clusterService;
+
+            action = new EntityProfileTransportAction(
+                actionFilters,
+                realTransportService,
+                settings,
+                modelManager,
+                hashRing,
+                clusterService,
+                cacheProvider
+            );
+
+            when(hashRing.getOwningNode(any(String.class))).thenReturn(Optional.of(testNodes[1].discoveryNode()));
+            registerHandler(testNodes[1]);
+
+            action.doExecute(null, request, future);
+
+            expectThrows(ConnectTransportException.class, () -> future.actionGet());
+        } finally {
+            tearDownTestNodes();
+        }
+    }
+
+    public void testResponseToXContent() throws IOException, JsonPathNotFoundException {
+        long lastActiveTimestamp = 10L;
+        EntityProfileResponse.Builder builder = new EntityProfileResponse.Builder();
+        builder.setLastActiveMs(lastActiveTimestamp).build();
+        builder.setModelProfile(new ModelProfile(modelId, modelSize, nodeId));
+        EntityProfileResponse response = builder.build();
+        String json = TestHelpers.xContentBuilderToString(response.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        assertEquals(lastActiveTimestamp, JsonDeserializer.getLongValue(json, EntityProfileResponse.LAST_ACTIVE_TS));
+        assertEquals(modelSize, JsonDeserializer.getChildNode(json, CommonName.MODEL, ModelProfile.MODEL_SIZE_IN_BYTES).getAsLong());
+    }
+
+    public void testSerialzationResponse() throws IOException {
+        EntityProfileResponse.Builder builder = new EntityProfileResponse.Builder();
+        builder.setLastActiveMs(lastActiveTimestamp).build();
+        ModelProfile model = new ModelProfile(modelId, modelSize, nodeId);
+        builder.setModelProfile(model);
+        EntityProfileResponse response = builder.build();
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+
+        StreamInput streamInput = output.bytes().streamInput();
+        EntityProfileResponse readResponse = EntityProfileAction.INSTANCE.getResponseReader().read(streamInput);
+        assertThat(response.getModelProfile(), equalTo(readResponse.getModelProfile()));
+        assertThat(response.getLastActiveMs(), equalTo(readResponse.getLastActiveMs()));
+    }
+
+    public void testResponseHashCodeEquals() {
+        EntityProfileResponse.Builder builder = new EntityProfileResponse.Builder();
+        builder.setLastActiveMs(lastActiveTimestamp).build();
+        ModelProfile model = new ModelProfile(modelId, modelSize, nodeId);
+        builder.setModelProfile(model);
+        EntityProfileResponse response = builder.build();
+
+        HashSet<EntityProfileResponse> set = new HashSet<>();
+        assertTrue(false == set.contains(response));
+        set.add(response);
+        assertTrue(set.contains(response));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.security.InvalidParameterException;
+import java.util.Collections;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportService;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
+
+public class GetAnomalyDetectorTests extends AbstractADTest {
+    private GetAnomalyDetectorTransportAction action;
+    private TransportService transportService;
+    private DiscoveryNodeFilterer nodeFilter;
+    private ActionFilters actionFilters;
+    private Client client;
+    private GetAnomalyDetectorRequest request;
+    private String detectorId = "yecrdnUBqurvo9uKU_d8";
+    private String entityValue = "app_0";
+    private String typeStr;
+    private String rawPath;
+    private PlainActionFuture<GetAnomalyDetectorResponse> future;
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        setUpThreadPool(EntityProfileTests.class.getSimpleName());
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        tearDownThreadPool();
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            null,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet()
+        );
+
+        nodeFilter = mock(DiscoveryNodeFilterer.class);
+
+        actionFilters = mock(ActionFilters.class);
+
+        client = mock(Client.class);
+        when(client.threadPool()).thenReturn(threadPool);
+
+        action = new GetAnomalyDetectorTransportAction(transportService, nodeFilter, actionFilters, client, xContentRegistry());
+    }
+
+    public void testInvalidRequest() throws IOException {
+        typeStr = "entity_info2,init_progress2";
+
+        rawPath = "_opendistro/_anomaly_detection/detectors/T4c3dXUBj-2IZN7itix_/_profile";
+
+        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, typeStr, rawPath, false, entityValue);
+
+        future = new PlainActionFuture<>();
+        action.doExecute(null, request, future);
+        assertException(future, InvalidParameterException.class, CommonErrorMessages.EMPTY_PROFILES_COLLECT);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testValidRequest() throws IOException {
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            GetRequest request = (GetRequest) args[0];
+            ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
+
+            String indexName = request.index();
+            if (indexName.equals(ANOMALY_DETECTORS_INDEX)) {
+                listener.onResponse(null);
+            }
+            return null;
+        }).when(client).get(any(), any());
+
+        typeStr = "entity_info,init_progress";
+
+        rawPath = "_opendistro/_anomaly_detection/detectors/T4c3dXUBj-2IZN7itix_/_profile";
+
+        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, typeStr, rawPath, false, entityValue);
+
+        future = new PlainActionFuture<>();
+        action.doExecute(null, request, future);
+        assertException(future, InvalidParameterException.class, CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportActionTests.java
@@ -18,7 +18,6 @@ package com.amazon.opendistroforelasticsearch.ad.transport;
 import java.io.IOException;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -61,7 +60,6 @@ public class GetAnomalyDetectorTransportActionTests extends ESIntegTestCase {
 
     @Test
     public void testGetTransportAction() throws IOException {
-        MultiGetResponse mockResponse = Mockito.mock(MultiGetResponse.class);
         GetAnomalyDetectorRequest getAnomalyDetectorRequest = new GetAnomalyDetectorRequest(
             "1234",
             4321,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileIT.java
@@ -24,7 +24,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
-import com.amazon.opendistroforelasticsearch.ad.model.ProfileName;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfileName;
 
 @ESIntegTestCase.ClusterScope(transportClientRatio = 0.9)
 public class ProfileIT extends ESIntegTestCase {
@@ -40,7 +40,7 @@ public class ProfileIT extends ESIntegTestCase {
     }
 
     public void testNormalProfile() throws ExecutionException, InterruptedException {
-        ProfileRequest profileRequest = new ProfileRequest("123", new HashSet<ProfileName>());
+        ProfileRequest profileRequest = new ProfileRequest("123", new HashSet<DetectorProfileName>(), false);
 
         ProfileResponse response = client().execute(ProfileAction.INSTANCE, profileRequest).get();
         assertTrue("getting profile failed", !response.hasFailures());

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ProfileTests.java
@@ -46,8 +46,8 @@ import test.com.amazon.opendistroforelasticsearch.ad.util.JsonDeserializer;
 
 import com.amazon.opendistroforelasticsearch.ad.common.exception.JsonPathNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfileName;
 import com.amazon.opendistroforelasticsearch.ad.model.ModelProfile;
-import com.amazon.opendistroforelasticsearch.ad.model.ProfileName;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 
@@ -115,9 +115,9 @@ public class ProfileTests extends ESTestCase {
     @Test
     public void testProfileNodeRequest() throws IOException {
 
-        Set<ProfileName> profilesToRetrieve = new HashSet<ProfileName>();
-        profilesToRetrieve.add(ProfileName.COORDINATING_NODE);
-        ProfileRequest ProfileRequest = new ProfileRequest(detectorId, profilesToRetrieve);
+        Set<DetectorProfileName> profilesToRetrieve = new HashSet<DetectorProfileName>();
+        profilesToRetrieve.add(DetectorProfileName.COORDINATING_NODE);
+        ProfileRequest ProfileRequest = new ProfileRequest(detectorId, profilesToRetrieve, false);
         ProfileNodeRequest ProfileNodeRequest = new ProfileNodeRequest(ProfileRequest);
         assertEquals("ProfileNodeRequest has the wrong detector id", ProfileNodeRequest.getDetectorId(), detectorId);
         assertEquals("ProfileNodeRequest has the wrong ProfileRequest", ProfileNodeRequest.getProfilesToBeRetrieved(), profilesToRetrieve);
@@ -163,9 +163,9 @@ public class ProfileTests extends ESTestCase {
     @Test
     public void testProfileRequest() throws IOException {
         String detectorId = "123";
-        Set<ProfileName> profilesToRetrieve = new HashSet<ProfileName>();
-        profilesToRetrieve.add(ProfileName.COORDINATING_NODE);
-        ProfileRequest profileRequest = new ProfileRequest(detectorId, profilesToRetrieve);
+        Set<DetectorProfileName> profilesToRetrieve = new HashSet<DetectorProfileName>();
+        profilesToRetrieve.add(DetectorProfileName.COORDINATING_NODE);
+        ProfileRequest profileRequest = new ProfileRequest(detectorId, profilesToRetrieve, false);
 
         // Test Serialization
         BytesStreamOutput output = new BytesStreamOutput();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR did various things to improve profile API:
First, the PR fixed the hang issue. Previously, when users run _profile/state or _profile on the multi-entity detector, the request hangs. The problem is due to incorrect maxResponseCount passed to MultiResponsesDelegateActionListener.
Second, the PR fixes the multi-entity detector's wrong state issue. Previously, we can show the init state after an anomaly has shown up. We may have the problem because we read the most active entity's init progress in the cache for a detector's init_progress. But the entity already produced anomaly has been evicted out of the cache. This PR fixes the issue by double-checking the result index's non-zero RCF score for a multi-entity detector before reporting the init state. If there is any non-zero RCF score, we say running state instead of the initing state.
Third, this PR adds more information to the entity level profile, including last_active_timestamp, last_sample_timestamp, init_progress, model, and state.
Fourth, this PR adds models and total_size_in_bytes to the multi-entity detector level profile.

This PR also fixes various "fail to return" issues in the rest API related transport action. We didn't return after sending channel responses. Later, when we use the channel to send back responses again, we get " java.lang.IllegalStateException: Channel is already closed."

Testing done:
1. manual testing passes.
2. added unit tests

After the change, we have the following output for multi-entity detectors:

```
http://localhost:9200/_opendistro/_anomaly_detection/detectors/T4c3dXUBj-2IZN7itix_/_profile?_all=true&pretty

{
	"state": "RUNNING",
	"models": [{
			"model_id": "T4c3dXUBj-2IZN7itix__entity_app_4",
			"model_size_in_bytes": 712480,
			"node_id": "g6pmr547QR-CfpEvO67M4g"
		},
		{
			"model_id": "T4c3dXUBj-2IZN7itix__entity_app_5",
			"model_size_in_bytes": 712480,
			"node_id": "g6pmr547QR-CfpEvO67M4g"
		},
		{
			"model_id": "T4c3dXUBj-2IZN7itix__entity_app_6",
			"model_size_in_bytes": 712480,
			"node_id": "g6pmr547QR-CfpEvO67M4g"
		},
		{
			"model_id": "T4c3dXUBj-2IZN7itix__entity_app_0",
			"model_size_in_bytes": 712480,
			"node_id": "g6pmr547QR-CfpEvO67M4g"
		},
		{
			"model_id": "T4c3dXUBj-2IZN7itix__entity_app_1",
			"model_size_in_bytes": 712480,
			"node_id": "g6pmr547QR-CfpEvO67M4g"
		},
		{
			"model_id": "T4c3dXUBj-2IZN7itix__entity_app_2",
			"model_size_in_bytes": 712480,
			"node_id": "g6pmr547QR-CfpEvO67M4g"
		},
		{
			"model_id": "T4c3dXUBj-2IZN7itix__entity_app_3",
			"model_size_in_bytes": 712480,
			"node_id": "g6pmr547QR-CfpEvO67M4g"
		}
	],
	"total_size_in_bytes": 4987360,
	"init_progress": {
		"percentage": "100%"
	},
	"total_entities": 7,
	"active_entities": 7
}

http://localhost:9200/_opendistro/_anomaly_detection/detectors/T4c3dXUBj-2IZN7itix_/_profile?_all=true&entity=app_6
{
    "category_field": "service",
    "value": "app_6",
    "is_active": true,
    "last_active_timestamp": 1604026394879,
    "last_sample_timestamp": 1604026394879,
    "init_progress": {
        "percentage": "100%"
    },
    "model": {
        "model_id": "TFUdd3UBBwIAGQeRh5IS_entity_app_6",
        "model_size_in_bytes": 712480,
        "node_id": "MQ-bTBW3Q2uU_2zX3pyEQg"
    },
    "state": "RUNNING"
}

http://localhost:9200/_opendistro/_anomaly_detection/detectors/T4c3dXUBj-2IZN7itix_/_profile/entity_info,init_progress?entity=app_0

{
    "category_field": "service",
    "value": "app_0",
    "is_active": true,
    "last_active_timestamp": 1604020861321,
    "last_sample_timestamp": 1604020861321,
    "init_progress": {
        "percentage": "100%"
    }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
