### PR TITLE
fix fatal error of missing method parseString

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,7 +315,7 @@ dependencies {
     compile "com.amazon.opendistroforelasticsearch:common-utils:1.11.0.1"
     compile group: 'com.google.guava', name: 'guava', version:'29.0-jre'
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     compile group: 'com.yahoo.datasketches', name: 'sketches-core', version: '0.13.4'
     compile group: 'com.yahoo.datasketches', name: 'memory', version: '0.12.2'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/CheckpointDao.java
@@ -112,6 +112,7 @@ public class CheckpointDao {
     private final AnomalyDetectionIndices indexUtil;
     private final RateLimiter bulkRateLimiter;
     private final int maxBulkRequestSize;
+    private final JsonParser parser = new JsonParser();
 
     /**
      * Constructor with dependencies and configuration.
@@ -466,7 +467,7 @@ public class CheckpointDao {
         try {
             return AccessController.doPrivileged((PrivilegedAction<Entry<EntityModel, Instant>>) () -> {
                 String model = (String) (checkpoint.get(FIELD_MODEL));
-                JsonObject json = JsonParser.parseString(model).getAsJsonObject();
+                JsonObject json = parser.parse(model).getAsJsonObject();
                 ArrayDeque<double[]> samples = new ArrayDeque<>(
                     Arrays.asList(this.gson.fromJson(json.getAsJsonArray(ENTITY_SAMPLE), new double[0][0].getClass()))
                 );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When cluster restarted, will restore model from checkpoint, but will throw fatal errors which will restart cluster.
```
[2020-10-29T19:43:34,676][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [ad5beb168c48658f8e0d1f227f3395cd] fatal error in thread [elasticsearch[ad5beb168c48658f8e0d1f227f3395cd][get][T#4]], exiting
java.lang.NoSuchMethodError: 'com.google.gson.JsonElement com.google.gson.JsonParser.parseString(java.lang.String)'
	at com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao.lambda$fromEntityModelCheckpoint$12(CheckpointDao.java:469) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao.fromEntityModelCheckpoint(CheckpointDao.java:467) ~[?:?]
	at com.amazon.opendistroforelasticsearch.ad.ml.CheckpointDao.lambda$restoreModelCheckpoint$13(CheckpointDao.java:501) ~[?:?]
```
It's caused by ES cluster using old GSON version which doesn't have `parseString` method. It takes time find out which package introduces the old version of GSON. This PR change to use an old method "parse" as a workaround. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
