### PR TITLE
add AD task and tune detector&AD result data model

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
@@ -1,0 +1,521 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import com.amazon.opendistroforelasticsearch.ad.annotation.Generated;
+import com.amazon.opendistroforelasticsearch.ad.util.ParseUtils;
+import com.google.common.base.Objects;
+
+/**
+ * One anomaly detection task means one detector starts to run until stopped.
+ */
+public class ADTask implements ToXContentObject, Writeable {
+
+    public static final String DETECTOR_STATE_INDEX = ".opendistro-anomaly-detection-state";
+
+    public static final String TASK_ID_FIELD = "task_id";
+    public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
+    public static final String STARTED_BY_FIELD = "started_by";
+    public static final String STOPPED_BY_FIELD = "stopped_by";
+    public static final String ERROR_FIELD = "error";
+    public static final String STATE_FIELD = "state";
+    public static final String DETECTOR_ID_FIELD = "detector_id";
+    public static final String TASK_PROGRESS_FIELD = "task_progress";
+    public static final String INIT_PROGRESS_FIELD = "init_progress";
+    public static final String CURRENT_PIECE_FIELD = "current_piece";
+    public static final String EXECUTION_START_TIME_FIELD = "execution_start_time";
+    public static final String EXECUTION_END_TIME_FIELD = "execution_end_time";
+    public static final String IS_LATEST_FIELD = "is_latest";
+    public static final String TASK_TYPE_FIELD = "task_type";
+    public static final String CHECKPOINT_ID_FIELD = "checkpoint_id";
+    public static final String DETECTOR_FIELD = "detector";
+
+    private String taskId = null;
+    private Instant lastUpdateTime = null;
+    private String startedBy = null;
+    private String stoppedBy = null;
+    private String error = null;
+    private String state = null;
+    private String detectorId = null;
+    private Float taskProgress = null;
+    private Float initProgress = null;
+    private Instant currentPiece = null;
+    private Instant executionStartTime = null;
+    private Instant executionEndTime = null;
+    private Boolean isLatest = null;
+    private String taskType = null;
+    private String checkpointId = null;
+    private AnomalyDetector detector = null;
+
+    private ADTask() {}
+
+    public ADTask(StreamInput input) throws IOException {
+        this.taskId = input.readOptionalString();
+        this.taskType = input.readOptionalString();
+        this.detectorId = input.readOptionalString();
+        if (input.readBoolean()) {
+            this.detector = new AnomalyDetector(input);
+        } else {
+            this.detector = null;
+        }
+        this.state = input.readOptionalString();
+        this.taskProgress = input.readOptionalFloat();
+        this.initProgress = input.readOptionalFloat();
+        this.currentPiece = input.readOptionalInstant();
+        this.executionStartTime = input.readOptionalInstant();
+        this.executionEndTime = input.readOptionalInstant();
+        this.isLatest = input.readOptionalBoolean();
+        this.error = input.readOptionalString();
+        this.checkpointId = input.readOptionalString();
+        this.lastUpdateTime = input.readOptionalInstant();
+        this.startedBy = input.readOptionalString();
+        this.stoppedBy = input.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(taskId);
+        out.writeOptionalString(taskType);
+        out.writeOptionalString(detectorId);
+        if (detector != null) {
+            out.writeBoolean(true);
+            detector.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+        out.writeOptionalString(state);
+        out.writeOptionalFloat(taskProgress);
+        out.writeOptionalFloat(initProgress);
+        out.writeOptionalInstant(currentPiece);
+        out.writeOptionalInstant(executionStartTime);
+        out.writeOptionalInstant(executionEndTime);
+        out.writeOptionalBoolean(isLatest);
+        out.writeOptionalString(error);
+        out.writeOptionalString(checkpointId);
+        out.writeOptionalInstant(lastUpdateTime);
+        out.writeOptionalString(startedBy);
+        out.writeOptionalString(stoppedBy);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String taskId = null;
+        private String taskType = null;
+        private String detectorId = null;
+        private AnomalyDetector detector = null;
+        private String state = null;
+        private Float taskProgress = null;
+        private Float initProgress = null;
+        private Instant currentPiece = null;
+        private Instant executionStartTime = null;
+        private Instant executionEndTime = null;
+        private Boolean isLatest = null;
+        private String error = null;
+        private String checkpointId = null;
+        private Instant lastUpdateTime = null;
+        private String startedBy = null;
+        private String stoppedBy = null;
+
+        public Builder() {}
+
+        public Builder taskId(String taskId) {
+            this.taskId = taskId;
+            return this;
+        }
+
+        public Builder lastUpdateTime(Instant lastUpdateTime) {
+            this.lastUpdateTime = lastUpdateTime;
+            return this;
+        }
+
+        public Builder startedBy(String startedBy) {
+            this.startedBy = startedBy;
+            return this;
+        }
+
+        public Builder stoppedBy(String stoppedBy) {
+            this.stoppedBy = stoppedBy;
+            return this;
+        }
+
+        public Builder error(String error) {
+            this.error = error;
+            return this;
+        }
+
+        public Builder state(String state) {
+            this.state = state;
+            return this;
+        }
+
+        public Builder detectorId(String detectorId) {
+            this.detectorId = detectorId;
+            return this;
+        }
+
+        public Builder taskProgress(Float taskProgress) {
+            this.taskProgress = taskProgress;
+            return this;
+        }
+
+        public Builder initProgress(Float initProgress) {
+            this.initProgress = initProgress;
+            return this;
+        }
+
+        public Builder currentPiece(Instant currentPiece) {
+            this.currentPiece = currentPiece;
+            return this;
+        }
+
+        public Builder executionStartTime(Instant executionStartTime) {
+            this.executionStartTime = executionStartTime;
+            return this;
+        }
+
+        public Builder executionEndTime(Instant executionEndTime) {
+            this.executionEndTime = executionEndTime;
+            return this;
+        }
+
+        public Builder isLatest(Boolean isLatest) {
+            this.isLatest = isLatest;
+            return this;
+        }
+
+        public Builder taskType(String taskType) {
+            this.taskType = taskType;
+            return this;
+        }
+
+        public Builder checkpointId(String checkpointId) {
+            this.checkpointId = checkpointId;
+            return this;
+        }
+
+        public Builder detector(AnomalyDetector detector) {
+            this.detector = detector;
+            return this;
+        }
+
+        public ADTask build() {
+            ADTask adTask = new ADTask();
+            adTask.taskId = this.taskId;
+            adTask.lastUpdateTime = this.lastUpdateTime;
+            adTask.error = this.error;
+            adTask.state = this.state;
+            adTask.detectorId = this.detectorId;
+            adTask.taskProgress = this.taskProgress;
+            adTask.initProgress = this.initProgress;
+            adTask.currentPiece = this.currentPiece;
+            adTask.executionStartTime = this.executionStartTime;
+            adTask.executionEndTime = this.executionEndTime;
+            adTask.isLatest = this.isLatest;
+            adTask.taskType = this.taskType;
+            adTask.checkpointId = this.checkpointId;
+            adTask.detector = this.detector;
+            adTask.startedBy = this.startedBy;
+            adTask.stoppedBy = this.stoppedBy;
+
+            return adTask;
+        }
+
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        if (taskId != null) {
+            xContentBuilder.field(TASK_ID_FIELD, taskId);
+        }
+        if (lastUpdateTime != null) {
+            xContentBuilder.field(LAST_UPDATE_TIME_FIELD, lastUpdateTime.toEpochMilli());
+        }
+        if (startedBy != null) {
+            xContentBuilder.field(STARTED_BY_FIELD, startedBy);
+        }
+        if (stoppedBy != null) {
+            xContentBuilder.field(STOPPED_BY_FIELD, stoppedBy);
+        }
+        if (error != null) {
+            xContentBuilder.field(ERROR_FIELD, error);
+        }
+        if (state != null) {
+            xContentBuilder.field(STATE_FIELD, state);
+        }
+        if (detectorId != null) {
+            xContentBuilder.field(DETECTOR_ID_FIELD, detectorId);
+        }
+        if (taskProgress != null) {
+            xContentBuilder.field(TASK_PROGRESS_FIELD, taskProgress);
+        }
+        if (initProgress != null) {
+            xContentBuilder.field(INIT_PROGRESS_FIELD, initProgress);
+        }
+        if (currentPiece != null) {
+            xContentBuilder.field(CURRENT_PIECE_FIELD, currentPiece.toEpochMilli());
+        }
+        if (executionStartTime != null) {
+            xContentBuilder.field(EXECUTION_START_TIME_FIELD, executionStartTime.toEpochMilli());
+        }
+        if (executionEndTime != null) {
+            xContentBuilder.field(EXECUTION_END_TIME_FIELD, executionEndTime.toEpochMilli());
+        }
+        if (isLatest != null) {
+            xContentBuilder.field(IS_LATEST_FIELD, isLatest);
+        }
+        if (taskType != null) {
+            xContentBuilder.field(TASK_TYPE_FIELD, taskType);
+        }
+        if (checkpointId != null) {
+            xContentBuilder.field(CHECKPOINT_ID_FIELD, checkpointId);
+        }
+        if (detector != null) {
+            xContentBuilder.field(DETECTOR_FIELD, detector);
+        }
+        return xContentBuilder.endObject();
+    }
+
+    public static ADTask parse(XContentParser parser) throws IOException {
+        return parse(parser, null);
+    }
+
+    public static ADTask parse(XContentParser parser, String taskId) throws IOException {
+        Instant lastUpdateTime = null;
+        String startedBy = null;
+        String stoppedBy = null;
+        String error = null;
+        String state = null;
+        String detectorId = null;
+        Float taskProgress = null;
+        Float initProgress = null;
+        Instant currentPiece = null;
+        Instant executionStartTime = null;
+        Instant executionEndTime = null;
+        Boolean isLatest = null;
+        String taskType = null;
+        String checkpointId = null;
+        AnomalyDetector detector = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case LAST_UPDATE_TIME_FIELD:
+                    lastUpdateTime = ParseUtils.toInstant(parser);
+                    break;
+                case STARTED_BY_FIELD:
+                    startedBy = parser.text();
+                    break;
+                case STOPPED_BY_FIELD:
+                    stoppedBy = parser.text();
+                    break;
+                case ERROR_FIELD:
+                    error = parser.text();
+                    break;
+                case STATE_FIELD:
+                    state = parser.text();
+                    break;
+                case DETECTOR_ID_FIELD:
+                    detectorId = parser.text();
+                    break;
+                case TASK_PROGRESS_FIELD:
+                    taskProgress = parser.floatValue();
+                    break;
+                case INIT_PROGRESS_FIELD:
+                    initProgress = parser.floatValue();
+                    break;
+                case CURRENT_PIECE_FIELD:
+                    currentPiece = ParseUtils.toInstant(parser);
+                    break;
+                case EXECUTION_START_TIME_FIELD:
+                    executionStartTime = ParseUtils.toInstant(parser);
+                    break;
+                case EXECUTION_END_TIME_FIELD:
+                    executionEndTime = ParseUtils.toInstant(parser);
+                    break;
+                case IS_LATEST_FIELD:
+                    isLatest = parser.booleanValue();
+                    break;
+                case TASK_TYPE_FIELD:
+                    taskType = parser.text();
+                    break;
+                case CHECKPOINT_ID_FIELD:
+                    checkpointId = parser.text();
+                    break;
+                case DETECTOR_FIELD:
+                    detector = AnomalyDetector.parse(parser);
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return new Builder()
+            .taskId(taskId)
+            .lastUpdateTime(lastUpdateTime)
+            .startedBy(startedBy)
+            .stoppedBy(stoppedBy)
+            .error(error)
+            .state(state)
+            .detectorId(detectorId)
+            .taskProgress(taskProgress)
+            .initProgress(initProgress)
+            .currentPiece(currentPiece)
+            .executionStartTime(executionStartTime)
+            .executionEndTime(executionEndTime)
+            .isLatest(isLatest)
+            .taskType(taskType)
+            .checkpointId(checkpointId)
+            .detector(detector)
+            .build();
+    }
+
+    @Generated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ADTask that = (ADTask) o;
+        return Objects.equal(getTaskId(), that.getTaskId())
+            && Objects.equal(getLastUpdateTime(), that.getLastUpdateTime())
+            && Objects.equal(getStartedBy(), that.getStartedBy())
+            && Objects.equal(getStoppedBy(), that.getStoppedBy())
+            && Objects.equal(getError(), that.getError())
+            && Objects.equal(getState(), that.getState())
+            && Objects.equal(getDetectorId(), that.getDetectorId())
+            && Objects.equal(getTaskProgress(), that.getTaskProgress())
+            && Objects.equal(getInitProgress(), that.getInitProgress())
+            && Objects.equal(getCurrentPiece(), that.getCurrentPiece())
+            && Objects.equal(getExecutionStartTime(), that.getExecutionStartTime())
+            && Objects.equal(getExecutionEndTime(), that.getExecutionEndTime())
+            && Objects.equal(getLatest(), that.getLatest())
+            && Objects.equal(getTaskType(), that.getTaskType())
+            && Objects.equal(getCheckpointId(), that.getCheckpointId())
+            && Objects.equal(getDetector(), that.getDetector());
+    }
+
+    @Generated
+    @Override
+    public int hashCode() {
+        return Objects
+            .hashCode(
+                taskId,
+                lastUpdateTime,
+                startedBy,
+                stoppedBy,
+                error,
+                state,
+                detectorId,
+                taskProgress,
+                initProgress,
+                currentPiece,
+                executionStartTime,
+                executionEndTime,
+                isLatest,
+                taskType,
+                checkpointId,
+                detector
+            );
+    }
+
+    public String getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(String taskId) {
+        this.taskId = taskId;
+    }
+
+    public Instant getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public String getStartedBy() {
+        return startedBy;
+    }
+
+    public String getStoppedBy() {
+        return stoppedBy;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public String getDetectorId() {
+        return detectorId;
+    }
+
+    public Float getTaskProgress() {
+        return taskProgress;
+    }
+
+    public Float getInitProgress() {
+        return initProgress;
+    }
+
+    public Instant getCurrentPiece() {
+        return currentPiece;
+    }
+
+    public Instant getExecutionStartTime() {
+        return executionStartTime;
+    }
+
+    public Instant getExecutionEndTime() {
+        return executionEndTime;
+    }
+
+    public Boolean getLatest() {
+        return isLatest;
+    }
+
+    public String getTaskType() {
+        return taskType;
+    }
+
+    public String getCheckpointId() {
+        return checkpointId;
+    }
+
+    public AnomalyDetector getDetector() {
+        return detector;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskState.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+public enum ADTaskState {
+    CREATED,
+    INIT,
+    RUNNING,
+    FAILED,
+    STOPPED,
+    FINISHED
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskState.java
@@ -15,6 +15,40 @@
 
 package com.amazon.opendistroforelasticsearch.ad.model;
 
+/**
+ * AD task states.
+ * <ul>
+ * <li><code>CREATED</code>:
+ *     When user start a historical detector, we will create one task to track the detector
+ *     execution and set its state as CREATED
+ *
+ * <li><code>INIT</code>:
+ *     After task created, coordinate node will gather all eligible node’s state and dispatch
+ *     task to the worker node with lowest load. When the worker node receives the request,
+ *     it will set the task state as INIT immediately, then start to run cold start to train
+ *     RCF model. We will track the initialization progress in task.
+ *     Init_Progress=ModelUpdates/MinSampleSize
+ *
+ * <li><code>RUNNING</code>:
+ *     If RCF model gets enough data points and passed training, it will start to detect data
+ *     normally and output positive anomaly scores. Once the RCF model starts to output positive
+ *     anomaly score, we will set the task state as RUNNING and init progress as 100%. We will
+ *     track task running progress in task: Task_Progress=DetectedPieces/AllPieces
+ *
+ * <li><code>FINISHED</code>:
+ *     When all historical data detected, we set the task state as FINISHED and task progress
+ *     as 100%.
+ *
+ * <li><code>STOPPED</code>:
+ *     User can cancel a running task by stopping detector, for example, user want to tune
+ *     feature and reran and don’t want current task run any more. When a historical detector
+ *     stopped, we will mark the task flag cancelled as true, when run next piece, we will
+ *     check this flag and stop the task. Then task stopped, will set its state as STOPPED
+ *
+ * <li><code>FAILED</code>:
+ *     If any exception happen, we will set task state as FAILED
+ * </ul>
+ */
 public enum ADTaskState {
     CREATED,
     INIT,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskType.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+public enum ADTaskType {
+    REALTIME,
+    HISTORICAL
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -43,7 +43,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
 
 import com.amazon.opendistroforelasticsearch.ad.annotation.Generated;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
@@ -226,31 +225,15 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     public AnomalyDetector(StreamInput input) throws IOException {
         detectorId = input.readString();
         version = input.readLong();
-        String name = input.readString();
-        if (Strings.isBlank(name)) {
-            throw new IllegalArgumentException("Detector name should be set");
-        }
-        this.name = name;
+        name = input.readString();
         description = input.readString();
-        String timeField = input.readString();
-        if (timeField == null) {
-            throw new IllegalArgumentException("Time field should be set");
-        }
-        this.timeField = timeField;
-        List<String> indices = input.readStringList();
-        if (indices == null || indices.isEmpty()) {
-            throw new IllegalArgumentException("Indices should be set");
-        }
-        this.indices = indices;
+        timeField = input.readString();
+        indices = input.readStringList();
         featureAttributes = input.readList(Feature::new);
         filterQuery = input.readNamedWriteable(QueryBuilder.class);
         detectionInterval = IntervalTimeConfiguration.readFrom(input);
         windowDelay = IntervalTimeConfiguration.readFrom(input);
-        Integer shingleSize = input.readInt();
-        if (shingleSize != null && shingleSize < 1) {
-            throw new IllegalArgumentException("Shingle size must be a positive integer");
-        }
-        this.shingleSize = shingleSize;
+        shingleSize = input.readInt();
         schemaVersion = input.readInt();
         this.categoryFields = input.readOptionalStringList();
         lastUpdateTime = input.readInstant();
@@ -518,14 +501,6 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
             detectorType,
             detectionDateRange
         );
-    }
-
-    public SearchSourceBuilder generateFeatureQuery() {
-        SearchSourceBuilder generatedFeatureQuery = new SearchSourceBuilder().query(filterQuery);
-        if (this.getFeatureAttributes() != null) {
-            this.getFeatureAttributes().stream().forEach(feature -> generatedFeatureQuery.aggregation(feature.getAggregation()));
-        }
-        return generatedFeatureQuery;
     }
 
     @Generated

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -202,6 +202,9 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         if (categoryFields != null && categoryFields.size() > CATEGORY_FIELD_LIMIT) {
             throw new IllegalArgumentException(CommonErrorMessages.CATEGORICAL_FIELD_NUMBER_SURPASSED + CATEGORY_FIELD_LIMIT);
         }
+        if (((IntervalTimeConfiguration) detectionInterval).getInterval() <= 0) {
+            throw new IllegalArgumentException("Detection interval must be a positive integer");
+        }
         this.detectorId = detectorId;
         this.version = version;
         this.name = name;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -478,11 +478,11 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         if (AnomalyDetector.isRealTimeDetector(detectionDateRange)) {
             detectorType = AnomalyDetector.isMultientityDetector(categoryField)
                 ? AnomalyDetectorType.REALTIME_MULTI_ENTITY.name()
-                : AnomalyDetectorType.REALTIME_SIGLE_ENTITY.name();
+                : AnomalyDetectorType.REALTIME_SINGLE_ENTITY.name();
         } else {
             detectorType = AnomalyDetector.isMultientityDetector(categoryField)
                 ? AnomalyDetectorType.HISTORICAL_MULTI_ENTITY.name()
-                : AnomalyDetectorType.HISTORICAL_SIGLE_ENTITY.name();
+                : AnomalyDetectorType.HISTORICAL_SINGLE_ENTITY.name();
         }
         return new AnomalyDetector(
             detectorId,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorType.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorType.java
@@ -16,8 +16,8 @@
 package com.amazon.opendistroforelasticsearch.ad.model;
 
 public enum AnomalyDetectorType {
-    REALTIME_SIGLE_ENTITY,
+    REALTIME_SINGLE_ENTITY,
     REALTIME_MULTI_ENTITY,
-    HISTORICAL_SIGLE_ENTITY,
+    HISTORICAL_SINGLE_ENTITY,
     HISTORICAL_MULTI_ENTITY
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorType.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+public enum AnomalyDetectorType {
+    REALTIME_SIGLE_ENTITY,
+    REALTIME_MULTI_ENTITY,
+    HISTORICAL_SIGLE_ENTITY,
+    HISTORICAL_MULTI_ENTITY
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
@@ -183,7 +183,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         this.anomalyGrade = input.readDouble();
         this.confidence = input.readDouble();
         int featureSize = input.readVInt();
-        this.featureData = new ArrayList<FeatureData>(featureSize);
+        this.featureData = new ArrayList<>(featureSize);
         for (int i = 0; i < featureSize; i++) {
             featureData.add(new FeatureData(input));
         }
@@ -192,10 +192,14 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         this.executionStartTime = input.readInstant();
         this.executionEndTime = input.readInstant();
         this.error = input.readOptionalString();
-        int entitySize = input.readVInt();
-        this.entity = new ArrayList<Entity>(entitySize);
-        for (int i = 0; i < entitySize; i++) {
-            entity.add(new Entity(input));
+        if (input.readBoolean()) {
+            int entitySize = input.readVInt();
+            this.entity = new ArrayList<>(entitySize);
+            for (int i = 0; i < entitySize; i++) {
+                entity.add(new Entity(input));
+            }
+        } else {
+            this.entity = null;
         }
         if (input.readBoolean()) {
             this.user = new User(input);
@@ -409,7 +413,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         return detectorId;
     }
 
-    private String getTaskId() {
+    public String getTaskId() {
         return taskId;
     }
 
@@ -468,9 +472,14 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         out.writeInstant(executionStartTime);
         out.writeInstant(executionEndTime);
         out.writeOptionalString(error);
-        out.writeVInt(entity.size());
-        for (Entity entityItem : entity) {
-            entityItem.writeTo(out);
+        if (entity != null) {
+            out.writeBoolean(true);
+            out.writeVInt(entity.size());
+            for (Entity entityItem : entity) {
+                entityItem.writeTo(out);
+            }
+        } else {
+            out.writeBoolean(false);
         }
         if (user != null) {
             out.writeBoolean(true); // user exists

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResult.java
@@ -64,8 +64,10 @@ public class AnomalyResult implements ToXContentObject, Writeable {
     public static final String ERROR_FIELD = "error";
     public static final String ENTITY_FIELD = "entity";
     public static final String USER_FIELD = "user";
+    public static final String TASK_ID_FIELD = "task_id";
 
     private final String detectorId;
+    private final String taskId;
     private final Double anomalyScore;
     private final Double anomalyGrade;
     private final Double confidence;
@@ -125,7 +127,42 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         User user,
         Integer schemaVersion
     ) {
+        this(
+            detectorId,
+            null,
+            anomalyScore,
+            anomalyGrade,
+            confidence,
+            featureData,
+            dataStartTime,
+            dataEndTime,
+            executionStartTime,
+            executionEndTime,
+            error,
+            entity,
+            user,
+            schemaVersion
+        );
+    }
+
+    public AnomalyResult(
+        String detectorId,
+        String taskId,
+        Double anomalyScore,
+        Double anomalyGrade,
+        Double confidence,
+        List<FeatureData> featureData,
+        Instant dataStartTime,
+        Instant dataEndTime,
+        Instant executionStartTime,
+        Instant executionEndTime,
+        String error,
+        List<Entity> entity,
+        User user,
+        Integer schemaVersion
+    ) {
         this.detectorId = detectorId;
+        this.taskId = taskId;
         this.anomalyScore = anomalyScore;
         this.anomalyGrade = anomalyGrade;
         this.confidence = confidence;
@@ -166,6 +203,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             user = null;
         }
         this.schemaVersion = input.readInt();
+        this.taskId = input.readOptionalString();
     }
 
     @Override
@@ -206,6 +244,9 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         if (user != null) {
             xContentBuilder.field(USER_FIELD, user);
         }
+        if (taskId != null) {
+            xContentBuilder.field(TASK_ID_FIELD, taskId);
+        }
         return xContentBuilder.endObject();
     }
 
@@ -223,6 +264,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         List<Entity> entityList = null;
         User user = null;
         Integer schemaVersion = CommonValue.NO_SCHEMA_VERSION;
+        String taskId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -276,6 +318,9 @@ public class AnomalyResult implements ToXContentObject, Writeable {
                 case CommonName.SCHEMA_VERSION_FIELD:
                     schemaVersion = parser.intValue();
                     break;
+                case TASK_ID_FIELD:
+                    taskId = parser.text();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -283,6 +328,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         }
         return new AnomalyResult(
             detectorId,
+            taskId,
             anomalyScore,
             anomalyGrade,
             confidence,
@@ -307,6 +353,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             return false;
         AnomalyResult that = (AnomalyResult) o;
         return Objects.equal(getDetectorId(), that.getDetectorId())
+            && Objects.equal(getTaskId(), that.getTaskId())
             && Objects.equal(getAnomalyScore(), that.getAnomalyScore())
             && Objects.equal(getAnomalyGrade(), that.getAnomalyGrade())
             && Objects.equal(getConfidence(), that.getConfidence())
@@ -325,6 +372,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
         return Objects
             .hashCode(
                 getDetectorId(),
+                getTaskId(),
                 getAnomalyScore(),
                 getAnomalyGrade(),
                 getConfidence(),
@@ -343,6 +391,7 @@ public class AnomalyResult implements ToXContentObject, Writeable {
     public String toString() {
         return new ToStringBuilder(this)
             .append("detectorId", detectorId)
+            .append("taskId", taskId)
             .append("anomalyScore", anomalyScore)
             .append("anomalyGrade", anomalyGrade)
             .append("confidence", confidence)
@@ -358,6 +407,10 @@ public class AnomalyResult implements ToXContentObject, Writeable {
 
     public String getDetectorId() {
         return detectorId;
+    }
+
+    private String getTaskId() {
+        return taskId;
     }
 
     public Double getAnomalyScore() {
@@ -426,5 +479,6 @@ public class AnomalyResult implements ToXContentObject, Writeable {
             out.writeBoolean(false); // user does not exist
         }
         out.writeInt(schemaVersion);
+        out.writeOptionalString(taskId);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRange.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRange.java
@@ -43,6 +43,12 @@ public class DetectionDateRange implements ToXContentObject, Writeable {
     public DetectionDateRange(Instant startTime, Instant endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
+        if (startTime == null) {
+            throw new IllegalArgumentException("Detection data range's start time must not be null");
+        }
+        if (endTime == null) {
+            throw new IllegalArgumentException("Detection data range's end time must not be null");
+        }
     }
 
     public DetectionDateRange(StreamInput in) throws IOException {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRange.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRange.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import com.amazon.opendistroforelasticsearch.ad.annotation.Generated;
+import com.amazon.opendistroforelasticsearch.ad.util.ParseUtils;
+import com.google.common.base.Objects;
+
+public class DetectionDateRange implements ToXContentObject, Writeable {
+
+    public static final String START_TIME_FIELD = "start_time";
+    public static final String END_TIME_FIELD = "end_time";
+
+    private final Instant startTime;
+    private final Instant endTime;
+
+    public DetectionDateRange(Instant startTime, Instant endTime) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public DetectionDateRange(StreamInput in) throws IOException {
+        this.startTime = in.readOptionalInstant();
+        this.endTime = in.readOptionalInstant();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        if (startTime != null) {
+            xContentBuilder.field(START_TIME_FIELD, startTime.toEpochMilli());
+        }
+        if (endTime != null) {
+            xContentBuilder.field(END_TIME_FIELD, endTime.toEpochMilli());
+        }
+        return xContentBuilder.endObject();
+    }
+
+    public static DetectionDateRange parse(XContentParser parser) throws IOException {
+        Instant startTime = null;
+        Instant endTime = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case START_TIME_FIELD:
+                    startTime = ParseUtils.toInstant(parser);
+                    break;
+                case END_TIME_FIELD:
+                    endTime = ParseUtils.toInstant(parser);
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return new DetectionDateRange(startTime, endTime);
+    }
+
+    @Generated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        DetectionDateRange that = (DetectionDateRange) o;
+        return Objects.equal(getStartTime(), that.getStartTime()) && Objects.equal(getEndTime(), that.getEndTime());
+    }
+
+    @Generated
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getStartTime(), getEndTime());
+    }
+
+    @Generated
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).append("startTime", startTime).append("endTime", endTime).toString();
+    }
+
+    public Instant getStartTime() {
+        return startTime;
+    }
+
+    public Instant getEndTime() {
+        return endTime;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalInstant(startTime);
+        out.writeOptionalInstant(endTime);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRange.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRange.java
@@ -52,8 +52,8 @@ public class DetectionDateRange implements ToXContentObject, Writeable {
     }
 
     public DetectionDateRange(StreamInput in) throws IOException {
-        this.startTime = in.readOptionalInstant();
-        this.endTime = in.readOptionalInstant();
+        this.startTime = in.readInstant();
+        this.endTime = in.readInstant();
     }
 
     @Override
@@ -125,7 +125,7 @@ public class DetectionDateRange implements ToXContentObject, Writeable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeOptionalInstant(startTime);
-        out.writeOptionalInstant(endTime);
+        out.writeInstant(startTime);
+        out.writeInstant(endTime);
     }
 }

--- a/src/main/resources/mappings/anomaly-detection-state.json
+++ b/src/main/resources/mappings/anomaly-detection-state.json
@@ -1,7 +1,7 @@
 {
   "dynamic": false,
   "_meta": {
-    "schema_version": 1
+    "schema_version": 2
   },
   "properties": {
     "schema_version": {
@@ -13,6 +13,205 @@
     },
     "error": {
       "type": "text"
+    },
+    "started_by": {
+      "type": "keyword"
+    },
+    "stopped_by": {
+      "type": "keyword"
+    },
+    "detector_id": {
+      "type": "keyword"
+    },
+    "state": {
+      "type": "keyword"
+    },
+    "task_progress": {
+      "type": "float"
+    },
+    "init_progress": {
+      "type": "float"
+    },
+    "current_piece": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "execution_start_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "execution_end_time": {
+      "type": "date",
+      "format": "strict_date_time||epoch_millis"
+    },
+    "is_latest": {
+      "type": "boolean"
+    },
+    "task_type": {
+      "type": "keyword"
+    },
+    "checkpoint_id": {
+      "type": "keyword"
+    },
+    "detector": {
+      "properties": {
+        "schema_version": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "description": {
+          "type": "text"
+        },
+        "time_field": {
+          "type": "keyword"
+        },
+        "indices": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "filter_query": {
+          "type": "object",
+          "enabled": false
+        },
+        "feature_attributes": {
+          "type": "nested",
+          "properties": {
+            "feature_id": {
+              "type": "keyword",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "feature_name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "feature_enabled": {
+              "type": "boolean"
+            },
+            "aggregation_query": {
+              "type": "object",
+              "enabled": false
+            }
+          }
+        },
+        "detection_interval": {
+          "properties": {
+            "period": {
+              "properties": {
+                "interval": {
+                  "type": "integer"
+                },
+                "unit": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "window_delay": {
+          "properties": {
+            "period": {
+              "properties": {
+                "interval": {
+                  "type": "integer"
+                },
+                "unit": {
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "shingle_size": {
+          "type": "integer"
+        },
+        "last_update_time": {
+          "type": "date",
+          "format": "strict_date_time||epoch_millis"
+        },
+        "ui_metadata": {
+          "type": "object",
+          "enabled": false
+        },
+        "user": {
+          "type": "nested",
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "backend_roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "roles": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            },
+            "custom_attribute_names": {
+              "type" : "text",
+              "fields" : {
+                "keyword" : {
+                  "type" : "keyword"
+                }
+              }
+            }
+          }
+        },
+        "category_field": {
+          "type": "keyword"
+        },
+        "detector_type": {
+          "type": "keyword"
+        },
+        "detection_date_range": {
+          "properties": {
+            "start_time": {
+              "type": "date",
+              "format": "strict_date_time||epoch_millis"
+            },
+            "end_time": {
+              "type": "date",
+              "format": "strict_date_time||epoch_millis"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/src/main/resources/mappings/anomaly-detectors.json
+++ b/src/main/resources/mappings/anomaly-detectors.json
@@ -1,7 +1,7 @@
 {
   "dynamic": false,
   "_meta": {
-    "schema_version": 2
+    "schema_version": 3
   },
   "properties": {
     "schema_version": {
@@ -144,6 +144,21 @@
     },
     "category_field": {
       "type": "keyword"
+    },
+    "detector_type": {
+      "type": "keyword"
+    },
+    "detection_date_range": {
+      "properties": {
+        "start_time": {
+          "type": "date",
+          "format": "strict_date_time||epoch_millis"
+        },
+        "end_time": {
+          "type": "date",
+          "format": "strict_date_time||epoch_millis"
+        }
+      }
     }
   }
 }

--- a/src/main/resources/mappings/anomaly-results.json
+++ b/src/main/resources/mappings/anomaly-results.json
@@ -1,7 +1,7 @@
 {
   "dynamic": false,
   "_meta": {
-    "schema_version": 2
+    "schema_version": 3
   },
   "properties": {
     "detector_id": {
@@ -100,6 +100,9 @@
     },
     "schema_version": {
       "type": "integer"
+    },
+    "task_id": {
+      "type": "keyword"
     }
   }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -105,10 +105,14 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskType;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorExecutionInput;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.model.Entity;
 import com.amazon.opendistroforelasticsearch.ad.model.Feature;
@@ -203,16 +207,26 @@ public class TestHelpers {
     }
 
     public static AnomalyDetector randomAnomalyDetector(Map<String, Object> uiMetadata, Instant lastUpdateTime) throws IOException {
-        return randomAnomalyDetector(ImmutableList.of(randomFeature()), uiMetadata, lastUpdateTime);
+        return randomAnomalyDetector(ImmutableList.of(randomFeature()), uiMetadata, lastUpdateTime, null, null);
     }
 
     public static AnomalyDetector randomAnomalyDetector(Map<String, Object> uiMetadata, Instant lastUpdateTime, boolean featureEnabled)
         throws IOException {
-        return randomAnomalyDetector(ImmutableList.of(randomFeature(featureEnabled)), uiMetadata, lastUpdateTime);
+        return randomAnomalyDetector(ImmutableList.of(randomFeature(featureEnabled)), uiMetadata, lastUpdateTime, null, null);
     }
 
     public static AnomalyDetector randomAnomalyDetector(List<Feature> features, Map<String, Object> uiMetadata, Instant lastUpdateTime)
         throws IOException {
+        return randomAnomalyDetector(features, uiMetadata, lastUpdateTime, null, null);
+    }
+
+    public static AnomalyDetector randomAnomalyDetector(
+        List<Feature> features,
+        Map<String, Object> uiMetadata,
+        Instant lastUpdateTime,
+        String detectorType,
+        DetectionDateRange dateRange
+    ) throws IOException {
         return new AnomalyDetector(
             randomAlphaOfLength(10),
             randomLong(),
@@ -229,7 +243,16 @@ public class TestHelpers {
             randomInt(),
             lastUpdateTime,
             null,
-            randomUser()
+            randomUser(),
+            detectorType,
+            dateRange
+        );
+    }
+
+    public static DetectionDateRange randomDetectionDateRange() {
+        return new DetectionDateRange(
+            Instant.now().truncatedTo(ChronoUnit.SECONDS).minus(10, ChronoUnit.DAYS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS)
         );
     }
 
@@ -432,20 +455,21 @@ public class TestHelpers {
     }
 
     public static AnomalyResult randomAnomalyDetectResult() {
-        return randomAnomalyDetectResult(randomDouble(), randomAlphaOfLength(5));
+        return randomAnomalyDetectResult(randomDouble(), randomAlphaOfLength(5), null);
     }
 
     public static AnomalyResult randomAnomalyDetectResult(double score) {
-        return randomAnomalyDetectResult(randomDouble(), null);
+        return randomAnomalyDetectResult(randomDouble(), null, null);
     }
 
     public static AnomalyResult randomAnomalyDetectResult(String error) {
-        return randomAnomalyDetectResult(Double.NaN, error);
+        return randomAnomalyDetectResult(Double.NaN, error, null);
     }
 
-    public static AnomalyResult randomAnomalyDetectResult(double score, String error) {
+    public static AnomalyResult randomAnomalyDetectResult(double score, String error, String taskId) {
         return new AnomalyResult(
             randomAlphaOfLength(5),
+            taskId,
             score,
             randomDouble(),
             randomDouble(),
@@ -455,6 +479,7 @@ public class TestHelpers {
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             error,
+            null,
             randomUser(),
             CommonValue.NO_SCHEMA_VERSION
         );
@@ -662,10 +687,6 @@ public class TestHelpers {
         );
     }
 
-    public static AnomalyResult randomDetectState() {
-        return randomAnomalyDetectResult(randomDouble(), randomAlphaOfLength(5));
-    }
-
     public static DetectorInternalState randomDetectState(String error) {
         return randomDetectState(error, Instant.now());
     }
@@ -690,5 +711,33 @@ public class TestHelpers {
         );
         mappings.put(index, Collections.singletonMap(CommonName.MAPPING_TYPE, Collections.singletonMap(fieldName, fieldMappingMetadata)));
         return mappings;
+    }
+
+    public static ADTask randomAdTask(String taskId, ADTaskState state, Instant executionEndTime, String stoppedBy, boolean withDetector)
+        throws IOException {
+        AnomalyDetector detector = withDetector
+            ? randomAnomalyDetector(ImmutableMap.of(), Instant.now().truncatedTo(ChronoUnit.SECONDS))
+            : null;
+        executionEndTime = executionEndTime == null ? null : executionEndTime.truncatedTo(ChronoUnit.SECONDS);
+        ADTask task = ADTask
+            .builder()
+            .taskId(taskId)
+            .taskType(ADTaskType.HISTORICAL.name())
+            .detectorId(randomAlphaOfLength(5))
+            .detector(detector)
+            .state(state.name())
+            .taskProgress(0.5f)
+            .initProgress(1.0f)
+            .currentPiece(Instant.now().truncatedTo(ChronoUnit.SECONDS).minus(randomIntBetween(1, 100), ChronoUnit.MINUTES))
+            .executionStartTime(Instant.now().truncatedTo(ChronoUnit.SECONDS).minus(100, ChronoUnit.MINUTES))
+            .executionEndTime(executionEndTime)
+            .isLatest(true)
+            .error(randomAlphaOfLength(5))
+            .checkpointId(randomAlphaOfLength(5))
+            .lastUpdateTime(Instant.now().truncatedTo(ChronoUnit.SECONDS))
+            .startedBy(randomAlphaOfLength(5))
+            .stoppedBy(stoppedBy)
+            .build();
+        return task;
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -227,6 +227,18 @@ public class TestHelpers {
         String detectorType,
         DetectionDateRange dateRange
     ) throws IOException {
+        return randomAnomalyDetector(features, uiMetadata, lastUpdateTime, detectorType, dateRange, true);
+    }
+
+    public static AnomalyDetector randomAnomalyDetector(
+        List<Feature> features,
+        Map<String, Object> uiMetadata,
+        Instant lastUpdateTime,
+        String detectorType,
+        DetectionDateRange dateRange,
+        boolean withUser
+    ) throws IOException {
+        User user = withUser ? randomUser() : null;
         return new AnomalyDetector(
             randomAlphaOfLength(10),
             randomLong(),
@@ -243,7 +255,7 @@ public class TestHelpers {
             randomInt(),
             lastUpdateTime,
             null,
-            randomUser(),
+            user,
             detectorType,
             dateRange
         );
@@ -467,6 +479,11 @@ public class TestHelpers {
     }
 
     public static AnomalyResult randomAnomalyDetectResult(double score, String error, String taskId) {
+        return randomAnomalyDetectResult(score, error, taskId, true);
+    }
+
+    public static AnomalyResult randomAnomalyDetectResult(double score, String error, String taskId, boolean withUser) {
+        User user = withUser ? randomUser() : null;
         return new AnomalyResult(
             randomAlphaOfLength(5),
             taskId,
@@ -480,7 +497,7 @@ public class TestHelpers {
             Instant.now().truncatedTo(ChronoUnit.SECONDS),
             error,
             null,
-            randomUser(),
+            user,
             CommonValue.NO_SCHEMA_VERSION
         );
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
@@ -226,7 +226,6 @@ public class SearchFeatureDaoTests {
         detectionInterval = new IntervalTimeConfiguration(1, ChronoUnit.MINUTES);
         when(detector.getTimeField()).thenReturn("testTimeField");
         when(detector.getIndices()).thenReturn(Arrays.asList("testIndices"));
-        when(detector.generateFeatureQuery()).thenReturn(featureQuery);
         when(detector.getDetectionInterval()).thenReturn(detectionInterval);
         when(detector.getFilterQuery()).thenReturn(QueryBuilders.matchAllQuery());
         when(detector.getCategoryField()).thenReturn(Collections.singletonList("a"));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+
+public class ADTaskTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return getInstanceFromNode(NamedWriteableRegistry.class);
+    }
+
+    public void testAdTaskSerialization() throws IOException {
+        ADTask adTask = TestHelpers.randomAdTask(randomAlphaOfLength(5), ADTaskState.STOPPED, Instant.now(), randomAlphaOfLength(5), true);
+        BytesStreamOutput output = new BytesStreamOutput();
+        adTask.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        ADTask parsedADTask = new ADTask(input);
+        assertEquals("AD task serialization doesn't work", adTask, parsedADTask);
+    }
+
+    public void testAdTaskSerializationWithNullDetector() throws IOException {
+        ADTask adTask = TestHelpers.randomAdTask(randomAlphaOfLength(5), ADTaskState.STOPPED, Instant.now(), randomAlphaOfLength(5), false);
+        BytesStreamOutput output = new BytesStreamOutput();
+        adTask.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        ADTask parsedADTask = new ADTask(input);
+        assertEquals("AD task serialization doesn't work", adTask, parsedADTask);
+    }
+
+    public void testParseADTask() throws IOException {
+        ADTask adTask = TestHelpers
+            .randomAdTask(null, ADTaskState.STOPPED, Instant.now().truncatedTo(ChronoUnit.SECONDS), randomAlphaOfLength(5), true);
+        String taskId = randomAlphaOfLength(5);
+        adTask.setTaskId(taskId);
+        String adTaskString = TestHelpers.xContentBuilderToString(adTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADTask parsedADTask = ADTask.parse(TestHelpers.parser(adTaskString), adTask.getTaskId());
+        assertEquals("Parsing AD task doesn't work", adTask, parsedADTask);
+    }
+
+    public void testParseADTaskWithoutTaskId() throws IOException {
+        String taskId = null;
+        ADTask adTask = TestHelpers
+            .randomAdTask(taskId, ADTaskState.STOPPED, Instant.now().truncatedTo(ChronoUnit.SECONDS), randomAlphaOfLength(5), true);
+        String adTaskString = TestHelpers.xContentBuilderToString(adTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADTask parsedADTask = ADTask.parse(TestHelpers.parser(adTaskString));
+        assertEquals("Parsing AD task doesn't work", adTask, parsedADTask);
+    }
+
+    public void testParseADTaskWithNullDetector() throws IOException {
+        String taskId = randomAlphaOfLength(5);
+        ADTask adTask = TestHelpers
+            .randomAdTask(taskId, ADTaskState.STOPPED, Instant.now().truncatedTo(ChronoUnit.SECONDS), randomAlphaOfLength(5), false);
+        String adTaskString = TestHelpers.xContentBuilderToString(adTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADTask parsedADTask = ADTask.parse(TestHelpers.parser(adTaskString), taskId);
+        assertEquals("Parsing AD task doesn't work", adTask, parsedADTask);
+    }
+
+    public void testParseNullableFields() throws IOException {
+        ADTask adTask = ADTask.builder().build();
+        String adTaskString = TestHelpers.xContentBuilderToString(adTask.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        ADTask parsedADTask = ADTask.parse(TestHelpers.parser(adTaskString));
+        assertEquals("Parsing AD task doesn't work", adTask, parsedADTask);
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorSerializationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorSerializationTests.java
@@ -79,4 +79,20 @@ public class AnomalyDetectorSerializationTests extends ESSingleNodeTestCase {
         assertTrue(parsedDetector.equals(detector));
     }
 
+    public void testHistoricalDetector() throws IOException {
+        AnomalyDetector detector = TestHelpers
+            .randomAnomalyDetector(
+                ImmutableList.of(TestHelpers.randomFeature()),
+                ImmutableMap.of(randomAlphaOfLength(5), randomAlphaOfLength(5)),
+                Instant.now(),
+                AnomalyDetectorType.HISTORICAL_SIGLE_ENTITY.name(),
+                TestHelpers.randomDetectionDateRange()
+            );
+        BytesStreamOutput output = new BytesStreamOutput();
+        detector.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyDetector parsedDetector = new AnomalyDetector(input);
+        assertTrue(parsedDetector.equals(detector));
+    }
+
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorSerializationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorSerializationTests.java
@@ -45,7 +45,6 @@ public class AnomalyDetectorSerializationTests extends ESSingleNodeTestCase {
     public void testDetectorWithUiMetadata() throws IOException {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableMap.of("testKey", "testValue"), Instant.now());
         BytesStreamOutput output = new BytesStreamOutput();
-        System.out.println(detector.toString());
         detector.writeTo(output);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         AnomalyDetector parsedDetector = new AnomalyDetector(input);
@@ -55,7 +54,6 @@ public class AnomalyDetectorSerializationTests extends ESSingleNodeTestCase {
     public void testDetectorWithoutUiMetadata() throws IOException {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(null, Instant.now());
         BytesStreamOutput output = new BytesStreamOutput();
-        System.out.println(detector.toString());
         detector.writeTo(output);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         AnomalyDetector parsedDetector = new AnomalyDetector(input);
@@ -65,7 +63,6 @@ public class AnomalyDetectorSerializationTests extends ESSingleNodeTestCase {
     public void testHCDetector() throws IOException {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields("testId", ImmutableList.of("category_field"));
         BytesStreamOutput output = new BytesStreamOutput();
-        System.out.println(detector.toString());
         detector.writeTo(output);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         AnomalyDetector parsedDetector = new AnomalyDetector(input);
@@ -76,7 +73,6 @@ public class AnomalyDetectorSerializationTests extends ESSingleNodeTestCase {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields("testId", ImmutableList.of("category_field"));
         detector.setUser(null);
         BytesStreamOutput output = new BytesStreamOutput();
-        System.out.println(detector.toString());
         detector.writeTo(output);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         AnomalyDetector parsedDetector = new AnomalyDetector(input);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorSerializationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorSerializationTests.java
@@ -85,7 +85,7 @@ public class AnomalyDetectorSerializationTests extends ESSingleNodeTestCase {
                 ImmutableList.of(TestHelpers.randomFeature()),
                 ImmutableMap.of(randomAlphaOfLength(5), randomAlphaOfLength(5)),
                 Instant.now(),
-                AnomalyDetectorType.HISTORICAL_SIGLE_ENTITY.name(),
+                AnomalyDetectorType.HISTORICAL_SINGLE_ENTITY.name(),
                 TestHelpers.randomDetectionDateRange()
             );
         BytesStreamOutput output = new BytesStreamOutput();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -79,7 +79,7 @@ public class AnomalyDetectorTests extends AbstractADTest {
                 ImmutableList.of(TestHelpers.randomFeature()),
                 TestHelpers.randomUiMetadata(),
                 Instant.now(),
-                AnomalyDetectorType.HISTORICAL_SIGLE_ENTITY.name(),
+                AnomalyDetectorType.HISTORICAL_SINGLE_ENTITY.name(),
                 TestHelpers.randomDetectionDateRange()
             );
         String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
@@ -96,7 +96,7 @@ public class AnomalyDetectorTests extends AbstractADTest {
                 ImmutableList.of(TestHelpers.randomFeature()),
                 TestHelpers.randomUiMetadata(),
                 Instant.now(),
-                AnomalyDetectorType.HISTORICAL_SIGLE_ENTITY.name(),
+                AnomalyDetectorType.HISTORICAL_SINGLE_ENTITY.name(),
                 TestHelpers.randomDetectionDateRange(),
                 false
             );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -362,6 +362,60 @@ public class AnomalyDetectorTests extends AbstractADTest {
             );
     }
 
+    public void testInvalidDetectionInterval() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new AnomalyDetector(
+                randomAlphaOfLength(10),
+                randomLong(),
+                randomAlphaOfLength(20),
+                randomAlphaOfLength(30),
+                randomAlphaOfLength(5),
+                ImmutableList.of(randomAlphaOfLength(10).toLowerCase()),
+                ImmutableList.of(TestHelpers.randomFeature()),
+                TestHelpers.randomQuery(),
+                new IntervalTimeConfiguration(0, ChronoUnit.MINUTES),
+                TestHelpers.randomIntervalTimeConfiguration(),
+                randomIntBetween(1, 2000),
+                null,
+                randomInt(),
+                Instant.now(),
+                null,
+                null,
+                null,
+                null
+            )
+        );
+        assertEquals("Detection interval must be a positive integer", exception.getMessage());
+    }
+
+    public void testInvalidWindowDelay() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new AnomalyDetector(
+                randomAlphaOfLength(10),
+                randomLong(),
+                randomAlphaOfLength(20),
+                randomAlphaOfLength(30),
+                randomAlphaOfLength(5),
+                ImmutableList.of(randomAlphaOfLength(10).toLowerCase()),
+                ImmutableList.of(TestHelpers.randomFeature()),
+                TestHelpers.randomQuery(),
+                new IntervalTimeConfiguration(1, ChronoUnit.MINUTES),
+                new IntervalTimeConfiguration(-1, ChronoUnit.MINUTES),
+                randomIntBetween(1, 2000),
+                null,
+                randomInt(),
+                Instant.now(),
+                null,
+                null,
+                null,
+                null
+            )
+        );
+        assertEquals("Interval -1 should be non-negative", exception.getMessage());
+    }
+
     public void testNullFeatures() throws IOException {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(null, null, Instant.now().truncatedTo(ChronoUnit.SECONDS));
         String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -42,6 +42,23 @@ public class AnomalyDetectorTests extends AbstractADTest {
         assertEquals("Parsing anomaly detector doesn't work", detector, parsedDetector);
     }
 
+    public void testParseHistoricalAnomalyDetector() throws IOException {
+        AnomalyDetector detector = TestHelpers
+            .randomAnomalyDetector(
+                ImmutableList.of(TestHelpers.randomFeature()),
+                TestHelpers.randomUiMetadata(),
+                Instant.now(),
+                AnomalyDetectorType.HISTORICAL_SIGLE_ENTITY.name(),
+                TestHelpers.randomDetectionDateRange()
+            );
+        String detectorString = TestHelpers.xContentBuilderToString(detector.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        LOG.info(detectorString);
+        detectorString = detectorString
+            .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        AnomalyDetector parsedDetector = AnomalyDetector.parse(TestHelpers.parser(detectorString));
+        assertEquals("Parsing anomaly detector doesn't work", detector, parsedDetector);
+    }
+
     public void testParseAnomalyDetectorWithNullFilterQuery() throws IOException {
         String detectorString = "{\"name\":\"todagtCMkwpcaedpyYUM\",\"description\":"
             + "\"ClrcaMpuLfeDSlVduRcKlqPZyqWDBf\",\"time_field\":\"dJRwh\",\"indices\":[\"eIrgWMqAED\"],"

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResultTests.java
@@ -32,11 +32,7 @@ public class AnomalyResultTests extends ESTestCase {
         detectResultString = detectResultString
             .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
         AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
-        assertEquals(
-            "Parsing anomaly detect result doesn't work",
-            detectResult,
-            parsedDetectResult
-        );
+        assertEquals("Parsing anomaly detect result doesn't work", detectResult, parsedDetectResult);
     }
 
     public void testParseAnomalyDetectorWithTaskId() throws IOException {
@@ -46,11 +42,7 @@ public class AnomalyResultTests extends ESTestCase {
         detectResultString = detectResultString
             .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
         AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
-        assertEquals(
-            "Parsing anomaly detect result doesn't work",
-            detectResult,
-            parsedDetectResult
-        );
+        assertEquals("Parsing anomaly detect result doesn't work", detectResult, parsedDetectResult);
     }
 
     public void testParseAnomalyDetectorWithEntity() throws IOException {
@@ -60,10 +52,6 @@ public class AnomalyResultTests extends ESTestCase {
         detectResultString = detectResultString
             .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
         AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
-        assertEquals(
-            "Parsing anomaly detect result doesn't work",
-            detectResult,
-            parsedDetectResult
-        );
+        assertEquals("Parsing anomaly detect result doesn't work", detectResult, parsedDetectResult);
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResultTests.java
@@ -34,12 +34,6 @@ public class AnomalyResultTests extends ESTestCase {
         AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
         assertEquals(
             "Parsing anomaly detect result doesn't work",
-            // String.format(
-            // Locale.ROOT,
-            // "\"Parsing anomaly detect result doesn't work\". Expected %s, but get %s",
-            // detectResult,
-            // parsedDetectResult
-            // ),
             detectResult,
             parsedDetectResult
         );
@@ -54,12 +48,6 @@ public class AnomalyResultTests extends ESTestCase {
         AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
         assertEquals(
             "Parsing anomaly detect result doesn't work",
-            // String.format(
-            // Locale.ROOT,
-            // "\"Parsing anomaly detect result doesn't work\". Expected %s, but get %s",
-            // detectResult,
-            // parsedDetectResult
-            // ),
             detectResult,
             parsedDetectResult
         );
@@ -74,12 +62,6 @@ public class AnomalyResultTests extends ESTestCase {
         AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
         assertEquals(
             "Parsing anomaly detect result doesn't work",
-            // String.format(
-            // Locale.ROOT,
-            // "\"Parsing anomaly detect result doesn't work\". Expected %s, but get %s",
-            // detectResult,
-            // parsedDetectResult
-            // ),
             detectResult,
             parsedDetectResult
         );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResultTests.java
@@ -26,7 +26,47 @@ import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 public class AnomalyResultTests extends ESTestCase {
 
     public void testParseAnomalyDetector() throws IOException {
-        AnomalyResult detectResult = TestHelpers.randomAnomalyDetectResult();
+        AnomalyResult detectResult = TestHelpers.randomAnomalyDetectResult(0.8, randomAlphaOfLength(5), null);
+        String detectResultString = TestHelpers
+            .xContentBuilderToString(detectResult.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        detectResultString = detectResultString
+            .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
+        assertEquals(
+            "Parsing anomaly detect result doesn't work",
+            // String.format(
+            // Locale.ROOT,
+            // "\"Parsing anomaly detect result doesn't work\". Expected %s, but get %s",
+            // detectResult,
+            // parsedDetectResult
+            // ),
+            detectResult,
+            parsedDetectResult
+        );
+    }
+
+    public void testParseAnomalyDetectorWithTaskId() throws IOException {
+        AnomalyResult detectResult = TestHelpers.randomAnomalyDetectResult(0.8, randomAlphaOfLength(5), randomAlphaOfLength(5));
+        String detectResultString = TestHelpers
+            .xContentBuilderToString(detectResult.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        detectResultString = detectResultString
+            .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
+        assertEquals(
+            "Parsing anomaly detect result doesn't work",
+            // String.format(
+            // Locale.ROOT,
+            // "\"Parsing anomaly detect result doesn't work\". Expected %s, but get %s",
+            // detectResult,
+            // parsedDetectResult
+            // ),
+            detectResult,
+            parsedDetectResult
+        );
+    }
+
+    public void testParseAnomalyDetectorWithEntity() throws IOException {
+        AnomalyResult detectResult = TestHelpers.randomMultiEntityAnomalyDetectResult(0.8, 0.5);
         String detectResultString = TestHelpers
             .xContentBuilderToString(detectResult.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
         detectResultString = detectResultString

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyResultTests.java
@@ -16,14 +16,36 @@
 package com.amazon.opendistroforelasticsearch.ad.model;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.Locale;
 
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
 
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 
-public class AnomalyResultTests extends ESTestCase {
+public class AnomalyResultTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return getInstanceFromNode(NamedWriteableRegistry.class);
+    }
 
     public void testParseAnomalyDetector() throws IOException {
         AnomalyResult detectResult = TestHelpers.randomAnomalyDetectResult(0.8, randomAlphaOfLength(5), null);
@@ -33,6 +55,92 @@ public class AnomalyResultTests extends ESTestCase {
             .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
         AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
         assertEquals("Parsing anomaly detect result doesn't work", detectResult, parsedDetectResult);
+    }
+
+    public void testParseAnomalyDetectorWithoutUser() throws IOException {
+        AnomalyResult detectResult = TestHelpers.randomAnomalyDetectResult(0.8, randomAlphaOfLength(5), randomAlphaOfLength(5), false);
+        String detectResultString = TestHelpers
+            .xContentBuilderToString(detectResult.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        detectResultString = detectResultString
+            .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
+        assertEquals("Parsing anomaly detect result doesn't work", detectResult, parsedDetectResult);
+    }
+
+    public void testParseAnomalyDetectorWithoutNormalResult() throws IOException {
+        AnomalyResult detectResult = new AnomalyResult(
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            null,
+            null,
+            null,
+            null,
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            null,
+            null,
+            randomAlphaOfLength(5),
+            null,
+            TestHelpers.randomUser(),
+            CommonValue.NO_SCHEMA_VERSION
+        );
+        String detectResultString = TestHelpers
+            .xContentBuilderToString(detectResult.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        detectResultString = detectResultString
+            .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
+        assertTrue(parsedDetectResult.getFeatureData().size() == 0);
+        assertTrue(
+            Objects.equal(detectResult.getDetectorId(), parsedDetectResult.getDetectorId())
+                && Objects.equal(detectResult.getTaskId(), parsedDetectResult.getTaskId())
+                && Objects.equal(detectResult.getAnomalyScore(), parsedDetectResult.getAnomalyScore())
+                && Objects.equal(detectResult.getAnomalyGrade(), parsedDetectResult.getAnomalyGrade())
+                && Objects.equal(detectResult.getConfidence(), parsedDetectResult.getConfidence())
+                && Objects.equal(detectResult.getDataStartTime(), parsedDetectResult.getDataStartTime())
+                && Objects.equal(detectResult.getDataEndTime(), parsedDetectResult.getDataEndTime())
+                && Objects.equal(detectResult.getExecutionStartTime(), parsedDetectResult.getExecutionStartTime())
+                && Objects.equal(detectResult.getExecutionEndTime(), parsedDetectResult.getExecutionEndTime())
+                && Objects.equal(detectResult.getError(), parsedDetectResult.getError())
+                && Objects.equal(detectResult.getEntity(), parsedDetectResult.getEntity())
+        );
+    }
+
+    public void testParseAnomalyDetectorWithNanAnomalyResult() throws IOException {
+        AnomalyResult detectResult = new AnomalyResult(
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            Double.NaN,
+            Double.NaN,
+            Double.NaN,
+            ImmutableList.of(),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            Instant.now().truncatedTo(ChronoUnit.SECONDS),
+            null,
+            null,
+            randomAlphaOfLength(5),
+            null,
+            null,
+            CommonValue.NO_SCHEMA_VERSION
+        );
+        String detectResultString = TestHelpers
+            .xContentBuilderToString(detectResult.toXContent(TestHelpers.builder(), ToXContent.EMPTY_PARAMS));
+        detectResultString = detectResultString
+            .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
+        AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
+        assertNull(parsedDetectResult.getAnomalyGrade());
+        assertNull(parsedDetectResult.getAnomalyScore());
+        assertNull(parsedDetectResult.getConfidence());
+        assertTrue(
+            Objects.equal(detectResult.getDetectorId(), parsedDetectResult.getDetectorId())
+                && Objects.equal(detectResult.getTaskId(), parsedDetectResult.getTaskId())
+                && Objects.equal(detectResult.getFeatureData(), parsedDetectResult.getFeatureData())
+                && Objects.equal(detectResult.getDataStartTime(), parsedDetectResult.getDataStartTime())
+                && Objects.equal(detectResult.getDataEndTime(), parsedDetectResult.getDataEndTime())
+                && Objects.equal(detectResult.getExecutionStartTime(), parsedDetectResult.getExecutionStartTime())
+                && Objects.equal(detectResult.getExecutionEndTime(), parsedDetectResult.getExecutionEndTime())
+                && Objects.equal(detectResult.getError(), parsedDetectResult.getError())
+                && Objects.equal(detectResult.getEntity(), parsedDetectResult.getEntity())
+        );
     }
 
     public void testParseAnomalyDetectorWithTaskId() throws IOException {
@@ -53,5 +161,32 @@ public class AnomalyResultTests extends ESTestCase {
             .replaceFirst("\\{", String.format(Locale.ROOT, "{\"%s\":\"%s\",", randomAlphaOfLength(5), randomAlphaOfLength(5)));
         AnomalyResult parsedDetectResult = AnomalyResult.parse(TestHelpers.parser(detectResultString));
         assertEquals("Parsing anomaly detect result doesn't work", detectResult, parsedDetectResult);
+    }
+
+    public void testSerializeAnomalyResult() throws IOException {
+        AnomalyResult detectResult = TestHelpers.randomAnomalyDetectResult(0.8, randomAlphaOfLength(5), randomAlphaOfLength(5));
+        BytesStreamOutput output = new BytesStreamOutput();
+        detectResult.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyResult parsedDetectResult = new AnomalyResult(input);
+        assertTrue(parsedDetectResult.equals(detectResult));
+    }
+
+    public void testSerializeAnomalyResultWithoutUser() throws IOException {
+        AnomalyResult detectResult = TestHelpers.randomAnomalyDetectResult(0.8, randomAlphaOfLength(5), randomAlphaOfLength(5), false);
+        BytesStreamOutput output = new BytesStreamOutput();
+        detectResult.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyResult parsedDetectResult = new AnomalyResult(input);
+        assertTrue(parsedDetectResult.equals(detectResult));
+    }
+
+    public void testSerializeAnomalyResultWithEntity() throws IOException {
+        AnomalyResult detectResult = TestHelpers.randomMultiEntityAnomalyDetectResult(0.8, 0.5);
+        BytesStreamOutput output = new BytesStreamOutput();
+        detectResult.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        AnomalyResult parsedDetectResult = new AnomalyResult(input);
+        assertTrue(parsedDetectResult.equals(detectResult));
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRangeTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRangeTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+
+public class DetectionDateRangeTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return getInstanceFromNode(NamedWriteableRegistry.class);
+    }
+
+    public void testParseDetectionDateRangeWithNullStartTime() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new DetectionDateRange(null, Instant.now())
+        );
+        assertEquals("Detection data range's start time must not be null", exception.getMessage());
+    }
+
+    public void testParseDetectionDateRangeWithNullEndTime() {
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> new DetectionDateRange(Instant.now(), null)
+        );
+        assertEquals("Detection data range's end time must not be null", exception.getMessage());
+    }
+
+    public void testSerializeDetectoinDateRange() throws IOException {
+        DetectionDateRange dateRange = TestHelpers.randomDetectionDateRange();
+        BytesStreamOutput output = new BytesStreamOutput();
+        dateRange.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        DetectionDateRange parsedDateRange = new DetectionDateRange(input);
+        assertTrue(parsedDateRange.equals(dateRange));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

## Description of changes:
Currently we only have realtime detector which can take streaming data and detect anomaly in realtime way. For historical detector, user can feed historical data and detect historical anomalies. When user start historical detector, we will start an AD task at backend and run it asynchronously. This PR is to add AD task and tune detector and AD result to support historical detector.

1. AD Task
    When user start a historical detector, we will create a new AD task. We will record task state, progress and detector snapshot in task.

2. Detector changes
    * Add detection date range: user can specify the historical date range to run anomaly detection
    * Add detector type: this is to make the search and aggregation easier. When create detector, user doesn't need to fill this field, we will check `detection_date_range` and `catetory_field` to decide detector type automatically.

3. AD result changes
    * Add task id: user can run historical detector multiple times, and for each run we will create a new AD task. We store task id in AD result, so user can query the latest AD task result with task id.

## Test
1.`./gradlew build`
2.`./gradlew integTest -PnumNodes=3`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
