### PR TITLE
add ad task stats

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -461,7 +461,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             )
             .put(StatNames.DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
             .put(StatNames.JVM_HEAP_USAGE.getName(), new ADStat<>(false, new SettableSupplier()))
-            .put(StatNames.HISTORICAL_DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
+            .put(StatNames.HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
             .put(StatNames.AD_EXECUTING_BATCH_TASK_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .put(StatNames.AD_CANCELED_BATCH_TASK_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .put(StatNames.AD_TOTAL_BATCH_TASK_EXECUTION_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -460,6 +460,12 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ADStat<>(true, new IndexStatusSupplier(indexUtils, DetectorInternalState.DETECTOR_STATE_INDEX))
             )
             .put(StatNames.DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
+            .put(StatNames.JVM_HEAP_USAGE.getName(), new ADStat<>(false, new SettableSupplier()))
+            .put(StatNames.HISTORICAL_DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
+            .put(StatNames.AD_EXECUTING_BATCH_TASK_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
+            .put(StatNames.AD_CANCELED_BATCH_TASK_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
+            .put(StatNames.AD_TOTAL_BATCH_TASK_EXECUTION_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
+            .put(StatNames.AD_BATCH_TASK_FAILURE_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .build();
 
         adStats = new ADStats(indexUtils, modelManager, stats);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -460,7 +460,6 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ADStat<>(true, new IndexStatusSupplier(indexUtils, DetectorInternalState.DETECTOR_STATE_INDEX))
             )
             .put(StatNames.DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
-            .put(StatNames.JVM_HEAP_USAGE.getName(), new ADStat<>(false, new SettableSupplier()))
             .put(StatNames.HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
             .put(StatNames.AD_EXECUTING_BATCH_TASK_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))
             .put(StatNames.AD_CANCELED_BATCH_TASK_COUNT.getName(), new ADStat<>(false, new CounterSupplier()))

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/InternalStatNames.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/InternalStatNames.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.stats;
+
+/**
+ * Enum containing names of all internal stats which will not be returned
+ * in AD stats REST API.
+ */
+public enum InternalStatNames {
+    JVM_HEAP_USAGE("jvm_heap_usage");
+
+    private String name;
+
+    InternalStatNames(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Get internal stat name
+     *
+     * @return name
+     */
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/StatNames.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/StatNames.java
@@ -19,7 +19,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Enum containing names of all stats
+ * Enum containing names of all external stats which will be returned in
+ * AD stats REST API.
  */
 public enum StatNames {
     AD_EXECUTE_REQUEST_COUNT("ad_execute_request_count"),
@@ -33,7 +34,6 @@ public enum StatNames {
     ANOMALY_DETECTION_JOB_INDEX_STATUS("anomaly_detection_job_index_status"),
     ANOMALY_DETECTION_STATE_STATUS("anomaly_detection_state_status"),
     MODEL_INFORMATION("models"),
-    JVM_HEAP_USAGE("jvm_heap_usage"),
     HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT("historical_single_entity_detector_count"),
     AD_EXECUTING_BATCH_TASK_COUNT("ad_executing_batch_task_count"),
     AD_CANCELED_BATCH_TASK_COUNT("ad_canceled_batch_task_count"),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/StatNames.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/StatNames.java
@@ -34,7 +34,7 @@ public enum StatNames {
     ANOMALY_DETECTION_STATE_STATUS("anomaly_detection_state_status"),
     MODEL_INFORMATION("models"),
     JVM_HEAP_USAGE("jvm_heap_usage"),
-    HISTORICAL_DETECTOR_COUNT("historical_detector_count"),
+    HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT("historical_single_entity_detector_count"),
     AD_EXECUTING_BATCH_TASK_COUNT("ad_executing_batch_task_count"),
     AD_CANCELED_BATCH_TASK_COUNT("ad_canceled_batch_task_count"),
     AD_TOTAL_BATCH_TASK_EXECUTION_COUNT("ad_total_batch_task_execution_count"),

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/StatNames.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/StatNames.java
@@ -32,7 +32,13 @@ public enum StatNames {
     MODELS_CHECKPOINT_INDEX_STATUS("models_checkpoint_index_status"),
     ANOMALY_DETECTION_JOB_INDEX_STATUS("anomaly_detection_job_index_status"),
     ANOMALY_DETECTION_STATE_STATUS("anomaly_detection_state_status"),
-    MODEL_INFORMATION("models");
+    MODEL_INFORMATION("models"),
+    JVM_HEAP_USAGE("jvm_heap_usage"),
+    HISTORICAL_DETECTOR_COUNT("historical_detector_count"),
+    AD_EXECUTING_BATCH_TASK_COUNT("ad_executing_batch_task_count"),
+    AD_CANCELED_BATCH_TASK_COUNT("ad_canceled_batch_task_count"),
+    AD_TOTAL_BATCH_TASK_EXECUTION_COUNT("ad_total_batch_task_execution_count"),
+    AD_BATCH_TASK_FAILURE_COUNT("ad_batch_task_failure_count");
 
     private String name;
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStatsNodesTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStatsNodesTransportAction.java
@@ -27,10 +27,12 @@ import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.monitor.jvm.JvmService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStats;
+import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
 
 /**
  *  ADStatsNodesTransportAction contains the logic to extract the stats from the nodes
@@ -39,6 +41,7 @@ public class ADStatsNodesTransportAction extends
     TransportNodesAction<ADStatsRequest, ADStatsNodesResponse, ADStatsNodeRequest, ADStatsNodeResponse> {
 
     private ADStats adStats;
+    private final JvmService jvmService;
 
     /**
      * Constructor
@@ -55,7 +58,8 @@ public class ADStatsNodesTransportAction extends
         ClusterService clusterService,
         TransportService transportService,
         ActionFilters actionFilters,
-        ADStats adStats
+        ADStats adStats,
+        JvmService jvmService
     ) {
         super(
             ADStatsNodesAction.NAME,
@@ -69,6 +73,7 @@ public class ADStatsNodesTransportAction extends
             ADStatsNodeResponse.class
         );
         this.adStats = adStats;
+        this.jvmService = jvmService;
     }
 
     @Override
@@ -98,6 +103,12 @@ public class ADStatsNodesTransportAction extends
     private ADStatsNodeResponse createADStatsNodeResponse(ADStatsRequest adStatsRequest) {
         Map<String, Object> statValues = new HashMap<>();
         Set<String> statsToBeRetrieved = adStatsRequest.getStatsToBeRetrieved();
+
+        if (statsToBeRetrieved.contains(StatNames.JVM_HEAP_USAGE.getName())) {
+            long heapUsedPercent = jvmService.stats().getMem().getHeapUsedPercent();
+            adStats.getStat(StatNames.JVM_HEAP_USAGE.getName()).setValue(heapUsedPercent);
+            statValues.put(StatNames.JVM_HEAP_USAGE.getName(), heapUsedPercent);
+        }
 
         for (String statName : adStats.getNodeStats().keySet()) {
             if (statsToBeRetrieved.contains(statName)) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStatsNodesTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStatsNodesTransportAction.java
@@ -32,7 +32,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStats;
-import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
+import com.amazon.opendistroforelasticsearch.ad.stats.InternalStatNames;
 
 /**
  *  ADStatsNodesTransportAction contains the logic to extract the stats from the nodes
@@ -104,10 +104,9 @@ public class ADStatsNodesTransportAction extends
         Map<String, Object> statValues = new HashMap<>();
         Set<String> statsToBeRetrieved = adStatsRequest.getStatsToBeRetrieved();
 
-        if (statsToBeRetrieved.contains(StatNames.JVM_HEAP_USAGE.getName())) {
+        if (statsToBeRetrieved.contains(InternalStatNames.JVM_HEAP_USAGE.getName())) {
             long heapUsedPercent = jvmService.stats().getMem().getHeapUsedPercent();
-            adStats.getStat(StatNames.JVM_HEAP_USAGE.getName()).setValue(heapUsedPercent);
-            statValues.put(StatNames.JVM_HEAP_USAGE.getName(), heapUsedPercent);
+            statValues.put(InternalStatNames.JVM_HEAP_USAGE.getName(), heapUsedPercent);
         }
 
         for (String statName : adStats.getNodeStats().keySet()) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorResponse.java
@@ -48,7 +48,7 @@ public class StatsAnomalyDetectorResponse extends ActionResponse implements ToXC
         return builder;
     }
 
-    public ADStatsResponse getAdStatsResponse() {
+    protected ADStatsResponse getAdStatsResponse() {
         return adStatsResponse;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorResponse.java
@@ -47,4 +47,8 @@ public class StatsAnomalyDetectorResponse extends ActionResponse implements ToXC
         adStatsResponse.toXContent(builder, params);
         return builder;
     }
+
+    public ADStatsResponse getAdStatsResponse() {
+        return adStatsResponse;
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportAction.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -31,6 +32,10 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
@@ -41,6 +46,8 @@ import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
 import com.amazon.opendistroforelasticsearch.ad.util.MultiResponsesDelegateActionListener;
 
 public class StatsAnomalyDetectorTransportAction extends HandledTransportAction<ADStatsRequest, StatsAnomalyDetectorResponse> {
+    public static final String DETECTOR_TYPE_AGG = "detector_type_agg";
+    private static final String HISTORICAL_DETECTOR_TYPE_PREFIX = "HISTORICAL";
     private final Logger logger = LogManager.getLogger(StatsAnomalyDetectorTransportAction.class);
 
     private final Client client;
@@ -120,23 +127,34 @@ public class StatsAnomalyDetectorTransportAction extends HandledTransportAction<
         ADStatsRequest adStatsRequest
     ) {
         ADStatsResponse adStatsResponse = new ADStatsResponse();
-        if (adStatsRequest.getStatsToBeRetrieved().contains(StatNames.DETECTOR_COUNT.getName())) {
-            if (clusterService.state().getRoutingTable().hasIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
-                final SearchRequest request = client
-                    .prepareSearch(AnomalyDetector.ANOMALY_DETECTORS_INDEX)
-                    .setSize(0)
-                    .setTrackTotalHits(true)
-                    .request();
-                client.search(request, ActionListener.wrap(indicesStatsResponse -> {
-                    adStats.getStat(StatNames.DETECTOR_COUNT.getName()).setValue(indicesStatsResponse.getHits().getTotalHits().value);
-                    adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
-                    listener.onResponse(adStatsResponse);
-                }, e -> listener.onFailure(new RuntimeException("Failed to get AD cluster stats", e))));
-            } else {
-                adStats.getStat(StatNames.DETECTOR_COUNT.getName()).setValue(0L);
+        if ((adStatsRequest.getStatsToBeRetrieved().contains(StatNames.DETECTOR_COUNT.getName())
+            || adStatsRequest.getStatsToBeRetrieved().contains(StatNames.HISTORICAL_DETECTOR_COUNT.getName()))
+            && clusterService.state().getRoutingTable().hasIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
+
+            TermsAggregationBuilder termsAgg = AggregationBuilders.terms(DETECTOR_TYPE_AGG).field(AnomalyDetector.DETECTOR_TYPE_FIELD);
+            SearchRequest request = new SearchRequest()
+                .indices(AnomalyDetector.ANOMALY_DETECTORS_INDEX)
+                .source(new SearchSourceBuilder().aggregation(termsAgg).size(0).trackTotalHits(true));
+
+            client.search(request, ActionListener.wrap(r -> {
+                StringTerms aggregation = r.getAggregations().get(DETECTOR_TYPE_AGG);
+                List<StringTerms.Bucket> buckets = aggregation.getBuckets();
+                long totalDetectors = r.getHits().getTotalHits().value;
+                long totalHistoricalDetectors = 0;
+                for (StringTerms.Bucket b : buckets) {
+                    if (b.getKeyAsString().contains(HISTORICAL_DETECTOR_TYPE_PREFIX)) {
+                        totalHistoricalDetectors += b.getDocCount();
+                    }
+                }
+                if (adStatsRequest.getStatsToBeRetrieved().contains(StatNames.DETECTOR_COUNT.getName())) {
+                    adStats.getStat(StatNames.DETECTOR_COUNT.getName()).setValue(totalDetectors);
+                }
+                if (adStatsRequest.getStatsToBeRetrieved().contains(StatNames.HISTORICAL_DETECTOR_COUNT.getName())) {
+                    adStats.getStat(StatNames.HISTORICAL_DETECTOR_COUNT.getName()).setValue(totalHistoricalDetectors);
+                }
                 adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
                 listener.onResponse(adStatsResponse);
-            }
+            }, e -> listener.onFailure(e)));
         } else {
             adStatsResponse.setClusterStats(getClusterStatsMap(adStatsRequest));
             listener.onResponse(adStatsResponse);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStatsNodesTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStatsNodesTransportActionTests.java
@@ -42,7 +42,7 @@ import com.amazon.opendistroforelasticsearch.ad.caching.EntityCache;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStat;
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStats;
-import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
+import com.amazon.opendistroforelasticsearch.ad.stats.InternalStatNames;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.CounterSupplier;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.IndexStatusSupplier;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.ModelsOnNodeSupplier;
@@ -91,7 +91,7 @@ public class ADStatsNodesTransportActionTests extends ESIntegTestCase {
                 put(nodeStatName2, new ADStat<>(false, new ModelsOnNodeSupplier(modelManager, cacheProvider)));
                 put(clusterStatName1, new ADStat<>(true, new IndexStatusSupplier(indexUtils, "index1")));
                 put(clusterStatName2, new ADStat<>(true, new IndexStatusSupplier(indexUtils, "index2")));
-                put(StatNames.JVM_HEAP_USAGE.getName(), new ADStat<>(true, new SettableSupplier()));
+                put(InternalStatNames.JVM_HEAP_USAGE.getName(), new ADStat<>(true, new SettableSupplier()));
             }
         };
 
@@ -153,7 +153,7 @@ public class ADStatsNodesTransportActionTests extends ESIntegTestCase {
         ADStatsRequest adStatsRequest = new ADStatsRequest((nodeId));
         adStatsRequest.clear();
 
-        Set<String> statsToBeRetrieved = new HashSet<>(Arrays.asList(nodeStatName1, StatNames.JVM_HEAP_USAGE.getName()));
+        Set<String> statsToBeRetrieved = new HashSet<>(Arrays.asList(nodeStatName1, InternalStatNames.JVM_HEAP_USAGE.getName()));
 
         for (String stat : statsToBeRetrieved) {
             adStatsRequest.addStat(stat);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStatsNodesTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADStatsNodesTransportActionTests.java
@@ -29,6 +29,8 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.monitor.jvm.JvmService;
+import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -40,9 +42,11 @@ import com.amazon.opendistroforelasticsearch.ad.caching.EntityCache;
 import com.amazon.opendistroforelasticsearch.ad.ml.ModelManager;
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStat;
 import com.amazon.opendistroforelasticsearch.ad.stats.ADStats;
+import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.CounterSupplier;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.IndexStatusSupplier;
 import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.ModelsOnNodeSupplier;
+import com.amazon.opendistroforelasticsearch.ad.stats.suppliers.SettableSupplier;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
 import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
 import com.amazon.opendistroforelasticsearch.ad.util.Throttler;
@@ -87,17 +91,26 @@ public class ADStatsNodesTransportActionTests extends ESIntegTestCase {
                 put(nodeStatName2, new ADStat<>(false, new ModelsOnNodeSupplier(modelManager, cacheProvider)));
                 put(clusterStatName1, new ADStat<>(true, new IndexStatusSupplier(indexUtils, "index1")));
                 put(clusterStatName2, new ADStat<>(true, new IndexStatusSupplier(indexUtils, "index2")));
+                put(StatNames.JVM_HEAP_USAGE.getName(), new ADStat<>(true, new SettableSupplier()));
             }
         };
 
         adStats = new ADStats(indexUtils, modelManager, statsMap);
+        JvmService jvmService = mock(JvmService.class);
+        JvmStats jvmStats = mock(JvmStats.class);
+        JvmStats.Mem mem = mock(JvmStats.Mem.class);
+
+        when(jvmService.stats()).thenReturn(jvmStats);
+        when(jvmStats.getMem()).thenReturn(mem);
+        when(mem.getHeapUsedPercent()).thenReturn(randomShort());
 
         action = new ADStatsNodesTransportAction(
             client().threadPool(),
             clusterService(),
             mock(TransportService.class),
             mock(ActionFilters.class),
-            adStats
+            adStats,
+            jvmService
         );
     }
 
@@ -119,6 +132,28 @@ public class ADStatsNodesTransportActionTests extends ESIntegTestCase {
         adStatsRequest.clear();
 
         Set<String> statsToBeRetrieved = new HashSet<>(Arrays.asList(nodeStatName1, nodeStatName2));
+
+        for (String stat : statsToBeRetrieved) {
+            adStatsRequest.addStat(stat);
+        }
+
+        ADStatsNodeResponse response = action.nodeOperation(new ADStatsNodeRequest(adStatsRequest));
+
+        Map<String, Object> stats = response.getStatsMap();
+
+        assertEquals(statsToBeRetrieved.size(), stats.size());
+        for (String statName : stats.keySet()) {
+            assertTrue(statsToBeRetrieved.contains(statName));
+        }
+    }
+
+    @Test
+    public void testNodeOperationWithJvmHeapUsage() {
+        String nodeId = clusterService().localNode().getId();
+        ADStatsRequest adStatsRequest = new ADStatsRequest((nodeId));
+        adStatsRequest.clear();
+
+        Set<String> statsToBeRetrieved = new HashSet<>(Arrays.asList(nodeStatName1, StatNames.JVM_HEAP_USAGE.getName()));
 
         for (String stat : statsToBeRetrieved) {
             adStatsRequest.addStat(stat);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportActionTests.java
@@ -113,14 +113,14 @@ public class StatsAnomalyDetectorTransportActionTests extends ESIntegTestCase {
     public void testStatsAnomalyDetectorWithClusterLevelStats() throws IOException {
         ADStatsRequest adStatsRequest = new ADStatsRequest(clusterService().localNode());
         adStatsRequest.addStat(StatNames.DETECTOR_COUNT.getName());
-        adStatsRequest.addStat(StatNames.HISTORICAL_DETECTOR_COUNT.getName());
+        adStatsRequest.addStat(StatNames.HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT.getName());
         StatsAnomalyDetectorResponse response = client().execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest).actionGet(5_000);
         assertEquals(1, response.getAdStatsResponse().getADStatsNodesResponse().getNodes().size());
         Map<String, Object> statsMap = response.getAdStatsResponse().getADStatsNodesResponse().getNodes().get(0).getStatsMap();
         Map<String, Object> clusterStats = response.getAdStatsResponse().getClusterStats();
         assertEquals(0, statsMap.size());
         assertEquals(2L, clusterStats.get(StatNames.DETECTOR_COUNT.getName()));
-        assertEquals(1L, clusterStats.get(StatNames.HISTORICAL_DETECTOR_COUNT.getName()));
+        assertEquals(1L, clusterStats.get(StatNames.HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT.getName()));
     }
 
     public void testStatsAnomalyDetectorWithDetectorCount() throws IOException {
@@ -132,18 +132,18 @@ public class StatsAnomalyDetectorTransportActionTests extends ESIntegTestCase {
         Map<String, Object> clusterStats = response.getAdStatsResponse().getClusterStats();
         assertEquals(0, statsMap.size());
         assertEquals(2L, clusterStats.get(StatNames.DETECTOR_COUNT.getName()));
-        assertFalse(clusterStats.containsKey(StatNames.HISTORICAL_DETECTOR_COUNT.getName()));
+        assertFalse(clusterStats.containsKey(StatNames.HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT.getName()));
     }
 
     public void testStatsAnomalyDetectorWithHistoricalDetectorCount() throws IOException {
         ADStatsRequest adStatsRequest = new ADStatsRequest(clusterService().localNode());
-        adStatsRequest.addStat(StatNames.HISTORICAL_DETECTOR_COUNT.getName());
+        adStatsRequest.addStat(StatNames.HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT.getName());
         StatsAnomalyDetectorResponse response = client().execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest).actionGet(5_000);
         assertEquals(1, response.getAdStatsResponse().getADStatsNodesResponse().getNodes().size());
         Map<String, Object> statsMap = response.getAdStatsResponse().getADStatsNodesResponse().getNodes().get(0).getStatsMap();
         Map<String, Object> clusterStats = response.getAdStatsResponse().getClusterStats();
         assertEquals(0, statsMap.size());
-        assertEquals(1L, clusterStats.get(StatNames.HISTORICAL_DETECTOR_COUNT.getName()));
+        assertEquals(1L, clusterStats.get(StatNames.HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT.getName()));
         assertFalse(clusterStats.containsKey(StatNames.DETECTOR_COUNT.getName()));
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportActionTests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorType;
+import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class StatsAnomalyDetectorTransportActionTests extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+        return Collections.singletonList(AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        createTestDetector();
+    }
+
+    private void createTestDetector() throws IOException {
+        CreateIndexResponse createIndexResponse = TestHelpers
+            .createIndex(admin(), AnomalyDetector.ANOMALY_DETECTORS_INDEX, AnomalyDetectionIndices.getAnomalyDetectorMappings());
+        assertEquals(true, createIndexResponse.isAcknowledged());
+
+        IndexRequest indexRequest = new IndexRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .source(
+                TestHelpers
+                    .randomAnomalyDetector(ImmutableMap.of(), Instant.now())
+                    .toXContent(XContentFactory.jsonBuilder(), XCONTENT_WITH_TYPE)
+            );
+        IndexResponse indexResponse = client().index(indexRequest).actionGet(5_000);
+        assertEquals(RestStatus.CREATED, indexResponse.status());
+
+        indexRequest = new IndexRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .source(
+                TestHelpers
+                    .randomAnomalyDetector(
+                        ImmutableList.of(TestHelpers.randomFeature()),
+                        ImmutableMap.of(),
+                        Instant.now(),
+                        AnomalyDetectorType.HISTORICAL_SINGLE_ENTITY.name(),
+                        TestHelpers.randomDetectionDateRange(),
+                        true
+                    )
+                    .toXContent(XContentFactory.jsonBuilder(), XCONTENT_WITH_TYPE)
+            );
+        indexResponse = client().index(indexRequest).actionGet(5_000);
+        assertEquals(RestStatus.CREATED, indexResponse.status());
+    }
+
+    public void testStatsAnomalyDetectorWithNodeLevelStats() {
+        ADStatsRequest adStatsRequest = new ADStatsRequest(clusterService().localNode());
+        adStatsRequest.addStat(StatNames.JVM_HEAP_USAGE.getName());
+        StatsAnomalyDetectorResponse response = client().execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest).actionGet(5_000);
+        assertEquals(1, response.getAdStatsResponse().getADStatsNodesResponse().getNodes().size());
+        assertTrue(
+            response
+                .getAdStatsResponse()
+                .getADStatsNodesResponse()
+                .getNodes()
+                .get(0)
+                .getStatsMap()
+                .containsKey(StatNames.JVM_HEAP_USAGE.getName())
+        );
+    }
+
+    public void testStatsAnomalyDetectorWithClusterLevelStats() throws IOException {
+        ADStatsRequest adStatsRequest = new ADStatsRequest(clusterService().localNode());
+        adStatsRequest.addStat(StatNames.DETECTOR_COUNT.getName());
+        adStatsRequest.addStat(StatNames.HISTORICAL_DETECTOR_COUNT.getName());
+        StatsAnomalyDetectorResponse response = client().execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest).actionGet(5_000);
+        assertEquals(1, response.getAdStatsResponse().getADStatsNodesResponse().getNodes().size());
+        Map<String, Object> statsMap = response.getAdStatsResponse().getADStatsNodesResponse().getNodes().get(0).getStatsMap();
+        Map<String, Object> clusterStats = response.getAdStatsResponse().getClusterStats();
+        assertEquals(0, statsMap.size());
+        assertEquals(2L, clusterStats.get(StatNames.DETECTOR_COUNT.getName()));
+        assertEquals(1L, clusterStats.get(StatNames.HISTORICAL_DETECTOR_COUNT.getName()));
+    }
+
+    public void testStatsAnomalyDetectorWithDetectorCount() throws IOException {
+        ADStatsRequest adStatsRequest = new ADStatsRequest(clusterService().localNode());
+        adStatsRequest.addStat(StatNames.DETECTOR_COUNT.getName());
+        StatsAnomalyDetectorResponse response = client().execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest).actionGet(5_000);
+        assertEquals(1, response.getAdStatsResponse().getADStatsNodesResponse().getNodes().size());
+        Map<String, Object> statsMap = response.getAdStatsResponse().getADStatsNodesResponse().getNodes().get(0).getStatsMap();
+        Map<String, Object> clusterStats = response.getAdStatsResponse().getClusterStats();
+        assertEquals(0, statsMap.size());
+        assertEquals(2L, clusterStats.get(StatNames.DETECTOR_COUNT.getName()));
+        assertFalse(clusterStats.containsKey(StatNames.HISTORICAL_DETECTOR_COUNT.getName()));
+    }
+
+    public void testStatsAnomalyDetectorWithHistoricalDetectorCount() throws IOException {
+        ADStatsRequest adStatsRequest = new ADStatsRequest(clusterService().localNode());
+        adStatsRequest.addStat(StatNames.HISTORICAL_DETECTOR_COUNT.getName());
+        StatsAnomalyDetectorResponse response = client().execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest).actionGet(5_000);
+        assertEquals(1, response.getAdStatsResponse().getADStatsNodesResponse().getNodes().size());
+        Map<String, Object> statsMap = response.getAdStatsResponse().getADStatsNodesResponse().getNodes().get(0).getStatsMap();
+        Map<String, Object> clusterStats = response.getAdStatsResponse().getClusterStats();
+        assertEquals(0, statsMap.size());
+        assertEquals(1L, clusterStats.get(StatNames.HISTORICAL_DETECTOR_COUNT.getName()));
+        assertFalse(clusterStats.containsKey(StatNames.DETECTOR_COUNT.getName()));
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/StatsAnomalyDetectorTransportActionTests.java
@@ -38,6 +38,7 @@ import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorType;
+import com.amazon.opendistroforelasticsearch.ad.stats.InternalStatNames;
 import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -96,7 +97,7 @@ public class StatsAnomalyDetectorTransportActionTests extends ESIntegTestCase {
 
     public void testStatsAnomalyDetectorWithNodeLevelStats() {
         ADStatsRequest adStatsRequest = new ADStatsRequest(clusterService().localNode());
-        adStatsRequest.addStat(StatNames.JVM_HEAP_USAGE.getName());
+        adStatsRequest.addStat(InternalStatNames.JVM_HEAP_USAGE.getName());
         StatsAnomalyDetectorResponse response = client().execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest).actionGet(5_000);
         assertEquals(1, response.getAdStatsResponse().getADStatsNodesResponse().getNodes().size());
         assertTrue(
@@ -106,7 +107,7 @@ public class StatsAnomalyDetectorTransportActionTests extends ESIntegTestCase {
                 .getNodes()
                 .get(0)
                 .getStatsMap()
-                .containsKey(StatNames.JVM_HEAP_USAGE.getName())
+                .containsKey(InternalStatNames.JVM_HEAP_USAGE.getName())
         );
     }
 


### PR DESCRIPTION
*Issue #, if available:*

## Description of changes:
Add AD task stats for historical detector

## Test
1.`./gradlew build`
2.`./gradlew integTest -PnumNodes=3`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
