### PR TITLE
Fix issue where data hole exists for Preview API

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -594,7 +594,13 @@ public class FeatureManager implements CleanState {
         ActionListener<Entry<List<Entry<Long, Long>>, double[][]>> listener
     ) throws IOException {
         searchFeatureDao
-            .getColdStartSamplesForPeriods(detector, sampleRanges, entity.getValue(), getSamplesRangesListener(sampleRanges, listener));
+            .getColdStartSamplesForPeriods(
+                detector,
+                sampleRanges,
+                entity.getValue(),
+                true,
+                getSamplesRangesListener(sampleRanges, listener)
+            );
     }
 
     private ActionListener<List<Optional<double[]>>> getSamplesRangesListener(

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityColdStarter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityColdStarter.java
@@ -417,6 +417,7 @@ public class EntityColdStarter {
                             detector,
                             sampleRanges,
                             entityName,
+                            false,
                             new ThreadedActionListener<>(
                                 logger,
                                 threadPool,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
@@ -517,10 +518,10 @@ public class FeatureManagerTests {
         coldStartSamples.add(Optional.of(new double[] { 30.0 }));
 
         doAnswer(invocation -> {
-            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(3);
+            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(4);
             listener.onResponse(coldStartSamples);
             return null;
-        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), any());
+        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), anyBoolean(), any());
 
         ActionListener<Features> listener = mock(ActionListener.class);
 
@@ -541,10 +542,10 @@ public class FeatureManagerTests {
         Entity entity = new Entity("fieldName", "value");
 
         doAnswer(invocation -> {
-            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(3);
+            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(4);
             listener.onResponse(new ArrayList<>());
             return null;
-        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), any());
+        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), anyBoolean(), any());
 
         ActionListener<Features> listener = mock(ActionListener.class);
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityColdStarterTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ml/EntityColdStarterTests.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.ad.ml;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -202,10 +203,10 @@ public class EntityColdStarterTests extends AbstractADTest {
         coldStartSamples.add(Optional.of(new double[] { 1.0 }));
         coldStartSamples.add(Optional.of(new double[] { -19.0 }));
         doAnswer(invocation -> {
-            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(3);
+            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(4);
             listener.onResponse(coldStartSamples);
             return null;
-        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), any());
+        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), anyBoolean(), any());
 
         entityColdStarter.trainModel(samples, modelId, entityName, detectorId, modelState);
 
@@ -268,7 +269,7 @@ public class EntityColdStarterTests extends AbstractADTest {
 
         entityColdStarter.trainModel(samples, modelId, entityName, detectorId, modelState);
 
-        verify(searchFeatureDao, never()).getColdStartSamplesForPeriods(any(), any(), any(), any());
+        verify(searchFeatureDao, never()).getColdStartSamplesForPeriods(any(), any(), any(), anyBoolean(), any());
 
         RandomCutForest forest = model.getRcf();
         assertTrue(forest == null);
@@ -294,10 +295,10 @@ public class EntityColdStarterTests extends AbstractADTest {
         coldStartSamples.add(Optional.empty());
         coldStartSamples.add(Optional.of(new double[] { -17.0 }));
         doAnswer(invocation -> {
-            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(3);
+            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(4);
             listener.onResponse(coldStartSamples);
             return null;
-        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), any());
+        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), anyBoolean(), any());
 
         entityColdStarter.trainModel(samples, modelId, entityName, detectorId, modelState);
 
@@ -336,10 +337,10 @@ public class EntityColdStarterTests extends AbstractADTest {
         coldStartSamples.add(Optional.of(new double[] { -17.0 }));
         coldStartSamples.add(Optional.of(new double[] { -38.0 }));
         doAnswer(invocation -> {
-            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(3);
+            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(4);
             listener.onResponse(coldStartSamples);
             return null;
-        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), any());
+        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), anyBoolean(), any());
 
         entityColdStarter.trainModel(samples, modelId, entityName, detectorId, modelState);
 
@@ -408,10 +409,10 @@ public class EntityColdStarterTests extends AbstractADTest {
         coldStartSamples.add(Optional.of(new double[] { 57.0 }));
         coldStartSamples.add(Optional.of(new double[] { 1.0 }));
         doAnswer(invocation -> {
-            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(3);
+            ActionListener<List<Optional<double[]>>> listener = invocation.getArgument(4);
             listener.onResponse(coldStartSamples);
             return null;
-        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), any());
+        }).when(searchFeatureDao).getColdStartSamplesForPeriods(any(), any(), any(), anyBoolean(), any());
 
         entityColdStarter.trainModel(samples, modelId, entityName, detectorId, modelState);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix issue where data hole exists for Preview API. For now, we only get cold start samples with non-zero doc, and we add samples to corresponding date range by [index of cold start samples](https://github.com/opendistro-for-elasticsearch/anomaly-detection/blob/2e7e39d01631e27822b64cdd93e75956d72efdf2/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java#L607-L613). This can cause issue because when source data has no doc in periods of time, size of `featureSamples` is less than `sampleRanges`, then only the some beginning date ranges of `sampleRanges` have data returned.

Fix is simple: just include zero count bucket in the response from ES. 

Example: data only exists in source starting from 11-13-2020
Before:
<img width="1154" alt="Screen Shot 2020-11-14 at 5 24 12 PM" src="https://user-images.githubusercontent.com/59710443/99431955-5d5add80-28c0-11eb-87ee-e8f1dbb28264.png">

After:
<img width="1162" alt="Screen Shot 2020-11-14 at 5 22 53 PM" src="https://user-images.githubusercontent.com/59710443/99431979-63e95500-28c0-11eb-8c1d-d08fa087d7d5.png">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
