### PR TITLE
filter out exceptions which should not be counted in failure stats

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,9 +51,9 @@ jobs:
             echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:/tmp/opendistro-anomaly-detection-$plugin_version.zip" >> Dockerfile
 
             docker build -t odfe-ad:test .
-            echo "::set-env name=imagePresent::true"
+            echo "imagePresent=true" >> $GITHUB_ENV
           else
-            echo "::set-env name=imagePresent::false"
+            echo "imagePresent=false" >> $GITHUB_ENV
           fi
 
       - name: Run Docker Image

--- a/.github/workflows/esad-cli-test-and-build-workflow.yml
+++ b/.github/workflows/esad-cli-test-and-build-workflow.yml
@@ -57,7 +57,7 @@ jobs:
           exit 1
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v1
+        uses: golangci/golangci-lint-action@v2.3.0
         with:
           version: v1.28
           working-directory: cli

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/AnomalyDetectionException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/AnomalyDetectionException.java
@@ -20,7 +20,14 @@ package com.amazon.opendistroforelasticsearch.ad.common.exception;
  */
 public class AnomalyDetectionException extends RuntimeException {
 
-    private final String anomalyDetectorId;
+    private String anomalyDetectorId;
+    // countedInStats will be used to tell whether the exception should be
+    // counted in failure stats.
+    private boolean countedInStats = true;
+
+    public AnomalyDetectionException(String message) {
+        super(message);
+    }
 
     /**
      * Constructor with an anomaly detector ID and a message.
@@ -38,6 +45,10 @@ public class AnomalyDetectionException extends RuntimeException {
         this.anomalyDetectorId = adID;
     }
 
+    public AnomalyDetectionException(Throwable cause) {
+        super(cause);
+    }
+
     public AnomalyDetectionException(String adID, Throwable cause) {
         super(cause);
         this.anomalyDetectorId = adID;
@@ -50,6 +61,26 @@ public class AnomalyDetectionException extends RuntimeException {
      */
     public String getAnomalyDetectorId() {
         return this.anomalyDetectorId;
+    }
+
+    /**
+     * Returns if the exception should be counted in stats.
+     *
+     * @return true if should count the exception in stats; otherwise return false
+     */
+    public boolean isCountedInStats() {
+        return countedInStats;
+    }
+
+    /**
+     * Set if the exception should be counted in stats.
+     *
+     * @param countInStats count the exception in stats
+     * @return the exception itself
+     */
+    public AnomalyDetectionException countedInStats(boolean countInStats) {
+        this.countedInStats = countInStats;
+        return this;
     }
 
     @Override

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/ClientException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/ClientException.java
@@ -16,10 +16,13 @@
 package com.amazon.opendistroforelasticsearch.ad.common.exception;
 
 /**
- * All exception visible to AD transport layer's client is under ClientVisible.
- *
+ * All exception visible to AD transport layer's client is under ClientException.
  */
 public class ClientException extends AnomalyDetectionException {
+
+    public ClientException(String message) {
+        super(message);
+    }
 
     public ClientException(String anomalyDetectorId, String message) {
         super(anomalyDetectorId, message);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/EndRunException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/EndRunException.java
@@ -22,6 +22,11 @@ package com.amazon.opendistroforelasticsearch.ad.common.exception;
 public class EndRunException extends ClientException {
     private boolean endNow;
 
+    public EndRunException(String message, boolean endNow) {
+        super(message);
+        this.endNow = endNow;
+    }
+
     public EndRunException(String anomalyDetectorId, String message, boolean endNow) {
         super(anomalyDetectorId, message);
         this.endNow = endNow;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/LimitExceededException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/LimitExceededException.java
@@ -28,6 +28,7 @@ public class LimitExceededException extends EndRunException {
      */
     public LimitExceededException(String anomalyDetectorId, String message) {
         super(anomalyDetectorId, message, true);
+        this.countedInStats(false);
     }
 
     /**
@@ -39,5 +40,6 @@ public class LimitExceededException extends EndRunException {
      */
     public LimitExceededException(String anomalyDetectorId, String message, boolean stopNow) {
         super(anomalyDetectorId, message, stopNow);
+        this.countedInStats(false);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/ResourceNotFoundException.java
@@ -28,5 +28,6 @@ public class ResourceNotFoundException extends AnomalyDetectionException {
      */
     public ResourceNotFoundException(String detectorId, String message) {
         super(detectorId, message);
+        countedInStats(false);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDao.java
@@ -47,6 +47,7 @@ import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation.S
 import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 
+import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.Interpolator;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
@@ -186,7 +187,9 @@ public class SearchFeatureDao {
                 result = percentile.next().getValue();
             }
         }
-        return Optional.ofNullable(result).orElseThrow(() -> new IllegalStateException("Failed to parse aggregation " + aggregation));
+        return Optional
+            .ofNullable(result)
+            .orElseThrow(() -> new EndRunException("Failed to parse aggregation " + aggregation, true).countedInStats(false));
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
@@ -123,7 +123,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      * @return anomaly detector index mapping
      * @throws IOException IOException if mapping file can't be read correctly
      */
-    private String getAnomalyDetectorMappings() throws IOException {
+    public static String getAnomalyDetectorMappings() throws IOException {
         URL url = AnomalyDetectionIndices.class.getClassLoader().getResource(ANOMALY_DETECTORS_INDEX_MAPPING_FILE);
         return Resources.toString(url, Charsets.UTF_8);
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
@@ -150,6 +150,13 @@ public class IndexAnomalyDetectorJobActionHandler extends AbstractActionHandler 
                 channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "Can't start detector job as no features configured"));
                 return;
             }
+            if (detector.getEnabledFeatureIds().size() == 0) {
+                channel
+                    .sendResponse(
+                        new BytesRestResponse(RestStatus.BAD_REQUEST, "Can't start detector job as no enabled features configured")
+                    );
+                return;
+            }
 
             IntervalTimeConfiguration interval = (IntervalTimeConfiguration) detector.getDetectionInterval();
             Schedule schedule = new IntervalSchedule(Instant.now(), (int) interval.getInterval(), interval.getUnit());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages.INVALID_SEARCH_QUERY_MSG;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -31,6 +33,8 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -45,6 +49,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.node.NodeClosedException;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
@@ -91,6 +96,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         .getExceptionName(new LimitExceededException("", ""));
     static final String NULL_RESPONSE = "Received null response from";
     static final String BUG_RESPONSE = "We might have bugs.";
+    static final String TROUBLE_QUERYING_ERR_MSG = "Having trouble querying data: ";
 
     private final TransportService transportService;
     private final TransportStateManager stateManager;
@@ -205,14 +211,18 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         AnomalyResultRequest request = AnomalyResultRequest.fromActionRequest(actionRequest);
         ActionListener<AnomalyResultResponse> original = listener;
         listener = ActionListener.wrap(original::onResponse, e -> {
-            adStats.getStat(StatNames.AD_EXECUTE_FAIL_COUNT.getName()).increment();
+            // If exception is AnomalyDetectionException and it should not be counted in stats,
+            // we will not count it in failure stats.
+            if (!(e instanceof AnomalyDetectionException) || ((AnomalyDetectionException) e).isCountedInStats()) {
+                adStats.getStat(StatNames.AD_EXECUTE_FAIL_COUNT.getName()).increment();
+            }
             original.onFailure(e);
         });
 
         String adID = request.getAdID();
 
         if (!EnabledSetting.isADPluginEnabled()) {
-            throw new EndRunException(adID, CommonErrorMessages.DISABLED_ERR_MSG, true);
+            throw new EndRunException(adID, CommonErrorMessages.DISABLED_ERR_MSG, true).countedInStats(false);
         }
 
         adStats.getStat(StatNames.AD_EXECUTE_REQUEST_COUNT.getName()).increment();
@@ -240,6 +250,10 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                 return;
             }
             AnomalyDetector anomalyDetector = detector.get();
+            if (anomalyDetector.getEnabledFeatureIds().size() == 0) {
+                listener.onFailure(new EndRunException(ALL_FEATURES_DISABLED_ERR_MSG, true).countedInStats(false));
+                return;
+            }
 
             String thresholdModelID = modelManager.getThresholdModelId(adID);
             Optional<DiscoveryNode> asThresholdNode = hashRing.getOwningNode(thresholdModelID);
@@ -375,18 +389,7 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
                         new ActionListenerResponseHandler<>(rcfListener, RCFResultResponse::new)
                     );
             }
-        }, exception -> {
-            if (exception instanceof IndexNotFoundException) {
-                listener.onFailure(new EndRunException(adID, "Having trouble querying data: " + exception.getMessage(), true));
-            } else if (exception instanceof IllegalArgumentException && detector.getEnabledFeatureIds().isEmpty()) {
-                listener.onFailure(new EndRunException(adID, ALL_FEATURES_DISABLED_ERR_MSG, true));
-            } else if (exception instanceof EndRunException) {
-                // invalid feature query
-                listener.onFailure(exception);
-            } else {
-                handleExecuteException(exception, listener, adID);
-            }
-        });
+        }, exception -> { handleFailure(exception, listener, adID); });
     }
 
     /**
@@ -471,15 +474,50 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
         return modelManager.combineRcfResults(rcfResultLib);
     }
 
+    private void handleFailure(Exception exception, ActionListener<AnomalyResultResponse> listener, String adID) {
+        if (exception instanceof IndexNotFoundException) {
+            listener.onFailure(new EndRunException(adID, TROUBLE_QUERYING_ERR_MSG + exception.getMessage(), true).countedInStats(false));
+        } else if (exception instanceof EndRunException) {
+            // invalid feature query
+            listener.onFailure(exception);
+        } else {
+            handleExecuteException(exception, listener, adID);
+        }
+    }
+
     void handleExecuteException(Exception ex, ActionListener<AnomalyResultResponse> listener, String adID) {
         if (ex instanceof ClientException) {
             listener.onFailure(ex);
         } else if (ex instanceof AnomalyDetectionException) {
             listener.onFailure(new InternalFailure((AnomalyDetectionException) ex));
+        } else if (ex instanceof SearchPhaseExecutionException && invalidQuery((SearchPhaseExecutionException) ex)) {
+            // This is to catch invalid aggregation on wrong field type. For example,
+            // sum aggregation on text field. We should end detector run for such case.
+            listener
+                .onFailure(
+                    new EndRunException(
+                        adID,
+                        INVALID_SEARCH_QUERY_MSG + ((SearchPhaseExecutionException) ex).getDetailedMessage(),
+                        ex,
+                        true
+                    ).countedInStats(false)
+                );
         } else {
             Throwable cause = ExceptionsHelper.unwrapCause(ex);
             listener.onFailure(new InternalFailure(adID, cause));
         }
+    }
+
+    private boolean invalidQuery(SearchPhaseExecutionException ex) {
+        boolean invalidQuery = true;
+        // If all shards return bad request and failure cause is IllegalArgumentException, we
+        // consider the feature query is invalid and will not count the error in failure stats.
+        for (ShardSearchFailure failure : ex.shardFailures()) {
+            if (RestStatus.BAD_REQUEST != failure.status() || !(failure.getCause() instanceof IllegalArgumentException)) {
+                invalidQuery = false;
+            }
+        }
+        return invalidQuery;
     }
 
     class RCFActionListener implements ActionListener<RCFResultResponse> {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ADIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ADIntegTestCase.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+
+public abstract class ADIntegTestCase extends ESIntegTestCase {
+
+    private long timeout = 5_000;
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> transportClientPlugins() {
+        return Collections.singletonList(AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void createDetectors(List<AnomalyDetector> detectors, boolean createIndexFirst) throws IOException {
+        if (createIndexFirst) {
+            createIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX, AnomalyDetectionIndices.getAnomalyDetectorMappings());
+        }
+
+        for (AnomalyDetector detector : detectors) {
+            indexDoc(AnomalyDetector.ANOMALY_DETECTORS_INDEX, detector.toXContent(XContentFactory.jsonBuilder(), XCONTENT_WITH_TYPE));
+        }
+    }
+
+    public void createDetectorIndex() throws IOException {
+        createIndex(AnomalyDetector.ANOMALY_DETECTORS_INDEX, AnomalyDetectionIndices.getAnomalyDetectorMappings());
+    }
+
+    public String createDetectors(AnomalyDetector detector) throws IOException {
+        return indexDoc(AnomalyDetector.ANOMALY_DETECTORS_INDEX, detector.toXContent(XContentFactory.jsonBuilder(), XCONTENT_WITH_TYPE));
+    }
+
+    public void createIndex(String indexName, String mappings) {
+        CreateIndexResponse createIndexResponse = TestHelpers.createIndex(admin(), indexName, mappings);
+        assertEquals(true, createIndexResponse.isAcknowledged());
+    }
+
+    public String indexDoc(String indexName, XContentBuilder source) {
+        IndexRequest indexRequest = new IndexRequest(indexName).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source(source);
+        IndexResponse indexResponse = client().index(indexRequest).actionGet(timeout);
+        assertEquals(RestStatus.CREATED, indexResponse.status());
+        return indexResponse.getId();
+    }
+
+    public String indexDoc(String indexName, Map<String, ?> source) {
+        IndexRequest indexRequest = new IndexRequest(indexName).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source(source);
+        IndexResponse indexResponse = client().index(indexRequest).actionGet(timeout);
+        assertEquals(RestStatus.CREATED, indexResponse.status());
+        return indexResponse.getId();
+    }
+
+    public GetResponse getDoc(String indexName, String id) {
+        GetRequest getRequest = new GetRequest(indexName).id(id);
+        return client().get(getRequest).actionGet(timeout);
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorRestTestCase.java
@@ -61,11 +61,16 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
     }
 
     protected AnomalyDetector createRandomAnomalyDetector(Boolean refresh, Boolean withMetadata) throws IOException {
+        return createRandomAnomalyDetector(refresh, withMetadata, true);
+    }
+
+    protected AnomalyDetector createRandomAnomalyDetector(Boolean refresh, Boolean withMetadata, boolean featureEnabled)
+        throws IOException {
         Map<String, Object> uiMetadata = null;
         if (withMetadata) {
             uiMetadata = TestHelpers.randomUiMetadata();
         }
-        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(uiMetadata, null);
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(uiMetadata, null, featureEnabled);
         String indexName = detector.getIndices().get(0);
         TestHelpers
             .makeRequest(
@@ -179,6 +184,11 @@ public abstract class AnomalyDetectorRestTestCase extends ODFERestTestCase {
                 detector.getLastUpdateTime()
             ),
             detectorJob };
+    }
+
+    protected Response startAnomalyDetector(String detectorId) throws IOException {
+        return TestHelpers
+            .makeRequest(client(), "POST", TestHelpers.AD_BASE_DETECTORS_URI + "/" + detectorId + "/_start", ImmutableMap.of(), "", null);
     }
 
     protected HttpEntity toHttpEntity(ToXContentObject object) throws IOException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad;
 
+import static com.carrotsearch.randomizedtesting.RandomizedTest.randomBoolean;
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.BUILT_IN_ROLES;
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
@@ -46,10 +47,12 @@ import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.client.AdminClient;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
@@ -177,15 +180,30 @@ public class TestHelpers {
         return randomAnomalyDetector(ImmutableList.of(randomFeature()), uiMetadata, lastUpdateTime);
     }
 
+    public static AnomalyDetector randomAnomalyDetector(Map<String, Object> uiMetadata, Instant lastUpdateTime, boolean featureEnabled)
+        throws IOException {
+        return randomAnomalyDetector(ImmutableList.of(randomFeature(featureEnabled)), uiMetadata, lastUpdateTime);
+    }
+
     public static AnomalyDetector randomAnomalyDetector(List<Feature> features, Map<String, Object> uiMetadata, Instant lastUpdateTime)
         throws IOException {
+        List<String> indices = ImmutableList.of(randomAlphaOfLength(10).toLowerCase());
+        return randomAnomalyDetector(indices, features, uiMetadata, lastUpdateTime);
+    }
+
+    public static AnomalyDetector randomAnomalyDetector(
+        List<String> indices,
+        List<Feature> features,
+        Map<String, Object> uiMetadata,
+        Instant lastUpdateTime
+    ) throws IOException {
         return new AnomalyDetector(
             randomAlphaOfLength(10),
             randomLong(),
             randomAlphaOfLength(20),
             randomAlphaOfLength(30),
             randomAlphaOfLength(5),
-            ImmutableList.of(randomAlphaOfLength(10).toLowerCase()),
+            indices,
             features,
             randomQuery(),
             randomIntervalTimeConfiguration(),
@@ -271,6 +289,10 @@ public class TestHelpers {
         String query = "{\"bool\":{\"must\":{\"term\":{\"user\":\"kimchy\"}},\"filter\":{\"term\":{\"tag\":"
             + "\"tech\"}},\"must_not\":{\"range\":{\"age\":{\"gte\":10,\"lte\":20}}},\"should\":[{\"term\":"
             + "{\"tag\":\"wow\"}},{\"term\":{\"tag\":\"elasticsearch\"}}],\"minimum_should_match\":1,\"boost\":1}}";
+        return randomQuery(query);
+    }
+
+    public static QueryBuilder randomQuery(String query) throws IOException {
         XContentParser parser = TestHelpers.parser(query);
         return parseInnerQueryBuilder(parser);
     }
@@ -281,6 +303,22 @@ public class TestHelpers {
 
     public static AggregationBuilder randomAggregation(String aggregationName) throws IOException {
         XContentParser parser = parser("{\"" + aggregationName + "\":{\"value_count\":{\"field\":\"ok\"}}}");
+
+        AggregatorFactories.Builder parsed = AggregatorFactories.parseAggregators(parser);
+        return parsed.getAggregatorFactories().iterator().next();
+    }
+
+    /**
+     * Parse string aggregation query into {@link AggregationBuilder}
+     * Sample input:
+     * "{\"test\":{\"value_count\":{\"field\":\"ok\"}}}"
+     *
+     * @param aggregationQuery aggregation builder
+     * @return aggregation builder
+     * @throws IOException IO exception
+     */
+    public static AggregationBuilder parseAggregation(String aggregationQuery) throws IOException {
+        XContentParser parser = parser(aggregationQuery);
 
         AggregatorFactories.Builder parsed = AggregatorFactories.parseAggregators(parser);
         return parsed.getAggregatorFactories().iterator().next();
@@ -306,7 +344,15 @@ public class TestHelpers {
         return randomFeature(randomAlphaOfLength(5), randomAlphaOfLength(5));
     }
 
+    public static Feature randomFeature(boolean enabled) {
+        return randomFeature(randomAlphaOfLength(5), randomAlphaOfLength(5), enabled);
+    }
+
     public static Feature randomFeature(String featureName, String aggregationName) {
+        return randomFeature(featureName, aggregationName, randomBoolean());
+    }
+
+    public static Feature randomFeature(String featureName, String aggregationName, boolean enabled) {
         AggregationBuilder testAggregation = null;
         try {
             testAggregation = randomAggregation(aggregationName);
@@ -314,7 +360,7 @@ public class TestHelpers {
             logger.error("Fail to generate test aggregation");
             throw new RuntimeException();
         }
-        return new Feature(randomAlphaOfLength(5), featureName, ESRestTestCase.randomBoolean(), testAggregation);
+        return new Feature(randomAlphaOfLength(5), featureName, enabled, testAggregation);
     }
 
     public static <S, T> void assertFailWith(Class<S> clazz, Callable<T> callable) throws Exception {
@@ -465,6 +511,11 @@ public class TestHelpers {
         ThreadPool pool = mock(ThreadPool.class);
         when(pool.getThreadContext()).thenReturn(createThreadContext());
         return pool;
+    }
+
+    public static CreateIndexResponse createIndex(AdminClient adminClient, String indexName, String indexMapping) {
+        CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(AnomalyDetector.TYPE, indexMapping, XContentType.JSON);
+        return adminClient.indices().create(request).actionGet(5_000);
     }
 
     public static void createIndex(RestClient client, String indexName, HttpEntity data) throws IOException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
@@ -84,6 +84,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
+import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.Interpolator;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.LinearUniformInterpolator;
 import com.amazon.opendistroforelasticsearch.ad.dataprocessor.SingleFeatureLinearUniformInterpolator;
@@ -343,7 +344,7 @@ public class SearchFeatureDaoTests {
             new Object[] { asList(multiBucket), asList(aggName), null }, };
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = EndRunException.class)
     @Parameters(method = "getFeaturesForPeriodThrowIllegalStateData")
     public void getFeaturesForPeriod_throwIllegalState_forUnknownAggregation(
         List<Aggregation> aggs,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -1034,4 +1034,11 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         Response profileResponse = getDetectorProfile(detector.getDetectorId(), true, "/models/");
         assertEquals("Incorrect profile status", RestStatus.OK, restStatus(profileResponse));
     }
+
+    public void testRunDetectorWithNoEnabledFeature() throws Exception {
+        AnomalyDetector detector = createRandomAnomalyDetector(true, true, false);
+        assertNotNull(detector.getDetectorId());
+        ResponseException e = expectThrows(ResponseException.class, () -> startAnomalyDetector(detector.getDetectorId()));
+        assertTrue(e.getMessage().contains("Can't start detector job as no enabled features configured"));
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportActionTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomQuery;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.ADIntegTestCase;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.Feature;
+import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class AnomalyResultTransportActionTests extends ADIntegTestCase {
+    private String testIndex;
+    private Instant testDataTimeStamp;
+    private long start;
+    private long end;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        testIndex = "test_data";
+        testDataTimeStamp = Instant.now();
+        start = testDataTimeStamp.minus(10, ChronoUnit.MINUTES).toEpochMilli();
+        end = testDataTimeStamp.plus(10, ChronoUnit.MINUTES).toEpochMilli();
+        ingestTestData();
+    }
+
+    private void ingestTestData() throws IOException {
+        String mappings = "{\"properties\":{\"timestamp\":{\"type\":\"date\",\"format\":\"strict_date_time||epoch_millis\"},"
+            + "\"value\":{\"type\":\"double\"}, \"type\":{\"type\":\"keyword\"},"
+            + "\"is_error\":{\"type\":\"boolean\"}, \"message\":{\"type\":\"text\"}}}";
+        createIndex(testIndex, mappings);
+        double value = randomDouble();
+        String type = randomAlphaOfLength(5);
+        boolean isError = randomBoolean();
+        String message = randomAlphaOfLength(10);
+        String id = indexDoc(
+            testIndex,
+            ImmutableMap
+                .of("timestamp", testDataTimeStamp.toEpochMilli(), "value", value, "type", type, "is_error", isError, "message", message)
+        );
+        GetResponse doc = getDoc(testIndex, id);
+        Map<String, Object> sourceAsMap = doc.getSourceAsMap();
+        assertEquals(testDataTimeStamp.toEpochMilli(), sourceAsMap.get("timestamp"));
+        assertEquals(value, sourceAsMap.get("value"));
+        assertEquals(type, sourceAsMap.get("type"));
+        assertEquals(isError, sourceAsMap.get("is_error"));
+        assertEquals(message, sourceAsMap.get("message"));
+        createDetectorIndex();
+    }
+
+    public void testFeatureQueryWithTermsAggregation() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"terms\":{\"field\":\"type\"}}}");
+        assertErrorMessage(adId, "Failed to parse aggregation");
+    }
+
+    public void testFeatureWithSumOfTextField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"sum\":{\"field\":\"message\"}}}");
+        assertErrorMessage(adId, "Text fields are not optimised for operations");
+    }
+
+    public void testFeatureWithSumOfTypeField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"sum\":{\"field\":\"type\"}}}");
+        assertErrorMessage(adId, "is not supported for aggregation [sum]");
+    }
+
+    public void testFeatureWithMaxOfTextField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"max\":{\"field\":\"message\"}}}");
+        assertErrorMessage(adId, "Text fields are not optimised for operations");
+    }
+
+    public void testFeatureWithMaxOfTypeField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"max\":{\"field\":\"type\"}}}");
+        assertErrorMessage(adId, "is not supported for aggregation [max]");
+    }
+
+    public void testFeatureWithMinOfTextField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"min\":{\"field\":\"message\"}}}");
+        assertErrorMessage(adId, "Text fields are not optimised for operations");
+    }
+
+    public void testFeatureWithMinOfTypeField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"min\":{\"field\":\"type\"}}}");
+        assertErrorMessage(adId, "is not supported for aggregation [min]");
+    }
+
+    public void testFeatureWithAvgOfTextField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"avg\":{\"field\":\"message\"}}}");
+        assertErrorMessage(adId, "Text fields are not optimised for operations");
+    }
+
+    public void testFeatureWithAvgOfTypeField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"avg\":{\"field\":\"type\"}}}");
+        assertErrorMessage(adId, "is not supported for aggregation [avg]");
+    }
+
+    public void testFeatureWithCountOfTextField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"value_count\":{\"field\":\"message\"}}}");
+        assertErrorMessage(adId, "Text fields are not optimised for operations");
+    }
+
+    public void testFeatureWithCardinalityOfTextField() throws IOException {
+        String adId = createDetectorWithFeatureAgg("{\"test\":{\"cardinality\":{\"field\":\"message\"}}}");
+        assertErrorMessage(adId, "Text fields are not optimised for operations");
+    }
+
+    private String createDetectorWithFeatureAgg(String aggQuery) throws IOException {
+        AggregationBuilder aggregationBuilder = TestHelpers.parseAggregation(aggQuery);
+        Feature feature = new Feature(randomAlphaOfLength(5), randomAlphaOfLength(10), true, aggregationBuilder);
+        AnomalyDetector detector = randomDetector(ImmutableList.of(testIndex), ImmutableList.of(feature));
+        String adId = createDetectors(detector);
+        return adId;
+    }
+
+    private AnomalyDetector randomDetector(List<String> indices, List<Feature> features) throws IOException {
+        return new AnomalyDetector(
+            randomAlphaOfLength(10),
+            randomLong(),
+            randomAlphaOfLength(20),
+            randomAlphaOfLength(30),
+            "timestamp",
+            indices,
+            features,
+            randomQuery("{\"bool\":{\"filter\":[{\"exists\":{\"field\":\"value\"}}]}}"),
+            new IntervalTimeConfiguration(ESRestTestCase.randomLongBetween(1, 5), ChronoUnit.MINUTES),
+            new IntervalTimeConfiguration(ESRestTestCase.randomLongBetween(1, 5), ChronoUnit.MINUTES),
+            8,
+            null,
+            randomInt(),
+            Instant.now()
+        );
+    }
+
+    private void assertErrorMessage(String adId, String errorMessage) {
+        AnomalyResultRequest resultRequest = new AnomalyResultRequest(adId, start, end);
+        RuntimeException e = expectThrowsAnyOf(
+            ImmutableList.of(NotSerializableExceptionWrapper.class, AnomalyDetectionException.class),
+            () -> client().execute(AnomalyResultAction.INSTANCE, resultRequest).actionGet(30_000)
+        );
+        assertTrue(e.getMessage().contains(errorMessage));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

Backport this change: https://github.com/opendistro-for-elasticsearch/anomaly-detection/pull/341

## Description of changes:

1. Catch wrong feature query exception and stop detector
2. Some exceptions are caused by customer input, which not related with the code logic. Will filter out such exceptions so we can get the failure stats which caused by server error.

## Test
1. `./gradlew build`
2. `./gradlew integTest -PnumNodes=3 `
3. Start local cluster and test



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
