### PR TITLE
fix detector and feature serialization

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/Feature.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/Feature.java
@@ -80,7 +80,7 @@ public class Feature implements Writeable, ToXContentObject {
         out.writeString(this.id);
         out.writeString(this.name);
         out.writeBoolean(this.enabled);
-        aggregation.writeTo(out);
+        out.writeNamedWriteable(aggregation);
     }
 
     @Override

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorSerializationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorSerializationTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class AnomalyDetectorSerializationTests extends ESSingleNodeTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return getInstanceFromNode(NamedWriteableRegistry.class);
+    }
+
+    public void testDetectorWithUiMetadata() throws IOException {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());
+        BytesStreamOutput output = new BytesStreamOutput();
+        System.out.println(detector.toString());
+        detector.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyDetector parsedDetector = new AnomalyDetector(input);
+        assertTrue(parsedDetector.equals(detector));
+    }
+
+    public void testDetectorWithoutUiMetadata() throws IOException {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(null, Instant.now());
+        BytesStreamOutput output = new BytesStreamOutput();
+        System.out.println(detector.toString());
+        detector.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyDetector parsedDetector = new AnomalyDetector(input);
+        assertTrue(parsedDetector.equals(detector));
+    }
+
+    public void testHCDetector() throws IOException {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields("testId", ImmutableList.of("category_field"));
+        BytesStreamOutput output = new BytesStreamOutput();
+        System.out.println(detector.toString());
+        detector.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyDetector parsedDetector = new AnomalyDetector(input);
+        assertTrue(parsedDetector.equals(detector));
+    }
+
+    public void testWithoutUser() throws IOException {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields("testId", ImmutableList.of("category_field"));
+        detector.setUser(null);
+        BytesStreamOutput output = new BytesStreamOutput();
+        System.out.println(detector.toString());
+        detector.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyDetector parsedDetector = new AnomalyDetector(input);
+        assertTrue(parsedDetector.equals(detector));
+    }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

## Description of changes:
Detector and feature serialization has issue, see such error:
```
[2020-12-03T03:10:00,566][ERROR][c.a.o.a.t.ADTaskManager  ] [node-1] Fail to execute batch task action BYSTJnYBeb-NN24R-TEn
org.elasticsearch.transport.RemoteTransportException: [node-3][127.0.0.1:9302][cluster:admin/opendistro/ad/detector/batch_run_remotely]
Caused by: java.lang.IllegalArgumentException: Unknown NamedWriteable [org.elasticsearch.search.aggregations.PipelineAggregationBuilder][value]
	at org.elasticsearch.common.io.stream.NamedWriteableRegistry.getReader(NamedWriteableRegistry.java:112) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput.readNamedWriteable(NamedWriteableAwareStreamInput.java:45) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput.readNamedWriteable(NamedWriteableAwareStreamInput.java:39) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.search.aggregations.AggregatorFactories$Builder.<init>(AggregatorFactories.java:258) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.search.aggregations.AbstractAggregationBuilder.<init>(AbstractAggregationBuilder.java:60) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder.<init>(ValuesSourceAggregationBuilder.java:166) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder$LeafOnly.<init>(ValuesSourceAggregationBuilder.java:122) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder.<init>(SumAggregationBuilder.java:75) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput.readNamedWriteable(NamedWriteableAwareStreamInput.java:46) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput.readNamedWriteable(NamedWriteableAwareStreamInput.java:39) ~[elasticsearch-7.10.0.jar:7.10.0]
	at com.amazon.opendistroforelasticsearch.ad.model.Feature.<init>(Feature.java:75) ~[?:?]
	at org.elasticsearch.common.io.stream.StreamInput.readCollection(StreamInput.java:1220) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.common.io.stream.StreamInput.readList(StreamInput.java:1170) ~[elasticsearch-7.10.0.jar:7.10.0]
	at com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.<init>(AnomalyDetector.java:275) ~[?:?]
	at com.amazon.opendistroforelasticsearch.ad.model.ADTask.<init>(ADTask.java:89) ~[?:?]
	at com.amazon.opendistroforelasticsearch.ad.transport.ADBatchAnomalyResultRequest.<init>(ADBatchAnomalyResultRequest.java:43) ~[?:?]
	at org.elasticsearch.transport.RequestHandlerRegistry.newRequest(RequestHandlerRegistry.java:59) ~[elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.transport.InboundHandler.handleRequest(InboundHandler.java:195) [elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.transport.InboundHandler.messageReceived(InboundHandler.java:107) [elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.transport.InboundHandler.inboundMessage(InboundHandler.java:89) [elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.transport.TcpTransport.inboundMessage(TcpTransport.java:700) [elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.transport.InboundPipeline.forwardFragments(InboundPipeline.java:142) [elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.transport.InboundPipeline.doHandleBytes(InboundPipeline.java:117) [elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.transport.InboundPipeline.handleBytes(InboundPipeline.java:82) [elasticsearch-7.10.0.jar:7.10.0]
	at org.elasticsearch.transport.netty4.Netty4MessageChannelHandler.channelRead(Netty4MessageChannelHandler.java:74) [transport-netty4-client-7.10.0.jar:7.10.0]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:271) [netty-handler-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[netty-codec-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:714) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysPlain(NioEventLoop.java:615) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:578) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493) [netty-transport-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989) [netty-common-4.1.49.Final.jar:4.1.49.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) [netty-common-4.1.49.Final.jar:4.1.49.Final]
	at java.lang.Thread.run(Thread.java:832) [?:?]
```

## Changes
This PR fixed serialization of anomaly detector and feature by writing to and reading from stream. 

## Test
1.Add unit test cases for serialization of anomaly detector and feature
2.`./gradlew build` pass 
3.`./gradlew run` and test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
