### PR TITLE
Add multi node integration testing into CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,10 @@ jobs:
           ./gradlew build
           ls -ltr build/distributions/
 
+      - name: Multi Nodes Integration Testing
+        run: |
+          ./gradlew integTest  -PnumNodes=3
+
       - name: Pull and Run Docker
         run: |
           plugin=`ls build/distributions/*.zip`


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/194
*Description of changes:*
Add multi node integration testing into CI workflow

*Testing:* 

- [x] Verified in desktop with ```./gradlew integTest  -PnumNodes=3``` 3 ES nodes are running during the testing
- [x] The workflow works well: https://github.com/opendistro-for-elasticsearch/anomaly-detection/runs/1448785594?check_suite_focus=true
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
