### PR TITLE
backport change of PR348: return directly for invalid query checking.

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportAction.java
@@ -509,15 +509,14 @@ public class AnomalyResultTransportAction extends HandledTransportAction<ActionR
     }
 
     private boolean invalidQuery(SearchPhaseExecutionException ex) {
-        boolean invalidQuery = true;
         // If all shards return bad request and failure cause is IllegalArgumentException, we
         // consider the feature query is invalid and will not count the error in failure stats.
         for (ShardSearchFailure failure : ex.shardFailures()) {
             if (RestStatus.BAD_REQUEST != failure.status() || !(failure.getCause() instanceof IllegalArgumentException)) {
-                invalidQuery = false;
+                return false;
             }
         }
-        return invalidQuery;
+        return true;
     }
 
     class RCFActionListener implements ActionListener<RCFResultResponse> {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tune invalid query checking, return false directly rather than reach end of for loop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
