### PR TITLE
fix double nan error when parse to json

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.google.gson.GsonBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.SpecialPermission;
@@ -255,7 +256,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
     }
 
     private static Void initGson() {
-        gson = new Gson();
+        gson = new GsonBuilder().serializeSpecialFloatingPointValues().create();
         return null;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -29,7 +29,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.gson.GsonBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.SpecialPermission;
@@ -163,6 +162,7 @@ import com.amazon.randomcutforest.serialize.RandomCutForestSerDe;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /**
  * Entry point of AD plugin.

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/RCFPollingTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/RCFPollingTests.java
@@ -180,6 +180,21 @@ public class RCFPollingTests extends AbstractADTest {
         };
     }
 
+    public void testDoubleNaN() {
+        try {
+            gson.toJson(Double.NaN);
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalArgumentException);
+            assertTrue(e.getMessage().contains("NaN is not a valid double value as per JSON specification"));
+        }
+
+        Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().create();
+        String json = gson.toJson(Double.NaN);
+        assertEquals("NaN", json);
+        Double value = gson.fromJson(json, Double.class);
+        assertTrue(value.isNaN());
+    }
+
     public void testNormal() {
         DiscoveryNode localNode = new DiscoveryNode(nodeId, transportAddress1, Version.CURRENT.minimumCompatibilityVersion());
         when(hashRing.getOwningNode(any(String.class))).thenReturn(Optional.of(localNode));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`new Gson().toJson(Double.NaN)` will throw such exception: "NaN is not a valid double value as per JSON specification"
This PR fixed this bug

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
