### PR TITLE
filter out empty value for entity features

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
@@ -793,9 +793,11 @@ public class SearchFeatureDao {
                     .stream()
                     .filter(agg -> AGG_NAME_TERM.equals(agg.getName()))
                     .flatMap(agg -> ((Terms) agg).getBuckets().stream())
-                    .collect(
-                        Collectors.toMap(Terms.Bucket::getKeyAsString, bucket -> parseBucket(bucket, detector.getEnabledFeatureIds()).get())
-                    );
+                    .collect(Collectors.toMap(Terms.Bucket::getKeyAsString, bucket -> parseBucket(bucket, detector.getEnabledFeatureIds())))
+                    .entrySet()
+                    .stream()
+                    .filter(entry -> entry.getValue().isPresent())
+                    .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().get()));
 
                 listener.onResponse(results);
             }, listener::onFailure);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
HC detector stays on initialization for days. We can see a lot of “NoSuchElementException” exception which caused by `Optional.EMPTY.get()`. This caused by null feature aggregation result (the category field value is not null). So if some entities have null feature data, will throw `NoSuchElementException` exception and skip other normal entities.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
