### PR TITLE
fix delete running detector bug

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -80,23 +80,6 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
         // to the detector. This is filtered by our Search Detector API.
         try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
             getDetectorJob(detectorId, listener, () -> deleteAnomalyDetectorJobDoc(detectorId, listener));
-
-            DeleteRequest deleteRequest = new DeleteRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, detectorId)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-            client.delete(deleteRequest, ActionListener.wrap(response -> {
-                if (response.getResult() == DocWriteResponse.Result.DELETED || response.getResult() == DocWriteResponse.Result.NOT_FOUND) {
-                    deleteDetectorStateDoc(detectorId, listener);
-                } else {
-                    LOG.error("Fail to delete anomaly detector job {}", detectorId);
-                }
-            }, exception -> {
-                if (exception instanceof IndexNotFoundException) {
-                    deleteDetectorStateDoc(detectorId, listener);
-                } else {
-                    LOG.error("Failed to delete anomaly detector job", exception);
-                    listener.onFailure(exception);
-                }
-            }));
         } catch (Exception e) {
             LOG.error(e);
             listener.onFailure(e);


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/anomaly-detection/issues/304

*Description of changes:*

We should not delete detector if it's running.

Test: 
Run ./gradlew run and test deleting running detector will fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
