### PR TITLE
Moving common-utils to 1.12.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -346,7 +346,7 @@ dependencies {
     compile "org.elasticsearch:elasticsearch:${es_version}"
     compileOnly "org.elasticsearch.plugin:elasticsearch-scripting-painless-spi:${versions.elasticsearch}"
     compileOnly "com.amazon.opendistroforelasticsearch:opendistro-job-scheduler-spi:1.12.0.0"
-    compile "com.amazon.opendistroforelasticsearch:common-utils:1.12.0.0"
+    compile "com.amazon.opendistroforelasticsearch:common-utils:1.12.0.2"
     compile group: 'com.google.guava', name: 'guava', version:'29.0-jre'
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
@@ -445,7 +445,7 @@ public final class ParseUtils {
     }
 
     public static User getUserContext(Client client) {
-        String userStr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER_AND_ROLES);
+        String userStr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         logger.debug("Filtering result by " + userStr);
         return User.parse(userStr);
     }


### PR DESCRIPTION
*Description of changes:* Moving the common-utils library to 1.12.0.2 consume latest changes in the security plugin.
Refer to commit: https://github.com/opendistro-for-elasticsearch/security/commit/7131b6a7ed2716697d7425ed441dcb7484f0b4ef




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
