### PR TITLE
start historical detector

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -470,7 +470,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
             )
             .put(
                 StatNames.ANOMALY_DETECTION_STATE_STATUS.getName(),
-                new ADStat<>(true, new IndexStatusSupplier(indexUtils, DetectorInternalState.DETECTOR_STATE_INDEX))
+                new ADStat<>(true, new IndexStatusSupplier(indexUtils, CommonName.DETECTION_STATE_INDEX))
             )
             .put(StatNames.DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
             .put(StatNames.HISTORICAL_SINGLE_ENTITY_DETECTOR_COUNT.getName(), new ADStat<>(true, new SettableSupplier()))
@@ -706,7 +706,7 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                         new SystemIndexDescriptor(AnomalyDetector.ANOMALY_DETECTORS_INDEX, "detector definition"),
                         new SystemIndexDescriptor(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, "detector job"),
                         new SystemIndexDescriptor(CommonName.CHECKPOINT_INDEX_NAME, "model checkpoint"),
-                        new SystemIndexDescriptor(DetectorInternalState.DETECTOR_STATE_INDEX, "detector information like total rcf updates")
+                        new SystemIndexDescriptor(CommonName.DETECTION_STATE_INDEX, "detector information like total rcf updates")
                     )
             );
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunner.java
@@ -189,7 +189,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                             false
                         );
                     if (profilesToCollect.contains(DetectorProfileName.ERROR)) {
-                        GetRequest getStateRequest = new GetRequest(DetectorInternalState.DETECTOR_STATE_INDEX, detectorId);
+                        GetRequest getStateRequest = new GetRequest(CommonName.DETECTION_STATE_INDEX, detectorId);
                         client.get(getStateRequest, onGetDetectorState(delegateListener, detectorId, enabledTimeMs));
                     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/EntityProfileRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/EntityProfileRunner.java
@@ -349,7 +349,7 @@ public class EntityProfileRunner extends AbstractProfileRunner {
 
         SearchSourceBuilder source = new SearchSourceBuilder()
             .query(boolQueryBuilder)
-            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX).field(AnomalyResult.EXECUTION_END_TIME_FIELD))
+            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX_TIME).field(AnomalyResult.EXECUTION_END_TIME_FIELD))
             .trackTotalHits(false)
             .size(0);
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/breaker/MemoryCircuitBreaker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/breaker/MemoryCircuitBreaker.java
@@ -22,11 +22,11 @@ import org.elasticsearch.monitor.jvm.JvmService;
  */
 public class MemoryCircuitBreaker extends ThresholdCircuitBreaker<Short> {
 
-    private static final short defaultThreshold = 85;
+    public static final short DEFAULT_JVM_HEAP_USAGE_THRESHOLD = 85;
     private final JvmService jvmService;
 
     public MemoryCircuitBreaker(JvmService jvmService) {
-        super(defaultThreshold);
+        super(DEFAULT_JVM_HEAP_USAGE_THRESHOLD);
         this.jvmService = jvmService;
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/ADTaskCancelledException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/ADTaskCancelledException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.common.exception;
+
+public class ADTaskCancelledException extends AnomalyDetectionException {
+    private String cancelledBy;
+
+    public ADTaskCancelledException(String msg, String user) {
+        super(msg);
+        this.cancelledBy = user;
+        this.countedInStats(false);
+    }
+
+    public String getCancelledBy() {
+        return cancelledBy;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/LimitExceededException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/LimitExceededException.java
@@ -37,7 +37,17 @@ public class LimitExceededException extends EndRunException {
      * @param message explanation for the limit
      */
     public LimitExceededException(String message) {
-        super(null, message, true);
+        super(message, true);
+    }
+
+    /**
+     * Constructor with error message.
+     *
+     * @param message explanation for the limit
+     * @param endRun end detector run or not
+     */
+    public LimitExceededException(String message, boolean endRun) {
+        super(null, message, endRun);
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
@@ -23,6 +23,7 @@ public class CommonName {
     public static final String CHECKPOINT_INDEX_NAME = ".opendistro-anomaly-checkpoints";
     // index name for anomaly detection state. Will store AD task in this index as well.
     public static final String DETECTION_STATE_INDEX = ".opendistro-anomaly-detection-state";
+    // TODO: move other index name here
 
     // The alias of the index in which to write AD result history
     public static final String ANOMALY_RESULT_INDEX_ALIAS = ".opendistro-anomaly-results";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
@@ -21,6 +21,8 @@ public class CommonName {
     // ======================================
     // index name for anomaly checkpoint of each model. One model one document.
     public static final String CHECKPOINT_INDEX_NAME = ".opendistro-anomaly-checkpoints";
+    // index name for anomaly detection state. Will store AD task in this index as well.
+    public static final String DETECTION_STATE_INDEX = ".opendistro-anomaly-detection-state";
 
     // The alias of the index in which to write AD result history
     public static final String ANOMALY_RESULT_INDEX_ALIAS = ".opendistro-anomaly-results";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
@@ -83,5 +83,11 @@ public class CommonName {
     // Query
     // ======================================
     // Used in finding the max timestamp
-    public static final String AGG_NAME_MAX = "max_timefield";
+    public static final String AGG_NAME_MAX_TIME = "max_timefield";
+    // Used in finding the min timestamp
+    public static final String AGG_NAME_MIN_TIME = "min_timefield";
+    // date histogram aggregation name
+    public static final String DATE_HISTOGRAM = "date_histogram";
+    // feature aggregation name
+    public static final String FEATURE_AGGS = "feature_aggs";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -700,7 +700,7 @@ public class FeatureManager implements CleanState {
         }
     }
 
-    public void getFeatureDataPoints(
+    public void getFeatureDataPointsByBatch(
         AnomalyDetector detector,
         long startTime,
         long endTime,
@@ -733,7 +733,6 @@ public class FeatureManager implements CleanState {
         });
         shingle.clear();
 
-        shingle.clear();
         getFullShingleEndTimes(endTime, detector.getDetectorIntervalInMilliseconds(), detector.getShingleSize())
             .mapToObj(time -> featuresMap.getOrDefault(time, new SimpleImmutableEntry<>(time, Optional.empty())))
             .forEach(e -> shingle.add(e));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -172,7 +172,7 @@ public class FeatureManager implements CleanState {
                 listener.onFailure(new EndRunException(detector.getDetectorId(), CommonErrorMessages.INVALID_SEARCH_QUERY_MSG, e, true));
             }
         } else {
-            getProcessedFeatures(shingle, detector, endTime, listener);
+            listener.onResponse(getProcessedFeatures(shingle, detector, endTime));
         }
     }
 
@@ -220,26 +220,7 @@ public class FeatureManager implements CleanState {
             .mapToObj(time -> featuresMap.getOrDefault(time, new SimpleImmutableEntry<>(time, Optional.empty())))
             .forEach(e -> shingle.add(e));
 
-        getProcessedFeatures(shingle, detector, endTime, listener);
-    }
-
-    private void getProcessedFeatures(
-        Deque<Entry<Long, Optional<double[]>>> shingle,
-        AnomalyDetector detector,
-        long endTime,
-        ActionListener<SinglePointFeatures> listener
-    ) {
-        int shingleSize = detector.getShingleSize();
-        Optional<double[]> currentPoint = shingle.peekLast().getValue();
-        listener
-            .onResponse(
-                new SinglePointFeatures(
-                    currentPoint,
-                    Optional
-                        .ofNullable(currentPoint.isPresent() ? filterAndFill(shingle, endTime, detector) : null)
-                        .map(points -> batchShingle(points, shingleSize)[0])
-                )
-            );
+        listener.onResponse(getProcessedFeatures(shingle, detector, endTime));
     }
 
     private double[][] filterAndFill(Deque<Entry<Long, Optional<double[]>>> shingle, long endTime, AnomalyDetector detector) {
@@ -708,11 +689,12 @@ public class FeatureManager implements CleanState {
     ) {
         try {
             searchFeatureDao.getFeaturesForPeriodByBatch(detector, startTime, endTime, ActionListener.wrap(points -> {
-                logger.info("features size: {}", points.size());
+                logger.debug("features size: {}", points.size());
                 listener.onResponse(points);
             }, listener::onFailure));
         } catch (Exception e) {
             logger.error("Failed to get features for detector: " + detector.getDetectorId());
+            listener.onFailure(e);
         }
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManager.java
@@ -699,4 +699,63 @@ public class FeatureManager implements CleanState {
             return -1;
         }
     }
+
+    public void getFeatureDataPoints(
+        AnomalyDetector detector,
+        long startTime,
+        long endTime,
+        ActionListener<Map<Long, Optional<double[]>>> listener
+    ) {
+        try {
+            searchFeatureDao.getFeaturesForPeriodByBatch(detector, startTime, endTime, ActionListener.wrap(points -> {
+                logger.info("features size: {}", points.size());
+                listener.onResponse(points);
+            }, listener::onFailure));
+        } catch (Exception e) {
+            logger.error("Failed to get features for detector: " + detector.getDetectorId());
+        }
+    }
+
+    public SinglePointFeatures getShingledFeature(
+        AnomalyDetector detector,
+        Deque<Entry<Long, Optional<double[]>>> shingle,
+        Map<Long, Optional<double[]>> dataPoints,
+        long endTime
+    ) {
+        long maxTimeDifference = detector.getDetectorIntervalInMilliseconds() / 2;
+        Map<Long, Entry<Long, Optional<double[]>>> featuresMap = getNearbyPointsForShingle(detector, shingle, endTime, maxTimeDifference)
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        List<Entry<Long, Long>> missingRanges = getMissingRangesInShingle(detector, featuresMap, endTime);
+        missingRanges.stream().forEach(r -> {
+            if (dataPoints.containsKey(r.getKey())) {
+                featuresMap.put(r.getValue(), new SimpleImmutableEntry<>(r.getValue(), dataPoints.get(r.getKey())));
+            }
+        });
+        shingle.clear();
+
+        shingle.clear();
+        getFullShingleEndTimes(endTime, detector.getDetectorIntervalInMilliseconds(), detector.getShingleSize())
+            .mapToObj(time -> featuresMap.getOrDefault(time, new SimpleImmutableEntry<>(time, Optional.empty())))
+            .forEach(e -> shingle.add(e));
+
+        return getProcessedFeatures(shingle, detector, endTime);
+    }
+
+    private SinglePointFeatures getProcessedFeatures(
+        Deque<Entry<Long, Optional<double[]>>> shingle,
+        AnomalyDetector detector,
+        long endTime
+    ) {
+        int shingleSize = detector.getShingleSize();
+        Optional<double[]> currentPoint = shingle.peekLast().getValue();
+        return new SinglePointFeatures(
+            currentPoint,
+            Optional
+                // if current point is not present or current shingle has more missing data points than
+                // max missing rate, will return null
+                .ofNullable(currentPoint.isPresent() ? filterAndFill(shingle, endTime, detector) : null)
+                .map(points -> batchShingle(points, shingleSize)[0])
+        );
+    }
+
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/ADIndex.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/ADIndex.java
@@ -20,7 +20,6 @@ import java.util.function.Supplier;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
-import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.util.ThrowingSupplierWrapper;
 
 /**
@@ -51,7 +50,7 @@ public enum ADIndex {
         ThrowingSupplierWrapper.throwingSupplierWrapper(AnomalyDetectionIndices::getCheckpointMappings)
     ),
     STATE(
-        DetectorInternalState.DETECTOR_STATE_INDEX,
+        CommonName.DETECTION_STATE_INDEX,
         false,
         ThrowingSupplierWrapper.throwingSupplierWrapper(AnomalyDetectionIndices::getDetectionStateMappings)
     );

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/ADIndex.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/ADIndex.java
@@ -53,7 +53,7 @@ public enum ADIndex {
     STATE(
         DetectorInternalState.DETECTOR_STATE_INDEX,
         false,
-        ThrowingSupplierWrapper.throwingSupplierWrapper(AnomalyDetectionIndices::getDetectorStateMappings)
+        ThrowingSupplierWrapper.throwingSupplierWrapper(AnomalyDetectionIndices::getDetectionStateMappings)
     );
 
     private final String indexName;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
@@ -211,7 +211,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      * @return anomaly detector state index mapping
      * @throws IOException IOException if mapping file can't be read correctly
      */
-    public static String getDetectorStateMappings() throws IOException {
+    public static String getDetectionStateMappings() throws IOException {
         URL url = AnomalyDetectionIndices.class.getClassLoader().getResource(ANOMALY_DETECTION_STATE_INDEX_MAPPING_FILE);
         return Resources.toString(url, Charsets.UTF_8);
     }
@@ -376,26 +376,33 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      * Create anomaly detector job index.
      *
      * @param actionListener action called after create index
-     * @throws IOException IOException from {@link AnomalyDetectionIndices#getAnomalyDetectorJobMappings}
      */
-    public void initAnomalyDetectorJobIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
-        // TODO: specify replica setting
-        CreateIndexRequest request = new CreateIndexRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)
-            .mapping(AnomalyDetector.TYPE, getAnomalyDetectorJobMappings(), XContentType.JSON);
-        choosePrimaryShards(request);
-        adminClient.indices().create(request, markMappingUpToDate(ADIndex.JOB, actionListener));
+    public void initAnomalyDetectorJobIndex(ActionListener<CreateIndexResponse> actionListener) {
+        try {
+            CreateIndexRequest request = new CreateIndexRequest(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)
+                .mapping(AnomalyDetector.TYPE, getAnomalyDetectorJobMappings(), XContentType.JSON);
+            choosePrimaryShards(request);
+            adminClient.indices().create(request, markMappingUpToDate(ADIndex.JOB, actionListener));
+        } catch (IOException e) {
+            logger.error("Fail to init AD job index", e);
+            actionListener.onFailure(e);
+        }
     }
 
     /**
      * Create the state index.
      *
      * @param actionListener action called after create index
-     * @throws IOException IOException from {@link AnomalyDetectionIndices#getDetectorStateMappings}
      */
-    public void initDetectorStateIndex(ActionListener<CreateIndexResponse> actionListener) throws IOException {
-        CreateIndexRequest request = new CreateIndexRequest(DetectorInternalState.DETECTOR_STATE_INDEX)
-            .mapping(AnomalyDetector.TYPE, getDetectorStateMappings(), XContentType.JSON);
-        adminClient.indices().create(request, markMappingUpToDate(ADIndex.STATE, actionListener));
+    public void initDetectionStateIndex(ActionListener<CreateIndexResponse> actionListener) {
+        try {
+            CreateIndexRequest request = new CreateIndexRequest(DetectorInternalState.DETECTOR_STATE_INDEX)
+                .mapping(AnomalyDetector.TYPE, getDetectionStateMappings(), XContentType.JSON);
+            adminClient.indices().create(request, markMappingUpToDate(ADIndex.STATE, actionListener));
+        } catch (IOException e) {
+            logger.error("Fail to init AD detection state index", e);
+            actionListener.onFailure(e);
+        }
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
@@ -74,7 +74,6 @@ import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
-import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
@@ -260,7 +259,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      * @return true if anomaly state index exists
      */
     public boolean doesDetectorStateIndexExist() {
-        return clusterService.state().getRoutingTable().hasIndex(DetectorInternalState.DETECTOR_STATE_INDEX);
+        return clusterService.state().getRoutingTable().hasIndex(CommonName.DETECTION_STATE_INDEX);
     }
 
     /**
@@ -396,7 +395,7 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      */
     public void initDetectionStateIndex(ActionListener<CreateIndexResponse> actionListener) {
         try {
-            CreateIndexRequest request = new CreateIndexRequest(DetectorInternalState.DETECTOR_STATE_INDEX)
+            CreateIndexRequest request = new CreateIndexRequest(CommonName.DETECTION_STATE_INDEX)
                 .mapping(AnomalyDetector.TYPE, getDetectionStateMappings(), XContentType.JSON);
             adminClient.indices().create(request, markMappingUpToDate(ADIndex.STATE, actionListener));
         } catch (IOException e) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
@@ -36,8 +36,6 @@ import com.google.common.base.Objects;
  */
 public class ADTask implements ToXContentObject, Writeable {
 
-    public static final String DETECTION_STATE_INDEX = ".opendistro-anomaly-detection-state";
-
     public static final String TASK_ID_FIELD = "task_id";
     public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
     public static final String STARTED_BY_FIELD = "started_by";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
@@ -36,7 +36,7 @@ import com.google.common.base.Objects;
  */
 public class ADTask implements ToXContentObject, Writeable {
 
-    public static final String DETECTOR_STATE_INDEX = ".opendistro-anomaly-detection-state";
+    public static final String DETECTION_STATE_INDEX = ".opendistro-anomaly-detection-state";
 
     public static final String TASK_ID_FIELD = "task_id";
     public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -51,6 +51,7 @@ import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
 import com.amazon.opendistroforelasticsearch.ad.util.ParseUtils;
 import com.amazon.opendistroforelasticsearch.commons.authuser.User;
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 
 /**
  * An AnomalyDetector is used to represent anomaly detection model(RCF) related parameters.
@@ -211,7 +212,7 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
         this.description = description;
         this.timeField = timeField;
         this.indices = indices;
-        this.featureAttributes = features;
+        this.featureAttributes = features == null ? ImmutableList.of() : ImmutableList.copyOf(features);
         this.filterQuery = filterQuery;
         this.detectionInterval = detectionInterval;
         this.windowDelay = windowDelay;
@@ -311,11 +312,8 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
             .field(DETECTION_INTERVAL_FIELD, detectionInterval)
             .field(WINDOW_DELAY_FIELD, windowDelay)
             .field(SHINGLE_SIZE_FIELD, shingleSize)
-            .field(CommonName.SCHEMA_VERSION_FIELD, schemaVersion);
-
-        if (featureAttributes != null) {
-            xContentBuilder.field(FEATURE_ATTRIBUTES_FIELD, featureAttributes.toArray());
-        }
+            .field(CommonName.SCHEMA_VERSION_FIELD, schemaVersion)
+            .field(FEATURE_ATTRIBUTES_FIELD, featureAttributes.toArray());
 
         if (uiMetadata != null && !uiMetadata.isEmpty()) {
             xContentBuilder.field(UI_METADATA_FIELD, uiMetadata);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRange.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectionDateRange.java
@@ -43,28 +43,32 @@ public class DetectionDateRange implements ToXContentObject, Writeable {
     public DetectionDateRange(Instant startTime, Instant endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
+        validate();
+    }
+
+    public DetectionDateRange(StreamInput in) throws IOException {
+        this.startTime = in.readInstant();
+        this.endTime = in.readInstant();
+        validate();
+    }
+
+    private void validate() {
         if (startTime == null) {
             throw new IllegalArgumentException("Detection data range's start time must not be null");
         }
         if (endTime == null) {
             throw new IllegalArgumentException("Detection data range's end time must not be null");
         }
-    }
-
-    public DetectionDateRange(StreamInput in) throws IOException {
-        this.startTime = in.readInstant();
-        this.endTime = in.readInstant();
+        if (startTime.isAfter(endTime)) {
+            throw new IllegalArgumentException("Detection data range's end time must be after start time");
+        }
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject();
-        if (startTime != null) {
-            xContentBuilder.field(START_TIME_FIELD, startTime.toEpochMilli());
-        }
-        if (endTime != null) {
-            xContentBuilder.field(END_TIME_FIELD, endTime.toEpochMilli());
-        }
+        xContentBuilder.field(START_TIME_FIELD, startTime.toEpochMilli());
+        xContentBuilder.field(END_TIME_FIELD, endTime.toEpochMilli());
         return xContentBuilder.endObject();
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorInternalState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorInternalState.java
@@ -42,8 +42,6 @@ public class DetectorInternalState implements ToXContentObject, Cloneable {
         it -> parse(it)
     );
 
-    public static final String DETECTOR_STATE_INDEX = ".opendistro-anomaly-detection-state";
-
     public static final String LAST_UPDATE_TIME_FIELD = "last_update_time";
     public static final String ERROR_FIELD = "error";
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorActionHandler.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.ad.rest.handler;
 
 import static com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector.ANOMALY_DETECTORS_INDEX;
+import static com.amazon.opendistroforelasticsearch.ad.util.ExceptionUtil.getShardsFailure;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.XCONTENT_WITH_TYPE;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -44,7 +45,6 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.unit.TimeValue;
@@ -448,7 +448,9 @@ public class IndexAnomalyDetectorActionHandler {
             anomalyDetector.getSchemaVersion(),
             Instant.now(),
             anomalyDetector.getCategoryField(),
-            user
+            user,
+            anomalyDetector.getDetectorType(),
+            anomalyDetector.getDetectionDateRange()
         );
         IndexRequest indexRequest = new IndexRequest(ANOMALY_DETECTORS_INDEX)
             .setRefreshPolicy(refreshPolicy)
@@ -462,7 +464,7 @@ public class IndexAnomalyDetectorActionHandler {
         client.index(indexRequest, new ActionListener<IndexResponse>() {
             @Override
             public void onResponse(IndexResponse indexResponse) {
-                String errorMsg = checkShardsFailure(indexResponse);
+                String errorMsg = getShardsFailure(indexResponse);
                 if (errorMsg != null) {
                     listener.onFailure(new ElasticsearchStatusException(errorMsg, indexResponse.status()));
                     return;
@@ -503,14 +505,4 @@ public class IndexAnomalyDetectorActionHandler {
         }
     }
 
-    private String checkShardsFailure(IndexResponse response) {
-        StringBuilder failureReasons = new StringBuilder();
-        if (response.getShardInfo().getFailed() > 0) {
-            for (ReplicationResponse.ShardInfo.Failure failure : response.getShardInfo().getFailures()) {
-                failureReasons.append(failure);
-            }
-            return failureReasons.toString();
-        }
-        return null;
-    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/settings/AnomalyDetectorSettings.java
@@ -335,4 +335,37 @@ public final class AnomalyDetectorSettings {
         );
 
     public static int THRESHOLD_MODEL_TRAINING_SIZE = 1000;
+
+    public static final Setting<Integer> MAX_OLD_AD_TASK_DOCS_PER_DETECTOR = Setting
+        .intSetting(
+            "opendistro.anomaly_detection.max_old_ad_task_docs_per_detector",
+            // One AD task is roughly 1.5KB for normal case. Suppose task's size
+            // is 2KB conservatively. If we store 1000 AD tasks for one detector,
+            // that will be 2GB.
+            10,
+            1, // keep at least 1 old AD task per detector
+            1000,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> BATCH_TASK_PIECE_SIZE = Setting
+        .intSetting(
+            "opendistro.anomaly_detection.batch_task_piece_size",
+            1000,
+            1,
+            10_000,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+
+    public static final Setting<Integer> BATCH_TASK_PIECE_INTERVAL_SECONDS = Setting
+        .intSetting(
+            "opendistro.anomaly_detection.batch_task_piece_interval_seconds",
+            5,
+            1,
+            600,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/ADStat.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/ADStat.java
@@ -75,4 +75,13 @@ public class ADStat<T> {
             ((CounterSupplier) supplier).increment();
         }
     }
+
+    /**
+     * Decrease the supplier if it can be decreased.
+     */
+    public void decrement() {
+        if (supplier instanceof CounterSupplier) {
+            ((CounterSupplier) supplier).decrement();
+        }
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/suppliers/CounterSupplier.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/stats/suppliers/CounterSupplier.java
@@ -42,4 +42,11 @@ public class CounterSupplier implements Supplier<Long> {
     public void increment() {
         counter.increment();
     }
+
+    /**
+     * Decrease the value of the counter by 1
+     */
+    public void decrement() {
+        counter.decrement();
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADBatchTaskRunner.java
@@ -1,0 +1,718 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.task;
+
+import static com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin.AD_BATCH_TASK_THREAD_POOL_NAME;
+import static com.amazon.opendistroforelasticsearch.ad.breaker.MemoryCircuitBreaker.DEFAULT_JVM_HEAP_USAGE_THRESHOLD;
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.AGG_NAME_MAX_TIME;
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.AGG_NAME_MIN_TIME;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.CURRENT_PIECE_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.EXECUTION_END_TIME_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.INIT_PROGRESS_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.STATE_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.TASK_PROGRESS_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_SIZE;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.NUM_MIN_SAMPLES;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.THRESHOLD_MODEL_TRAINING_SIZE;
+import static com.amazon.opendistroforelasticsearch.ad.stats.InternalStatNames.JVM_HEAP_USAGE;
+import static com.amazon.opendistroforelasticsearch.ad.stats.StatNames.AD_EXECUTING_BATCH_TASK_COUNT;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.ThreadedActionListener;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.metrics.InternalMax;
+import org.elasticsearch.search.aggregations.metrics.InternalMin;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.breaker.ADCircuitBreakerService;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.ADTaskCancelledException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.ResourceNotFoundException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.feature.FeatureManager;
+import com.amazon.opendistroforelasticsearch.ad.feature.SinglePointFeatures;
+import com.amazon.opendistroforelasticsearch.ad.indices.ADIndex;
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.ml.ThresholdingModel;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
+import com.amazon.opendistroforelasticsearch.ad.model.FeatureData;
+import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.opendistroforelasticsearch.ad.settings.EnabledSetting;
+import com.amazon.opendistroforelasticsearch.ad.stats.ADStats;
+import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchAnomalyResultRequest;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchAnomalyResultResponse;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchTaskRemoteExecutionAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsNodeResponse;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsNodesAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsRequest;
+import com.amazon.opendistroforelasticsearch.ad.transport.handler.AnomalyResultBulkIndexHandler;
+import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
+import com.amazon.opendistroforelasticsearch.ad.util.ExceptionUtil;
+import com.amazon.opendistroforelasticsearch.ad.util.ParseUtils;
+import com.amazon.randomcutforest.RandomCutForest;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.RateLimiter;
+
+public class ADBatchTaskRunner {
+    private final Logger logger = LogManager.getLogger(ADBatchTaskRunner.class);
+
+    private final RateLimiter rateLimiter = RateLimiter.create(1);
+
+    private final ThreadPool threadPool;
+    private final Client client;
+    private final ADStats adStats;
+    private final DiscoveryNodeFilterer nodeFilter;
+    private final ClusterService clusterService;
+    private final FeatureManager featureManager;
+    private final ADCircuitBreakerService adCircuitBreakerService;
+    private final ADTaskManager adTaskManager;
+    private final AnomalyResultBulkIndexHandler anomalyResultBulkIndexHandler;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private AnomalyDetectionIndices anomalyDetectionIndices;
+
+    private final ADTaskCacheManager adTaskCacheManager;
+    private final TransportRequestOptions option;
+
+    private volatile Integer maxAdBatchTaskPerNode;
+    private volatile Integer pieceSize;
+    private volatile Integer pieceIntervalSeconds;
+
+    public ADBatchTaskRunner(
+        Settings settings,
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        Client client,
+        DiscoveryNodeFilterer nodeFilter,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        ADCircuitBreakerService adCircuitBreakerService,
+        FeatureManager featureManager,
+        ADTaskManager adTaskManager,
+        AnomalyDetectionIndices anomalyDetectionIndices,
+        ADStats adStats,
+        AnomalyResultBulkIndexHandler anomalyResultBulkIndexHandler,
+        ADTaskCacheManager adTaskCacheManager
+    ) {
+        this.threadPool = threadPool;
+        this.clusterService = clusterService;
+        this.client = client;
+        this.anomalyResultBulkIndexHandler = anomalyResultBulkIndexHandler;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.nodeFilter = nodeFilter;
+        this.adStats = adStats;
+        this.adCircuitBreakerService = adCircuitBreakerService;
+        this.adTaskManager = adTaskManager;
+        this.featureManager = featureManager;
+        this.anomalyDetectionIndices = anomalyDetectionIndices;
+
+        this.option = TransportRequestOptions
+            .builder()
+            .withType(TransportRequestOptions.Type.REG)
+            .withTimeout(AnomalyDetectorSettings.REQUEST_TIMEOUT.get(settings))
+            .build();
+
+        this.adTaskCacheManager = adTaskCacheManager;
+
+        this.maxAdBatchTaskPerNode = MAX_BATCH_TASK_PER_NODE.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_BATCH_TASK_PER_NODE, it -> maxAdBatchTaskPerNode = it);
+
+        this.pieceSize = BATCH_TASK_PIECE_SIZE.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(BATCH_TASK_PIECE_SIZE, it -> pieceSize = it);
+
+        this.pieceIntervalSeconds = BATCH_TASK_PIECE_INTERVAL_SECONDS.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(BATCH_TASK_PIECE_INTERVAL_SECONDS, it -> pieceIntervalSeconds = it);
+    }
+
+    /**
+     * Run AD task.
+     * 1. Set AD task state as {@link ADTaskState#INIT}
+     * 2. Gather node stats and find node with least load to run AD task.
+     *
+     * @param adTask AD task
+     * @param transportService transport service
+     * @param listener action listener
+     */
+    public void run(ADTask adTask, TransportService transportService, ActionListener<ADBatchAnomalyResultResponse> listener) {
+        Map<String, Object> updatedFields = new HashMap<>();
+        updatedFields.put(STATE_FIELD, ADTaskState.INIT.name());
+        updatedFields.put(INIT_PROGRESS_FIELD, 0.0f);
+        adTaskManager
+            .updateADTask(adTask.getTaskId(), updatedFields, ActionListener.wrap(r -> getNodeStats(adTask, ActionListener.wrap(node -> {
+                if (clusterService.localNode().getId().equals(node.getId())) {
+                    // Execute batch task locally
+                    logger
+                        .info(
+                            "execute AD task {} locally on node {} for detector {}",
+                            adTask.getTaskId(),
+                            node.getId(),
+                            adTask.getDetectorId()
+                        );
+                    startADBatchTask(adTask, false, listener);
+                } else {
+                    // Execute batch task remotely
+                    logger
+                        .info(
+                            "execute AD task {} remotely on node {} for detector {}",
+                            adTask.getTaskId(),
+                            node.getId(),
+                            adTask.getDetectorId()
+                        );
+                    transportService
+                        .sendRequest(
+                            node,
+                            ADBatchTaskRemoteExecutionAction.NAME,
+                            new ADBatchAnomalyResultRequest(adTask),
+                            option,
+                            new ActionListenerResponseHandler<>(listener, ADBatchAnomalyResultResponse::new)
+                        );
+                }
+            }, e -> listener.onFailure(e))), e -> {
+                logger.warn("Failed to move task to INIT state, task id " + adTask.getTaskId());
+                listener.onFailure(e);
+            }));
+    }
+
+    private void getNodeStats(ADTask adTask, ActionListener<DiscoveryNode> listener) {
+        DiscoveryNode[] dataNodes = nodeFilter.getEligibleDataNodes();
+        ADStatsRequest adStatsRequest = new ADStatsRequest(dataNodes);
+        adStatsRequest.addAll(ImmutableSet.of(AD_EXECUTING_BATCH_TASK_COUNT.getName(), JVM_HEAP_USAGE.getName()));
+
+        client.execute(ADStatsNodesAction.INSTANCE, adStatsRequest, ActionListener.wrap(adStatsResponse -> {
+            List<ADStatsNodeResponse> candidateNodeResponse = adStatsResponse
+                .getNodes()
+                .stream()
+                .filter(stat -> (long) stat.getStatsMap().get(JVM_HEAP_USAGE.getName()) < DEFAULT_JVM_HEAP_USAGE_THRESHOLD)
+                .collect(Collectors.toList());
+
+            if (candidateNodeResponse.size() == 0) {
+                String errorMessage = "All nodes' memory usage exceeds limitation. No eligible node to run detector "
+                    + adTask.getDetectorId();
+                logger.warn(errorMessage);
+                listener.onFailure(new LimitExceededException(adTask.getDetectorId(), errorMessage));
+                return;
+            }
+            candidateNodeResponse = candidateNodeResponse
+                .stream()
+                .filter(stat -> (Long) stat.getStatsMap().get(AD_EXECUTING_BATCH_TASK_COUNT.getName()) < maxAdBatchTaskPerNode)
+                .collect(Collectors.toList());
+            if (candidateNodeResponse.size() == 0) {
+                String errorMessage = "All nodes' executing historical detector count exceeds limitation. No eligible node to run detector "
+                    + adTask.getDetectorId();
+                logger.warn(errorMessage);
+                listener.onFailure(new LimitExceededException(adTask.getDetectorId(), errorMessage));
+                return;
+            }
+            candidateNodeResponse = candidateNodeResponse
+                .stream()
+                .sorted(
+                    (ADStatsNodeResponse r1, ADStatsNodeResponse r2) -> ((Long) r1
+                        .getStatsMap()
+                        .get(AD_EXECUTING_BATCH_TASK_COUNT.getName()))
+                            .compareTo((Long) r2.getStatsMap().get(AD_EXECUTING_BATCH_TASK_COUNT.getName()))
+                )
+                .collect(Collectors.toList());
+
+            if (candidateNodeResponse.size() == 1) {
+                listener.onResponse(candidateNodeResponse.get(0).getNode());
+            } else {
+                // if multiple nodes have same running task count, choose the one with least JVM heap usage.
+                Long minTaskCount = (Long) candidateNodeResponse.get(0).getStatsMap().get(AD_EXECUTING_BATCH_TASK_COUNT.getName());
+                Optional<ADStatsNodeResponse> first = candidateNodeResponse
+                    .stream()
+                    .filter(c -> minTaskCount.equals(c.getStatsMap().get(AD_EXECUTING_BATCH_TASK_COUNT.getName())))
+                    .sorted(
+                        (ADStatsNodeResponse r1, ADStatsNodeResponse r2) -> ((Long) r1.getStatsMap().get(JVM_HEAP_USAGE.getName()))
+                            .compareTo((Long) r2.getStatsMap().get(JVM_HEAP_USAGE.getName()))
+                    )
+                    .findFirst();
+                listener.onResponse(first.get().getNode());
+            }
+        }, exception -> {
+            logger.error("Failed to get node's task stats", exception);
+            listener.onFailure(exception);
+        }));
+    }
+
+    /**
+     * Start AD task in dedicated batch task thread pool.
+     *
+     * @param adTask ad task
+     * @param runTaskRemotely run task remotely or not
+     * @param listener action listener
+     */
+    public void startADBatchTask(ADTask adTask, boolean runTaskRemotely, ActionListener<ADBatchAnomalyResultResponse> listener) {
+        try {
+            if (!EnabledSetting.isADPluginEnabled()) {
+                throw new EndRunException(adTask.getDetectorId(), CommonErrorMessages.DISABLED_ERR_MSG, true);
+            }
+            threadPool.executor(AD_BATCH_TASK_THREAD_POOL_NAME).execute(() -> {
+                try {
+                    executeADBatchTask(adTask);
+                } catch (Exception e) {
+                    listener.onFailure(e);
+                    adTaskManager.handleADTaskException(adTask, e);
+                }
+            });
+            listener.onResponse(new ADBatchAnomalyResultResponse(clusterService.localNode().getId(), runTaskRemotely));
+        } catch (Exception e) {
+            logger.error("Fail to start AD batch task " + adTask.getTaskId(), e);
+            listener.onFailure(e);
+        }
+    }
+
+    private void executeADBatchTask(ADTask adTask) {
+        ActionListener<String> listener = internalBatchTaskListener(adTask);
+
+        // track AD executing batch task and total batch task execution count
+        adStats.getStat(AD_EXECUTING_BATCH_TASK_COUNT.getName()).increment();
+        adStats.getStat(StatNames.AD_TOTAL_BATCH_TASK_EXECUTION_COUNT.getName()).increment();
+
+        // put AD task into cache
+        adTaskCacheManager.put(adTask);
+
+        // check if circuit breaker is open
+        checkCircuitBreaker(adTask);
+
+        // start to run first piece
+        Instant executeStartTime = Instant.now();
+        runFirstPiece(adTask, executeStartTime, listener);
+    }
+
+    private ActionListener<String> internalBatchTaskListener(ADTask adTask) {
+        String taskId = adTask.getTaskId();
+        ActionListener<String> listener = ActionListener.wrap(response -> {
+            // If batch task finished normally, remove task from cache and decrease executing task count by 1.
+            adTaskCacheManager.remove(taskId);
+            adStats.getStat(AD_EXECUTING_BATCH_TASK_COUNT.getName()).decrement();
+        }, e -> {
+            // If batch task failed, remove task from cache and decrease executing task count by 1.
+            adTaskCacheManager.remove(taskId);
+            adStats.getStat(AD_EXECUTING_BATCH_TASK_COUNT.getName()).decrement();
+
+            // Check if batch task was cancelled or not by exception type.
+            // If it's cancelled, then increase cancelled task count by 1, otherwise increase failure count by 1.
+            if (e instanceof ADTaskCancelledException) {
+                adStats.getStat(StatNames.AD_CANCELED_BATCH_TASK_COUNT.getName()).increment();
+            } else if (ExceptionUtil.countInStats(e)) {
+                adStats.getStat(StatNames.AD_BATCH_TASK_FAILURE_COUNT.getName()).increment();
+            }
+            // Handle AD task exception
+            adTaskManager.handleADTaskException(adTask, e);
+        });
+        return listener;
+    }
+
+    private void checkCircuitBreaker(ADTask adTask) {
+        String taskId = adTask.getTaskId();
+        if (adCircuitBreakerService.isOpen()) {
+            String error = "Circuit breaker is open";
+            logger.error("AD task: {}, {}", taskId, error);
+            throw new LimitExceededException(adTask.getDetectorId(), error, true);
+        }
+    }
+
+    private void runFirstPiece(ADTask adTask, Instant executeStartTime, ActionListener<String> listener) {
+        try {
+            adTaskManager
+                .updateADTask(
+                    adTask.getTaskId(),
+                    ImmutableMap
+                        .of(
+                            STATE_FIELD,
+                            ADTaskState.INIT.name(),
+                            CURRENT_PIECE_FIELD,
+                            adTask.getDetector().getDetectionDateRange().getStartTime().toEpochMilli(),
+                            TASK_PROGRESS_FIELD,
+                            0.0f,
+                            INIT_PROGRESS_FIELD,
+                            0.0f
+                        ),
+                    ActionListener.wrap(r -> {
+                        try {
+                            checkIfADTaskCancelled(adTask.getTaskId());
+                            getDateRangeOfSourceData(adTask, (minDate, maxDate) -> {
+                                long interval = ((IntervalTimeConfiguration) adTask.getDetector().getDetectionInterval())
+                                    .toDuration()
+                                    .toMillis();
+
+                                DetectionDateRange detectionDateRange = adTask.getDetector().getDetectionDateRange();
+                                long dataStartTime = detectionDateRange.getStartTime().toEpochMilli();
+                                long dataEndTime = detectionDateRange.getEndTime().toEpochMilli();
+
+                                if (minDate >= dataEndTime || maxDate <= dataStartTime) {
+                                    listener
+                                        .onFailure(
+                                            new ResourceNotFoundException(
+                                                adTask.getDetectorId(),
+                                                "There is no data in the detection date range"
+                                            )
+                                        );
+                                    return;
+                                }
+                                if (minDate > dataStartTime) {
+                                    dataStartTime = minDate;
+                                }
+                                if (maxDate < dataEndTime) {
+                                    dataEndTime = maxDate;
+                                }
+
+                                // normalize start/end time to make it consistent with feature data agg result
+                                dataStartTime = dataStartTime - dataStartTime % interval;
+                                dataEndTime = dataEndTime - dataEndTime % interval;
+                                if ((dataEndTime - dataStartTime) < THRESHOLD_MODEL_TRAINING_SIZE * interval) {
+                                    listener
+                                        .onFailure(
+                                            new AnomalyDetectionException("There is no enough data to train model").countedInStats(false)
+                                        );
+                                    return;
+                                }
+                                long expectedPieceEndTime = dataStartTime + pieceSize * interval;
+                                long firstPieceEndTime = expectedPieceEndTime > dataEndTime ? dataEndTime : expectedPieceEndTime;
+                                logger
+                                    .debug(
+                                        "start first piece from {} to {}, interval {}, dataStartTime {}, dataEndTime {},"
+                                            + " detectorId {}, taskId {}",
+                                        dataStartTime,
+                                        firstPieceEndTime,
+                                        interval,
+                                        dataStartTime,
+                                        dataEndTime,
+                                        adTask.getDetectorId(),
+                                        adTask.getTaskId()
+                                    );
+                                getFeatureData(
+                                    adTask,
+                                    dataStartTime, // first piece start time
+                                    firstPieceEndTime, // first piece end time
+                                    dataStartTime,
+                                    dataEndTime,
+                                    interval,
+                                    executeStartTime,
+                                    listener
+                                );
+                            }, listener);
+                        } catch (Exception e) {
+                            listener.onFailure(e);
+                        }
+                    }, e -> { listener.onFailure(e); })
+                );
+        } catch (Exception exception) {
+            listener.onFailure(exception);
+        }
+    }
+
+    private void getDateRangeOfSourceData(ADTask adTask, BiConsumer<Long, Long> consumer, ActionListener listener) {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+            .aggregation(AggregationBuilders.min(AGG_NAME_MIN_TIME).field(adTask.getDetector().getTimeField()))
+            .aggregation(AggregationBuilders.max(AGG_NAME_MAX_TIME).field(adTask.getDetector().getTimeField()))
+            .size(0);
+        SearchRequest request = new SearchRequest()
+            .indices(adTask.getDetector().getIndices().toArray(new String[0]))
+            .source(searchSourceBuilder);
+
+        client.search(request, ActionListener.wrap(r -> {
+            InternalMin minAgg = r.getAggregations().get(AGG_NAME_MIN_TIME);
+            InternalMax maxAgg = r.getAggregations().get(AGG_NAME_MAX_TIME);
+            double minValue = minAgg.getValue();
+            double maxValue = maxAgg.getValue();
+            // If time field not exist or there is no value, will return infinity value
+            if (minValue == Double.POSITIVE_INFINITY) {
+                listener.onFailure(new ResourceNotFoundException(adTask.getDetectorId(), "There is no data in the time field"));
+                return;
+            }
+            consumer.accept((long) minValue, (long) maxValue);
+        }, e -> { listener.onFailure(e); }));
+    }
+
+    private void getFeatureData(
+        ADTask adTask,
+        long pieceStartTime,
+        long pieceEndTime,
+        long dataStartTime,
+        long dataEndTime,
+        long interval,
+        Instant executeStartTime,
+        ActionListener<String> listener
+    ) {
+        ActionListener<Map<Long, Optional<double[]>>> actionListener = ActionListener.wrap(dataPoints -> {
+            try {
+                if (dataPoints.size() == 0) {
+                    logger.debug("No data in current piece with end time: " + pieceEndTime);
+                    runNextPiece(adTask, pieceEndTime, dataStartTime, dataEndTime, interval, listener);
+                } else {
+                    detectAnomaly(
+                        adTask,
+                        dataPoints,
+                        pieceStartTime,
+                        pieceEndTime,
+                        dataStartTime,
+                        dataEndTime,
+                        interval,
+                        executeStartTime,
+                        listener
+                    );
+                }
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }, exception -> {
+            logger.error("Fail to execute onFeatureResponseLocalRCF", exception);
+            listener.onFailure(exception);
+        });
+        ThreadedActionListener threadedActionListener = new ThreadedActionListener<>(
+            logger,
+            threadPool,
+            AD_BATCH_TASK_THREAD_POOL_NAME,
+            actionListener,
+            false
+        );
+
+        featureManager.getFeatureDataPoints(adTask.getDetector(), pieceStartTime, pieceEndTime, threadedActionListener);
+    }
+
+    private void detectAnomaly(
+        ADTask adTask,
+        Map<Long, Optional<double[]>> dataPoints,
+        long pieceStartTime,
+        long pieceEndTime,
+        long dataStartTime,
+        long dataEndTime,
+        long interval,
+        Instant executeStartTime,
+        ActionListener<String> listener
+    ) {
+        String taskId = adTask.getTaskId();
+        RandomCutForest rcf = adTaskCacheManager.getRcfModel(taskId);
+        ThresholdingModel threshold = adTaskCacheManager.getThresholdModel(taskId);
+        Deque<Map.Entry<Long, Optional<double[]>>> shingle = adTaskCacheManager.getShingle(taskId);
+
+        List<AnomalyResult> anomalyResults = new ArrayList<>();
+
+        long intervalEndTime = pieceStartTime;
+        for (int i = 0; i < pieceSize && intervalEndTime < dataEndTime; i++) {
+            intervalEndTime = intervalEndTime + interval;
+            SinglePointFeatures feature = featureManager.getShingledFeature(adTask.getDetector(), shingle, dataPoints, intervalEndTime);
+            List<FeatureData> featureData = null;
+            if (feature.getUnprocessedFeatures().isPresent()) {
+                featureData = ParseUtils.getFeatureData(feature.getUnprocessedFeatures().get(), adTask.getDetector());
+            }
+            if (!feature.getProcessedFeatures().isPresent()) {
+                String error = feature.getUnprocessedFeatures().isPresent()
+                    ? "No full shingle in current detection window"
+                    : "No data in current detection window";
+                AnomalyResult anomalyResult = new AnomalyResult(
+                    adTask.getDetectorId(),
+                    taskId,
+                    Double.NaN,
+                    Double.NaN,
+                    Double.NaN,
+                    featureData,
+                    Instant.ofEpochMilli(intervalEndTime - interval),
+                    Instant.ofEpochMilli(intervalEndTime),
+                    executeStartTime,
+                    Instant.now(),
+                    error,
+                    null,
+                    adTask.getDetector().getUser(),
+                    anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT)
+                );
+                anomalyResults.add(anomalyResult);
+            } else {
+                double[] point = feature.getProcessedFeatures().get();
+                double score = rcf.getAnomalyScore(point);
+                rcf.update(point);
+                double grade = 0d;
+                double confidence = 0d;
+                if (!adTaskCacheManager.isThresholdModelTrained(taskId)) {
+                    if (adTaskCacheManager.getThresholdModelTrainingDataSize(taskId) < THRESHOLD_MODEL_TRAINING_SIZE) {
+                        if (score > 0) {
+                            adTaskCacheManager.addThresholdModelTrainingData(taskId, score);
+                        }
+                    } else {
+                        logger.debug("training threshold model");
+                        threshold.train(adTaskCacheManager.getThresholdModelTrainingData(taskId));
+                        adTaskCacheManager.setThresholdModelTrained(taskId, true);
+                    }
+                } else {
+                    grade = threshold.grade(score);
+                    confidence = threshold.confidence();
+                    if (score > 0) {
+                        threshold.update(score);
+                    }
+                }
+
+                AnomalyResult anomalyResult = new AnomalyResult(
+                    adTask.getDetectorId(),
+                    taskId,
+                    score,
+                    grade,
+                    confidence,
+                    featureData,
+                    Instant.ofEpochMilli(intervalEndTime - interval),
+                    Instant.ofEpochMilli(intervalEndTime),
+                    executeStartTime,
+                    Instant.now(),
+                    null,
+                    null,
+                    adTask.getDetector().getUser(),
+                    anomalyDetectionIndices.getSchemaVersion(ADIndex.RESULT)
+                );
+                anomalyResults.add(anomalyResult);
+            }
+        }
+
+        anomalyResultBulkIndexHandler
+            .bulkIndexAnomalyResult(
+                anomalyResults,
+                new ThreadedActionListener<>(logger, threadPool, AD_BATCH_TASK_THREAD_POOL_NAME, ActionListener.wrap(r -> {
+                    try {
+                        runNextPiece(adTask, pieceEndTime, dataStartTime, dataEndTime, interval, listener);
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
+                }, e -> {
+                    logger.error("Fail to bulk index anomaly result", e);
+                    listener.onFailure(e);
+                }), false)
+            );
+    }
+
+    private void runNextPiece(
+        ADTask adTask,
+        long pieceStartTime,
+        long dataStartTime,
+        long dataEndTime,
+        long interval,
+        ActionListener<String> listener
+    ) {
+        String taskId = adTask.getTaskId();
+        float initProgress = calculateInitProgress(taskId);
+        String taskState = initProgress >= 1.0f ? ADTaskState.RUNNING.name() : ADTaskState.INIT.name();
+
+        if (pieceStartTime < dataEndTime) {
+            checkCircuitBreaker(adTask);
+            long expectedPieceEndTime = pieceStartTime + pieceSize * interval;
+            long pieceEndTime = expectedPieceEndTime > dataEndTime ? dataEndTime : expectedPieceEndTime;
+            int i = 0;
+            while (i < pieceIntervalSeconds) {
+                // check if task cancelled every second, so frontend can get STOPPED state
+                // in 1 second once task cancelled.
+                checkIfADTaskCancelled(taskId);
+                rateLimiter.acquire(1);
+                i++;
+            }
+            logger.debug("start next piece start from {} to {}, interval {}", pieceStartTime, pieceEndTime, interval);
+            float taskProgress = (float) (pieceStartTime - dataStartTime) / (dataEndTime - dataStartTime);
+            adTaskManager
+                .updateADTask(
+                    taskId,
+                    ImmutableMap
+                        .of(
+                            STATE_FIELD,
+                            taskState,
+                            CURRENT_PIECE_FIELD,
+                            pieceStartTime,
+                            TASK_PROGRESS_FIELD,
+                            taskProgress,
+                            INIT_PROGRESS_FIELD,
+                            initProgress
+                        ),
+                    ActionListener
+                        .wrap(
+                            r -> getFeatureData(
+                                adTask,
+                                pieceStartTime,
+                                pieceEndTime,
+                                dataStartTime,
+                                dataEndTime,
+                                interval,
+                                Instant.now(),
+                                listener
+                            ),
+                            e -> listener.onFailure(e)
+                        )
+                );
+        } else {
+            logger.info("AD task finished for detector {}, task id: {}", adTask.getDetectorId(), taskId);
+            adTaskCacheManager.remove(taskId);
+            adTaskManager
+                .updateADTask(
+                    taskId,
+                    ImmutableMap
+                        .of(
+                            STATE_FIELD,
+                            ADTaskState.FINISHED.name(),
+                            CURRENT_PIECE_FIELD,
+                            dataEndTime,
+                            TASK_PROGRESS_FIELD,
+                            1.0f,
+                            EXECUTION_END_TIME_FIELD,
+                            Instant.now().toEpochMilli(),
+                            INIT_PROGRESS_FIELD,
+                            initProgress
+                        ),
+                    ActionListener.wrap(r -> listener.onResponse("task execution done"), e -> listener.onFailure(e))
+                );
+        }
+    }
+
+    private float calculateInitProgress(String taskId) {
+        RandomCutForest rcf = adTaskCacheManager.getRcfModel(taskId);
+        if (rcf == null) {
+            return 0.0f;
+        }
+        float initProgress = (float) rcf.getTotalUpdates() / NUM_MIN_SAMPLES;
+        return initProgress > 1.0f ? 1.0f : initProgress;
+    }
+
+    private void checkIfADTaskCancelled(String taskId) {
+        if (adTaskCacheManager.contains(taskId) && adTaskCacheManager.isCancelled(taskId)) {
+            throw new ADTaskCancelledException(adTaskCacheManager.getCancelReason(taskId), adTaskCacheManager.getCancelledBy(taskId));
+        }
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADBatchTaskRunner.java
@@ -545,8 +545,10 @@ public class ADBatchTaskRunner {
 
         long intervalEndTime = pieceStartTime;
         for (int i = 0; i < pieceSize && intervalEndTime < dataEndTime; i++) {
+            Optional<double[]> dataPoint = dataPoints.containsKey(intervalEndTime) ? dataPoints.get(intervalEndTime) : Optional.empty();
             intervalEndTime = intervalEndTime + interval;
-            SinglePointFeatures feature = featureManager.getShingledFeature(adTask.getDetector(), shingle, dataPoints, intervalEndTime);
+            SinglePointFeatures feature = featureManager
+                .getShingledFeatureForHistoricalDetector(adTask.getDetector(), shingle, dataPoint, intervalEndTime);
             List<FeatureData> featureData = null;
             if (feature.getUnprocessedFeatures().isPresent()) {
                 featureData = ParseUtils.getFeatureData(feature.getUnprocessedFeatures().get(), adTask.getDetector());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManager.java
@@ -131,6 +131,10 @@ public class ADTaskCacheManager {
         return getBatchTaskCache(taskId).getThresholdModelTrainingData();
     }
 
+    public int getThresholdModelTrainingDataSize(String taskId) {
+        return getBatchTaskCache(taskId).getThresholdModelTrainingDataSize().get();
+    }
+
     public int addThresholdModelTrainingData(String taskId, double... data) {
         ADBatchTaskCache taskCache = getBatchTaskCache(taskId);
         double[] thresholdModelTrainingData = taskCache.getThresholdModelTrainingData();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.task;
+
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.DETECTOR_ID_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.ERROR_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.EXECUTION_END_TIME_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.EXECUTION_START_TIME_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.IS_LATEST_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.LAST_UPDATE_TIME_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.STATE_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
+import static com.amazon.opendistroforelasticsearch.ad.util.ExceptionUtil.getErrorMessage;
+import static com.amazon.opendistroforelasticsearch.ad.util.ExceptionUtil.getShardsFailure;
+import static org.elasticsearch.action.DocWriteResponse.Result.CREATED;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.UpdateByQueryAction;
+import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskType;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.rest.handler.IndexAnomalyDetectorJobActionHandler;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchAnomalyResultAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchAnomalyResultRequest;
+import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobResponse;
+import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
+import com.amazon.opendistroforelasticsearch.commons.authuser.User;
+
+/**
+ * Manage AD task.
+ */
+public class ADTaskManager {
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private final Client client;
+    private final NamedXContentRegistry xContentRegistry;
+    private final AnomalyDetectionIndices detectionIndices;
+    private volatile Integer maxAdTaskDocsPerDetector;
+
+    public ADTaskManager(
+        Settings settings,
+        ClusterService clusterService,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        AnomalyDetectionIndices detectionIndices
+    ) {
+        this.client = client;
+        this.xContentRegistry = xContentRegistry;
+        this.detectionIndices = detectionIndices;
+
+        this.maxAdTaskDocsPerDetector = MAX_OLD_AD_TASK_DOCS_PER_DETECTOR.get(settings);
+        clusterService
+            .getClusterSettings()
+            .addSettingsUpdateConsumer(MAX_OLD_AD_TASK_DOCS_PER_DETECTOR, it -> maxAdTaskDocsPerDetector = it);
+    }
+
+    /**
+     * Start detector. Will create schedule job for realtime detector,
+     * and start AD task for historical detector.
+     *
+     * @param detectorId detector id
+     * @param handler anomaly detector job action handler
+     * @param user user
+     * @param listener action listener
+     */
+    public void startDetector(
+        String detectorId,
+        IndexAnomalyDetectorJobActionHandler handler,
+        User user,
+        ActionListener<AnomalyDetectorJobResponse> listener
+    ) {
+        getDetector(
+            detectorId,
+            (detector) -> handler.startAnomalyDetectorJob(detector), // run realtime detector
+            (detector) -> createADTaskIndex(detector, user, listener), // run historical detector
+            listener
+        );
+    }
+
+    private void getDetector(
+        String detectorId,
+        Consumer<AnomalyDetector> realTimeDetectorConsumer,
+        Consumer<AnomalyDetector> historicalDetectorConsumer,
+        ActionListener listener
+    ) {
+        GetRequest getRequest = new GetRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX).id(detectorId);
+        client.get(getRequest, ActionListener.wrap(response -> {
+            if (!response.isExists()) {
+                listener
+                    .onFailure(
+                        new ElasticsearchStatusException("AnomalyDetector is not found with id: " + detectorId, RestStatus.NOT_FOUND)
+                    );
+                return;
+            }
+            try (
+                XContentParser parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry, response.getSourceAsBytesRef())
+            ) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                AnomalyDetector detector = AnomalyDetector.parse(parser, response.getId(), response.getVersion());
+
+                String error = validateDetector(detector);
+                if (error != null) {
+                    listener.onFailure(new ElasticsearchStatusException(error, RestStatus.BAD_REQUEST));
+                    return;
+                }
+
+                if (detector.isRealTimeDetector()) {
+                    // run realtime detector
+                    realTimeDetectorConsumer.accept(detector);
+                } else {
+                    // run historical detector
+                    historicalDetectorConsumer.accept(detector);
+                }
+            } catch (Exception e) {
+                String message = "Failed to start anomaly detector";
+                logger.error(message, e);
+                listener.onFailure(new ElasticsearchStatusException(message, RestStatus.INTERNAL_SERVER_ERROR));
+            }
+        }, exception -> listener.onFailure(exception)));
+    }
+
+    private String validateDetector(AnomalyDetector detector) {
+        if (detector.getFeatureAttributes().size() == 0) {
+            return "Can't start detector job as no features configured";
+        }
+        if (detector.getEnabledFeatureIds().size() == 0) {
+            return "Can't start detector job as no enabled features configured";
+        }
+        return null;
+    }
+
+    protected void createADTaskIndex(AnomalyDetector detector, User user, ActionListener<AnomalyDetectorJobResponse> listener) {
+        if (detectionIndices.doesDetectorStateIndexExist()) {
+            checkCurrentTaskState(detector, user, listener);
+        } else {
+            detectionIndices.initDetectionStateIndex(ActionListener.wrap(r -> {
+                if (r.isAcknowledged()) {
+                    logger.info("Created {} with mappings.", ADTask.DETECTION_STATE_INDEX);
+                    executeHistoricalDetector(detector, user, listener);
+                } else {
+                    String error = "Create index " + ADTask.DETECTION_STATE_INDEX + " with mappings not acknowledged";
+                    logger.warn(error);
+                    listener.onFailure(new ElasticsearchStatusException(error, RestStatus.INTERNAL_SERVER_ERROR));
+                }
+            }, e -> {
+                if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
+                    executeHistoricalDetector(detector, user, listener);
+                } else {
+                    logger.error("Failed to init anomaly detection state index", e);
+                    listener.onFailure(e);
+                }
+            }));
+        }
+    }
+
+    private void checkCurrentTaskState(AnomalyDetector detector, User user, ActionListener<AnomalyDetectorJobResponse> listener) {
+        BoolQueryBuilder query = new BoolQueryBuilder();
+        query.filter(new TermQueryBuilder(DETECTOR_ID_FIELD, detector.getDetectorId()));
+        query.filter(new TermsQueryBuilder(STATE_FIELD, ADTaskState.CREATED.name(), ADTaskState.INIT.name(), ADTaskState.RUNNING.name()));
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(query);
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(searchSourceBuilder);
+        searchRequest.indices(ADTask.DETECTION_STATE_INDEX);
+
+        client.search(searchRequest, ActionListener.wrap(r -> {
+            if (r.getHits().getTotalHits().value > 0) {
+                listener.onFailure(new ElasticsearchStatusException("Detector is already running", RestStatus.BAD_REQUEST));
+            } else {
+                executeHistoricalDetector(detector, user, listener);
+            }
+        }, e -> {
+            logger.error("Failed to search current running task for detector " + detector.getDetectorId(), e);
+            listener.onFailure(e);
+        }));
+    }
+
+    private void executeHistoricalDetector(AnomalyDetector detector, User user, ActionListener<AnomalyDetectorJobResponse> listener) {
+        UpdateByQueryRequest updateByQueryRequest = new UpdateByQueryRequest();
+        updateByQueryRequest.indices(ADTask.DETECTION_STATE_INDEX);
+        BoolQueryBuilder query = new BoolQueryBuilder();
+        query.filter(new TermQueryBuilder(DETECTOR_ID_FIELD, detector.getDetectorId()));
+        query.filter(new TermQueryBuilder(IS_LATEST_FIELD, true));
+        updateByQueryRequest.setQuery(query);
+        updateByQueryRequest.setRefresh(true);
+        updateByQueryRequest.setScript(new Script("ctx._source.is_latest = false;"));
+
+        client.execute(UpdateByQueryAction.INSTANCE, updateByQueryRequest, ActionListener.wrap(r -> {
+            List<BulkItemResponse.Failure> bulkFailures = r.getBulkFailures();
+            if (bulkFailures.isEmpty()) {
+                createNewADTask(detector, user, listener);
+            } else {
+                logger.error("Failed to update old task's state for detector: {}, response: {} ", detector.getDetectorId(), r.toString());
+                listener.onFailure(bulkFailures.get(0).getCause());
+            }
+        }, e -> {
+            logger.error("Failed to reset old tasks as not latest for detector " + detector.getDetectorId(), e);
+            listener.onFailure(e);
+        }));
+    }
+
+    private void createNewADTask(AnomalyDetector detector, User user, ActionListener<AnomalyDetectorJobResponse> listener) {
+        String userName = user == null ? null : user.getName();
+        Instant now = Instant.now();
+        ADTask adTask = new ADTask.Builder()
+            .detectorId(detector.getDetectorId())
+            .detector(detector)
+            .isLatest(true)
+            .taskType(ADTaskType.HISTORICAL.name())
+            .executionStartTime(now)
+            .taskProgress(0.0f)
+            .initProgress(0.0f)
+            .state(ADTaskState.CREATED.name())
+            .lastUpdateTime(now)
+            .startedBy(userName)
+            .build();
+
+        IndexRequest request = new IndexRequest(ADTask.DETECTION_STATE_INDEX);
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            request
+                .source(adTask.toXContent(builder, RestHandlerUtils.XCONTENT_WITH_TYPE))
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            client
+                .index(
+                    request,
+                    ActionListener
+                        .wrap(
+                            r -> onIndexADTaskResponse(r, adTask, (response) -> cleanOldAdTaskDocs(response, adTask, listener), listener),
+                            e -> {
+                                logger.error("Failed to create AD task for detector " + detector.getDetectorId(), e);
+                                listener.onFailure(e);
+                            }
+                        )
+                );
+        } catch (Exception e) {
+            logger.error("Failed to create AD task for detector " + detector.getDetectorId(), e);
+            listener.onFailure(e);
+        }
+    }
+
+    private void onIndexADTaskResponse(
+        IndexResponse response,
+        ADTask adTask,
+        Consumer<IndexResponse> function,
+        ActionListener<AnomalyDetectorJobResponse> listener
+    ) {
+        if (response == null || response.getResult() != CREATED) {
+            String errorMsg = getShardsFailure(response);
+            listener.onFailure(new ElasticsearchStatusException(errorMsg, response.status()));
+            return;
+        }
+        adTask.setTaskId(response.getId());
+        if (function != null) {
+            function.accept(response);
+        }
+    }
+
+    private void cleanOldAdTaskDocs(IndexResponse response, ADTask adTask, ActionListener<AnomalyDetectorJobResponse> listener) {
+        BoolQueryBuilder query = new BoolQueryBuilder();
+        query.filter(new TermQueryBuilder(DETECTOR_ID_FIELD, adTask.getDetectorId()));
+        query.filter(new TermQueryBuilder(IS_LATEST_FIELD, false));
+        SearchRequest searchRequest = new SearchRequest();
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder
+            .query(query)
+            .sort(EXECUTION_START_TIME_FIELD, SortOrder.DESC)
+            // Search query "from" starts from 0.
+            .from(maxAdTaskDocsPerDetector - 1)
+            .trackTotalHits(true)
+            .size(1);
+        String s = sourceBuilder.toString();
+        searchRequest.source(sourceBuilder).indices(ADTask.DETECTION_STATE_INDEX);
+        String detectorId = adTask.getDetectorId();
+        client.search(searchRequest, ActionListener.wrap(r -> {
+            Iterator<SearchHit> iterator = r.getHits().iterator();
+            if (iterator.hasNext()) {
+                logger
+                    .debug(
+                        "AD tasks count for detector {} is {}, exceeds limit of {}",
+                        detectorId,
+                        r.getHits().getTotalHits().value,
+                        maxAdTaskDocsPerDetector
+                    );
+                SearchHit searchHit = r.getHits().getAt(0);
+                try (
+                    XContentParser parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry, searchHit.getSourceRef())
+                ) {
+                    ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                    ADTask task = ADTask.parse(parser, searchHit.getId());
+
+                    DeleteByQueryRequest request = new DeleteByQueryRequest(ADTask.DETECTION_STATE_INDEX);
+                    RangeQueryBuilder rangeQueryBuilder = new RangeQueryBuilder(EXECUTION_START_TIME_FIELD);
+                    rangeQueryBuilder.lt(task.getExecutionStartTime().toEpochMilli()).format("epoch_millis");
+                    request.setQuery(rangeQueryBuilder);
+                    client.execute(DeleteByQueryAction.INSTANCE, request, ActionListener.wrap(res -> {
+                        logger
+                            .debug(
+                                "Deleted {} old AD tasks started equals or before {} for detector {}",
+                                res.getDeleted(),
+                                adTask.getExecutionStartTime().toEpochMilli(),
+                                detectorId
+                            );
+                        runBatchResultAction(response, adTask, listener);
+                    }, e -> {
+                        logger.warn("Failed to clean AD tasks for detector " + detectorId, e);
+                        listener.onFailure(e);
+                    }));
+                } catch (Exception e) {
+                    logger.warn("Failed to parse AD tasks for detector " + detectorId, e);
+                    listener.onFailure(e);
+                }
+            } else {
+                runBatchResultAction(response, adTask, listener);
+            }
+        }, e -> logger.warn("Failed to search AD tasks for detector " + detectorId, e)));
+    }
+
+    private void runBatchResultAction(IndexResponse response, ADTask adTask, ActionListener<AnomalyDetectorJobResponse> listener) {
+        client.execute(ADBatchAnomalyResultAction.INSTANCE, new ADBatchAnomalyResultRequest(adTask), ActionListener.wrap(r -> {
+            String remoteOrLocal = r.isRunTaskRemotely() ? "remote" : "local";
+            logger
+                .info(
+                    "AD task {} of detector {} dispatched to {} node {}",
+                    adTask.getTaskId(),
+                    adTask.getDetectorId(),
+                    remoteOrLocal,
+                    r.getNodeId()
+                );
+            AnomalyDetectorJobResponse anomalyDetectorJobResponse = new AnomalyDetectorJobResponse(
+                response.getId(),
+                response.getVersion(),
+                response.getSeqNo(),
+                response.getPrimaryTerm(),
+                RestStatus.OK
+            );
+            listener.onResponse(anomalyDetectorJobResponse);
+        }, exception -> handleADTaskException(adTask, exception)));
+    }
+
+    /**
+     * Handle exceptions for AD task. Update task state and record error message.
+     *
+     * @param adTask AD task
+     * @param e exception
+     */
+    public void handleADTaskException(ADTask adTask, Exception e) {
+        // TODO: handle timeout exception
+        // TODO: handle TaskCancelledException
+        Map<String, Object> updatedFields = new HashMap<>();
+        logger.error("Failed to execute AD batch task, task id: " + adTask.getTaskId() + ", detector id: " + adTask.getDetectorId(), e);
+        updatedFields.put(STATE_FIELD, ADTaskState.FAILED.name());
+        updatedFields.put(ERROR_FIELD, getErrorMessage(e));
+        updatedFields.put(EXECUTION_END_TIME_FIELD, Instant.now().toEpochMilli());
+        updateADTask(adTask.getTaskId(), updatedFields);
+    }
+
+    private void updateADTask(String taskId, Map<String, Object> updatedFields) {
+        updateADTask(taskId, updatedFields, ActionListener.wrap(response -> {
+            if (response.status() == RestStatus.OK) {
+                logger.info("Updated AD task successfully: {}", response.status());
+            } else {
+                logger.error("Failed to update AD task {}, status: {}", taskId, response.status());
+            }
+        }, e -> logger.error("Failed to update task: " + taskId, e)));
+    }
+
+    /**
+     * Update AD task for specific fields.
+     *
+     * @param taskId task id
+     * @param updatedFields updated fields, key: filed name, value: new value
+     * @param listener action listener
+     */
+    public void updateADTask(String taskId, Map<String, Object> updatedFields, ActionListener<UpdateResponse> listener) {
+        UpdateRequest updateRequest = new UpdateRequest(ADTask.DETECTION_STATE_INDEX, taskId);
+        Map<String, Object> updatedContent = new HashMap<>();
+        updatedContent.putAll(updatedFields);
+        updatedContent.put(LAST_UPDATE_TIME_FIELD, Instant.now().toEpochMilli());
+        updateRequest.doc(updatedContent);
+        updateRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+        client
+            .update(
+                updateRequest,
+                ActionListener.wrap(response -> listener.onResponse(response), exception -> listener.onFailure(exception))
+            );
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
@@ -335,7 +335,6 @@ public class ADTaskManager {
             .from(maxAdTaskDocsPerDetector - 1)
             .trackTotalHits(true)
             .size(1);
-        String s = sourceBuilder.toString();
         searchRequest.source(sourceBuilder).indices(CommonName.DETECTION_STATE_INDEX);
         String detectorId = adTask.getDetectorId();
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultAction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
+
+public class ADBatchAnomalyResultAction extends ActionType<ADBatchAnomalyResultResponse> {
+    public static final String NAME = CommonValue.EXTERNAL_ACTION_PREFIX + "detector/ad_task";
+    public static final ADBatchAnomalyResultAction INSTANCE = new ADBatchAnomalyResultAction();
+
+    private ADBatchAnomalyResultAction() {
+        super(NAME, ADBatchAnomalyResultResponse::new);
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+
+public class ADBatchAnomalyResultRequest extends ActionRequest {
+    private ADTask adTask;
+
+    public ADBatchAnomalyResultRequest(StreamInput in) throws IOException {
+        super(in);
+        adTask = new ADTask(in);
+    }
+
+    public ADBatchAnomalyResultRequest(ADTask adTask) {
+        super();
+        this.adTask = adTask;
+    }
+
+    public ADTask getAdTask() {
+        return adTask;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        adTask.writeTo(out);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (Strings.isEmpty(adTask.getTaskId())) {
+            validationException = addValidationError("Task id can't be null", validationException);
+        }
+        AnomalyDetector detector = adTask.getDetector();
+        if (detector == null) {
+            validationException = addValidationError("Detector can't be null", validationException);
+        } else if (detector.isRealTimeDetector()) {
+            validationException = addValidationError("Can't run batch task for realtime detector", validationException);
+        }
+        return validationException;
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+public class ADBatchAnomalyResultResponse extends ActionResponse {
+    public String nodeId;
+    public boolean runTaskRemotely;
+
+    public ADBatchAnomalyResultResponse(String nodeId, boolean runTaskRemotely) {
+        this.nodeId = nodeId;
+        this.runTaskRemotely = runTaskRemotely;
+    }
+
+    public ADBatchAnomalyResultResponse(StreamInput in) throws IOException {
+        super(in);
+        nodeId = in.readString();
+        runTaskRemotely = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(nodeId);
+        out.writeBoolean(runTaskRemotely);
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public boolean isRunTaskRemotely() {
+        return runTaskRemotely;
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultTransportAction.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.task.ADBatchTaskRunner;
+
+public class ADBatchAnomalyResultTransportAction extends HandledTransportAction<ADBatchAnomalyResultRequest, ADBatchAnomalyResultResponse> {
+
+    private final TransportService transportService;
+    private final ADBatchTaskRunner adBatchTaskRunner;
+
+    @Inject
+    public ADBatchAnomalyResultTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ADBatchTaskRunner adBatchTaskRunner
+    ) {
+        super(ADBatchAnomalyResultAction.NAME, transportService, actionFilters, ADBatchAnomalyResultRequest::new);
+        this.transportService = transportService;
+        this.adBatchTaskRunner = adBatchTaskRunner;
+    }
+
+    @Override
+    protected void doExecute(Task task, ADBatchAnomalyResultRequest request, ActionListener<ADBatchAnomalyResultResponse> actionListener) {
+        adBatchTaskRunner.run(request.getAdTask(), transportService, actionListener);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchTaskRemoteExecutionAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchTaskRemoteExecutionAction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
+
+public class ADBatchTaskRemoteExecutionAction extends ActionType<ADBatchAnomalyResultResponse> {
+    public static final String NAME = CommonValue.EXTERNAL_ACTION_PREFIX + "detector/ad_task_remote";
+    public static final ADBatchTaskRemoteExecutionAction INSTANCE = new ADBatchTaskRemoteExecutionAction();
+
+    private ADBatchTaskRemoteExecutionAction() {
+        super(NAME, ADBatchAnomalyResultResponse::new);
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchTaskRemoteExecutionTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchTaskRemoteExecutionTransportAction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.task.ADBatchTaskRunner;
+
+public class ADBatchTaskRemoteExecutionTransportAction extends
+    HandledTransportAction<ADBatchAnomalyResultRequest, ADBatchAnomalyResultResponse> {
+
+    private final ADBatchTaskRunner adBatchTaskRunner;
+
+    @Inject
+    public ADBatchTaskRemoteExecutionTransportAction(
+        ActionFilters actionFilters,
+        TransportService transportService,
+        ADBatchTaskRunner adBatchTaskRunner
+    ) {
+        super(ADBatchTaskRemoteExecutionAction.NAME, transportService, actionFilters, ADBatchAnomalyResultRequest::new);
+        this.adBatchTaskRunner = adBatchTaskRunner;
+    }
+
+    @Override
+    protected void doExecute(Task task, ADBatchAnomalyResultRequest request, ActionListener<ADBatchAnomalyResultResponse> listener) {
+        adBatchTaskRunner.startADBatchTask(request.getAdTask(), true, listener);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteAnomalyDetectorTransportAction.java
@@ -47,9 +47,9 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
-import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.rest.handler.AnomalyDetectorFunction;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
@@ -127,7 +127,7 @@ public class DeleteAnomalyDetectorTransportAction extends HandledTransportAction
 
     private void deleteDetectorStateDoc(String detectorId, ActionListener<DeleteResponse> listener) {
         LOG.info("Delete detector info {}", detectorId);
-        DeleteRequest deleteRequest = new DeleteRequest(DetectorInternalState.DETECTOR_STATE_INDEX, detectorId);
+        DeleteRequest deleteRequest = new DeleteRequest(CommonName.DETECTION_STATE_INDEX, detectorId);
         client
             .delete(
                 deleteRequest,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultBulkIndexHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultBulkIndexHandler.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport.handler;
+
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.ANOMALY_RESULT_INDEX_ALIAS;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
+import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
+import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
+
+public class AnomalyResultBulkIndexHandler extends AnomalyIndexHandler<AnomalyResult> {
+    private static final Logger LOG = LogManager.getLogger(AnomalyResultBulkIndexHandler.class);
+
+    private AnomalyDetectionIndices anomalyDetectionIndices;
+
+    public AnomalyResultBulkIndexHandler(
+        Client client,
+        Settings settings,
+        ThreadPool threadPool,
+        Consumer<ActionListener<CreateIndexResponse>> createIndex,
+        BooleanSupplier indexExists,
+        ClientUtil clientUtil,
+        IndexUtils indexUtils,
+        ClusterService clusterService,
+        AnomalyDetectionIndices anomalyDetectionIndices
+    ) {
+        super(client, settings, threadPool, ANOMALY_RESULT_INDEX_ALIAS, createIndex, indexExists, clientUtil, indexUtils, clusterService);
+        this.anomalyDetectionIndices = anomalyDetectionIndices;
+    }
+
+    /**
+     * Bulk index anomaly results. Create anomaly result index first if it doesn't exist.
+     *
+     * @param anomalyResults anomaly results
+     * @param listener action listener
+     */
+    public void bulkIndexAnomalyResult(List<AnomalyResult> anomalyResults, ActionListener<BulkResponse> listener) {
+        if (anomalyResults == null || anomalyResults.size() == 0) {
+            listener.onResponse(null);
+            return;
+        }
+        try {
+            if (!anomalyDetectionIndices.doesAnomalyResultIndexExist()) {
+                anomalyDetectionIndices.initAnomalyResultIndexDirectly(ActionListener.wrap(response -> {
+                    if (response.isAcknowledged()) {
+                        bulkSaveDetectorResult(anomalyResults, listener);
+                    } else {
+                        String error = "Creating anomaly result index with mappings call not acknowledged";
+                        LOG.error(error);
+                        listener.onFailure(new AnomalyDetectionException(error));
+                    }
+                }, exception -> {
+                    if (ExceptionsHelper.unwrapCause(exception) instanceof ResourceAlreadyExistsException) {
+                        // It is possible the index has been created while we sending the create request
+                        bulkSaveDetectorResult(anomalyResults, listener);
+                    } else {
+                        listener.onFailure(exception);
+                    }
+                }));
+            } else {
+                bulkSaveDetectorResult(anomalyResults, listener);
+            }
+        } catch (AnomalyDetectionException e) {
+            listener.onFailure(e);
+        } catch (Exception e) {
+            String error = "Failed to bulk index anomaly result";
+            LOG.error(error, e);
+            listener.onFailure(new AnomalyDetectionException(error, e));
+        }
+    }
+
+    private void bulkSaveDetectorResult(List<AnomalyResult> anomalyResults, ActionListener<BulkResponse> listener) {
+        LOG.debug("Start to bulk save {} anomaly results", anomalyResults.size());
+        BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
+        anomalyResults.forEach(anomalyResult -> {
+            try (XContentBuilder builder = jsonBuilder()) {
+                IndexRequest indexRequest = new IndexRequest(ANOMALY_RESULT_INDEX_ALIAS)
+                    .source(anomalyResult.toXContent(builder, RestHandlerUtils.XCONTENT_WITH_TYPE));
+                bulkRequestBuilder.add(indexRequest);
+            } catch (Exception e) {
+                String error = "Failed to prepare request to bulk index anomaly results";
+                LOG.error(error, e);
+                throw new AnomalyDetectionException(error);
+            }
+        });
+        client.bulk(bulkRequestBuilder.request(), ActionListener.wrap(r -> {
+            LOG.debug("bulk index AD result successfully, took: {}", r.getTook().duration());
+            listener.onResponse(r);
+        }, e -> {
+            LOG.error("bulk index ad result failed", e);
+            listener.onFailure(e);
+        }));
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectionStateHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectionStateHandler.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
 import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
@@ -97,7 +98,7 @@ public class DetectionStateHandler extends AnomalyIndexHandler<DetectorInternalS
             client,
             settings,
             threadPool,
-            DetectorInternalState.DETECTOR_STATE_INDEX,
+            CommonName.DETECTION_STATE_INDEX,
             createIndex,
             indexExists,
             clientUtil,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ExceptionUtil.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ExceptionUtil.java
@@ -15,9 +15,13 @@
 
 package com.amazon.opendistroforelasticsearch.ad.util;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.ResourceNotFoundException;
 
 public class ExceptionUtil {
@@ -57,4 +61,49 @@ public class ExceptionUtil {
         return false;
     }
 
+    /**
+     * Get failure of all shards.
+     *
+     * @param response index response
+     * @return composite failures of all shards
+     */
+    public static String getShardsFailure(IndexResponse response) {
+        StringBuilder failureReasons = new StringBuilder();
+        if (response.getShardInfo() != null && response.getShardInfo().getFailed() > 0) {
+            for (ReplicationResponse.ShardInfo.Failure failure : response.getShardInfo().getFailures()) {
+                failureReasons.append(failure.reason());
+            }
+            return failureReasons.toString();
+        }
+        return null;
+    }
+
+    /**
+     * Count exception in AD failure stats of not.
+     *
+     * @param e exception
+     * @return true if should count in AD failure stats; otherwise return false
+     */
+    public static boolean countInStats(Exception e) {
+        if (!(e instanceof AnomalyDetectionException) || ((AnomalyDetectionException) e).isCountedInStats()) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Get error message from exception.
+     *
+     * @param e exception
+     * @return readable error message or full stack trace
+     */
+    public static String getErrorMessage(Exception e) {
+        if (e instanceof IllegalArgumentException || e instanceof AnomalyDetectionException) {
+            return e.getMessage();
+        } else if (e instanceof ElasticsearchException) {
+            return ((ElasticsearchException) e).getDetailedMessage();
+        } else {
+            return ExceptionUtils.getFullStackTrace(e);
+        }
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
@@ -616,6 +616,7 @@ public final class ParseUtils {
      * @param xContentRegistry content registry
      * @return search source builder
      * @throws IOException throw IO exception if fail to parse feature aggregation
+     * @throws AnomalyDetectionException throw AD exception if no enabled feature
      */
     public static SearchSourceBuilder batchFeatureQuery(
         AnomalyDetector detector,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ADIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ADIntegTestCase.java
@@ -52,6 +52,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
 
 import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
@@ -95,7 +96,7 @@ public abstract class ADIntegTestCase extends ESIntegTestCase {
     }
 
     public String createADTask(ADTask adTask) throws IOException {
-        return indexDoc(ADTask.DETECTION_STATE_INDEX, adTask.toXContent(jsonBuilder(), XCONTENT_WITH_TYPE));
+        return indexDoc(CommonName.DETECTION_STATE_INDEX, adTask.toXContent(jsonBuilder(), XCONTENT_WITH_TYPE));
     }
 
     public void createDetectorIndex() throws IOException {
@@ -103,7 +104,7 @@ public abstract class ADIntegTestCase extends ESIntegTestCase {
     }
 
     public void createDetectionStateIndex() throws IOException {
-        createIndex(ADTask.DETECTION_STATE_INDEX, AnomalyDetectionIndices.getDetectionStateMappings());
+        createIndex(CommonName.DETECTION_STATE_INDEX, AnomalyDetectionIndices.getDetectionStateMappings());
     }
 
     public void createTestDataIndex(String indexName) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/ADUnitTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/ADUnitTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+
+import com.google.common.collect.Sets;
+
+public class ADUnitTestCase extends ESTestCase {
+
+    @Captor
+    protected ArgumentCaptor<Exception> exceptionCaptor;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        MockitoAnnotations.initMocks(this);
+    }
+
+    /**
+     * Create cluster setting.
+     *
+     * @param settings cluster settings
+     * @param setting add setting if the code to be tested contains setting update consumer
+     * @return instance of ClusterSettings
+     */
+    public ClusterSettings clusterSetting(Settings settings, Setting<?>... setting) {
+        final Set<Setting<?>> settingsSet = Stream
+            .concat(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS.stream(), Sets.newHashSet(setting).stream())
+            .collect(Collectors.toSet());
+        ClusterSettings clusterSettings = new ClusterSettings(settings, settingsSet);
+        return clusterSettings;
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorJobRunnerTests.java
@@ -162,7 +162,7 @@ public class AnomalyDetectorJobRunnerTests extends AbstractADTest {
             client,
             settings,
             threadPool,
-            ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initDetectorStateIndex),
+            ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initDetectionStateIndex),
             anomalyDetectionIndices::doesDetectorStateIndexExist,
             this.clientUtil,
             indexUtils,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunnerTests.java
@@ -145,7 +145,7 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
                 }
             } else {
                 if (errorResultStatus == ErrorResultStatus.INDEX_NOT_EXIT) {
-                    listener.onFailure(new IndexNotFoundException(DetectorInternalState.DETECTOR_STATE_INDEX));
+                    listener.onFailure(new IndexNotFoundException(CommonName.DETECTION_STATE_INDEX));
                     return null;
                 }
                 DetectorInternalState.Builder result = new DetectorInternalState.Builder().lastUpdateTime(Instant.now());
@@ -164,9 +164,7 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
                         break;
                 }
                 listener
-                    .onResponse(
-                        TestHelpers.createGetResponse(result.build(), detector.getDetectorId(), DetectorInternalState.DETECTOR_STATE_INDEX)
-                    );
+                    .onResponse(TestHelpers.createGetResponse(result.build(), detector.getDetectorId(), CommonName.DETECTION_STATE_INDEX));
 
             }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/EntityProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/EntityProfileRunnerTests.java
@@ -144,7 +144,7 @@ public class EntityProfileRunnerTests extends AbstractADTest {
             String indexName = request.indices()[0];
             ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) args[1];
             if (indexName.equals(CommonName.ANOMALY_RESULT_INDEX_ALIAS)) {
-                InternalMax maxAgg = new InternalMax(CommonName.AGG_NAME_MAX, latestSampleTimestamp, DocValueFormat.RAW, emptyMap());
+                InternalMax maxAgg = new InternalMax(CommonName.AGG_NAME_MAX_TIME, latestSampleTimestamp, DocValueFormat.RAW, emptyMap());
                 InternalAggregations internalAggregations = InternalAggregations.from(Collections.singletonList(maxAgg));
 
                 SearchHits hits = new SearchHits(new SearchHit[] {}, null, Float.NaN);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/HistoricalDetectorIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/HistoricalDetectorIntegTestCase.java
@@ -39,6 +39,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTaskType;
@@ -149,7 +150,7 @@ public abstract class HistoricalDetectorIntegTestCase extends ADIntegTestCase {
         SearchRequest searchRequest = new SearchRequest();
         SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
         sourceBuilder.query(query).sort(EXECUTION_START_TIME_FIELD, SortOrder.DESC).trackTotalHits(true).size(size);
-        searchRequest.source(sourceBuilder).indices(ADTask.DETECTION_STATE_INDEX);
+        searchRequest.source(sourceBuilder).indices(CommonName.DETECTION_STATE_INDEX);
         SearchResponse searchResponse = client().search(searchRequest).actionGet();
         Iterator<SearchHit> iterator = searchResponse.getHits().iterator();
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/HistoricalDetectorIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/HistoricalDetectorIntegTestCase.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.DETECTOR_ID_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.EXECUTION_START_TIME_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.IS_LATEST_FIELD;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.TermQueryBuilder;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskType;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
+import com.amazon.opendistroforelasticsearch.ad.model.Feature;
+import com.google.common.collect.ImmutableMap;
+
+public abstract class HistoricalDetectorIntegTestCase extends ADIntegTestCase {
+
+    protected String testIndex = "test_historical_data";
+    protected int detectionIntervalInMinutes = 1;
+    protected int DEFAULT_TEST_DATA_DOCS = 3000;
+
+    public void ingestTestData(String testIndex, Instant startTime, int detectionIntervalInMinutes, String type) {
+        ingestTestData(testIndex, startTime, detectionIntervalInMinutes, type, DEFAULT_TEST_DATA_DOCS);
+    }
+
+    public void ingestTestData(String testIndex, Instant startTime, int detectionIntervalInMinutes, String type, int totalDocs) {
+        createTestDataIndex(testIndex);
+        List<Map<String, ?>> docs = new ArrayList<>();
+        Instant currentInterval = Instant.from(startTime);
+
+        for (int i = 0; i < totalDocs; i++) {
+            currentInterval = currentInterval.plus(detectionIntervalInMinutes, ChronoUnit.MINUTES);
+            double value = i % 500 == 0 ? randomDoubleBetween(1000, 2000, true) : randomDoubleBetween(10, 100, true);
+            docs
+                .add(
+                    ImmutableMap
+                        .of(
+                            timeField,
+                            currentInterval.toEpochMilli(),
+                            "value",
+                            value,
+                            "type",
+                            type,
+                            "is_error",
+                            randomBoolean(),
+                            "message",
+                            randomAlphaOfLength(5)
+                        )
+                );
+        }
+        BulkResponse bulkResponse = bulkIndexDocs(testIndex, docs, 30_000);
+        assertEquals(RestStatus.OK, bulkResponse.status());
+        assertFalse(bulkResponse.hasFailures());
+        long count = countDocs(testIndex);
+        assertEquals(totalDocs, count);
+    }
+
+    public Feature maxValueFeature() throws IOException {
+        AggregationBuilder aggregationBuilder = TestHelpers.parseAggregation("{\"test\":{\"max\":{\"field\":\"" + valueField + "\"}}}");
+        return new Feature(randomAlphaOfLength(5), randomAlphaOfLength(10), true, aggregationBuilder);
+    }
+
+    public AnomalyDetector randomDetector(DetectionDateRange dateRange, List<Feature> features) throws IOException {
+        return TestHelpers.randomDetector(dateRange, features, testIndex, detectionIntervalInMinutes, timeField);
+    }
+
+    public ADTask randomCreatedADTask(String taskId, AnomalyDetector detector) {
+        String detectorId = detector == null ? null : detector.getDetectorId();
+        return randomCreatedADTask(taskId, detector, detectorId);
+    }
+
+    public ADTask randomCreatedADTask(String taskId, AnomalyDetector detector, String detectorId) {
+        return randomADTask(taskId, detector, detectorId, ADTaskState.CREATED);
+    }
+
+    public ADTask randomADTask(String taskId, AnomalyDetector detector, String detectorId, ADTaskState state) {
+        ADTask.Builder builder = ADTask
+            .builder()
+            .taskId(taskId)
+            .taskType(ADTaskType.HISTORICAL.name())
+            .detectorId(detectorId)
+            .detector(detector)
+            .state(state.name())
+            .taskProgress(0.0f)
+            .initProgress(0.0f)
+            .isLatest(true)
+            .startedBy(randomAlphaOfLength(5))
+            .executionStartTime(Instant.now().minus(randomLongBetween(10, 100), ChronoUnit.MINUTES));
+        if (ADTaskState.FINISHED == state) {
+            setPropertyForNotRunningTask(builder);
+        } else if (ADTaskState.FAILED == state) {
+            setPropertyForNotRunningTask(builder);
+            builder.error(randomAlphaOfLength(5));
+        } else if (ADTaskState.STOPPED == state) {
+            setPropertyForNotRunningTask(builder);
+            builder.error(randomAlphaOfLength(5));
+            builder.stoppedBy(randomAlphaOfLength(5));
+        }
+        return builder.build();
+    }
+
+    private ADTask.Builder setPropertyForNotRunningTask(ADTask.Builder builder) {
+        builder.executionEndTime(Instant.now().minus(randomLongBetween(1, 5), ChronoUnit.MINUTES));
+        builder.isLatest(false);
+        return builder;
+    }
+
+    public List<ADTask> searchADTasks(String detectorId, Boolean isLatest, int size) throws IOException {
+        BoolQueryBuilder query = new BoolQueryBuilder();
+        query.filter(new TermQueryBuilder(DETECTOR_ID_FIELD, detectorId));
+        if (isLatest != null) {
+            query.filter(new TermQueryBuilder(IS_LATEST_FIELD, false));
+        }
+        SearchRequest searchRequest = new SearchRequest();
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(query).sort(EXECUTION_START_TIME_FIELD, SortOrder.DESC).trackTotalHits(true).size(size);
+        searchRequest.source(sourceBuilder).indices(ADTask.DETECTION_STATE_INDEX);
+        SearchResponse searchResponse = client().search(searchRequest).actionGet();
+        Iterator<SearchHit> iterator = searchResponse.getHits().iterator();
+
+        List<ADTask> adTasks = new ArrayList<>();
+        while (iterator.hasNext()) {
+            SearchHit next = iterator.next();
+            ADTask task = ADTask.parse(TestHelpers.parser(next.getSourceAsString()), next.getId());
+            adTasks.add(task);
+        }
+        return adTasks;
+    }
+
+    public ADTask toADTask(GetResponse doc) throws IOException {
+        return ADTask.parse(TestHelpers.parser(doc.getSourceAsString()));
+    }
+
+    public AnomalyDetectorJob toADJob(GetResponse doc) throws IOException {
+        return AnomalyDetectorJob.parse(TestHelpers.parser(doc.getSourceAsString()));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/MultiEntityProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/MultiEntityProfileRunnerTests.java
@@ -47,6 +47,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.junit.Before;
 
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
@@ -113,11 +114,9 @@ public class MultiEntityProfileRunnerTests extends AbstractADTest {
             if (indexName.equals(ANOMALY_DETECTORS_INDEX)) {
                 listener
                     .onResponse(TestHelpers.createGetResponse(detector, detector.getDetectorId(), AnomalyDetector.ANOMALY_DETECTORS_INDEX));
-            } else if (indexName.equals(DetectorInternalState.DETECTOR_STATE_INDEX)) {
+            } else if (indexName.equals(CommonName.DETECTION_STATE_INDEX)) {
                 listener
-                    .onResponse(
-                        TestHelpers.createGetResponse(result.build(), detector.getDetectorId(), DetectorInternalState.DETECTOR_STATE_INDEX)
-                    );
+                    .onResponse(TestHelpers.createGetResponse(result.build(), detector.getDetectorId(), CommonName.DETECTION_STATE_INDEX));
             } else if (indexName.equals(ANOMALY_DETECTOR_JOB_INDEX)) {
                 listener
                     .onResponse(

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -119,6 +119,7 @@ import com.amazon.opendistroforelasticsearch.ad.model.ADTaskType;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorExecutionInput;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorType;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
@@ -252,6 +253,7 @@ public class TestHelpers {
             uiMetadata,
             lastUpdateTime,
             detectorType,
+            ESRestTestCase.randomLongBetween(1, 1000),
             dateRange,
             withUser
         );
@@ -263,6 +265,7 @@ public class TestHelpers {
         Map<String, Object> uiMetadata,
         Instant lastUpdateTime,
         String detectorType,
+        long detectionIntervalInMinutes,
         DetectionDateRange dateRange,
         boolean withUser
     ) throws IOException {
@@ -276,7 +279,7 @@ public class TestHelpers {
             indices,
             features,
             randomQuery(),
-            randomIntervalTimeConfiguration(),
+            new IntervalTimeConfiguration(detectionIntervalInMinutes, ChronoUnit.MINUTES),
             randomIntervalTimeConfiguration(),
             randomIntBetween(1, 2000),
             uiMetadata,
@@ -284,6 +287,38 @@ public class TestHelpers {
             lastUpdateTime,
             null,
             user,
+            detectorType,
+            dateRange
+        );
+    }
+
+    public static AnomalyDetector randomDetector(
+        DetectionDateRange dateRange,
+        List<Feature> features,
+        String indexName,
+        int detectionIntervalInMinutes,
+        String timeField
+    ) throws IOException {
+        String detectorType = dateRange == null
+            ? AnomalyDetectorType.REALTIME_SINGLE_ENTITY.name()
+            : AnomalyDetectorType.HISTORICAL_SINGLE_ENTITY.name();
+        return new AnomalyDetector(
+            randomAlphaOfLength(10),
+            randomLong(),
+            randomAlphaOfLength(20),
+            randomAlphaOfLength(30),
+            timeField,
+            ImmutableList.of(indexName),
+            features,
+            randomQuery("{\"bool\":{\"filter\":[{\"exists\":{\"field\":\"value\"}}]}}"),
+            new IntervalTimeConfiguration(detectionIntervalInMinutes, ChronoUnit.MINUTES),
+            new IntervalTimeConfiguration(ESRestTestCase.randomLongBetween(1, 5), ChronoUnit.MINUTES),
+            8,
+            null,
+            randomInt(),
+            Instant.now(),
+            null,
+            null,
             detectorType,
             dateRange
         );

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/common/exception/ADTaskCancelledExceptionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/common/exception/ADTaskCancelledExceptionTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.common.exception;
+
+import org.elasticsearch.test.ESTestCase;
+
+public class ADTaskCancelledExceptionTests extends ESTestCase {
+
+    public void testConstructor() {
+        String message = randomAlphaOfLength(5);
+        String user = randomAlphaOfLength(5);
+        ADTaskCancelledException exception = new ADTaskCancelledException(message, user);
+        assertEquals(message, exception.getMessage());
+        assertEquals(user, exception.getCancelledBy());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/FeatureManagerTests.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.feature;
 
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_IMPUTATION_NEIGHBOR_DISTANCE;
 import static java.util.Arrays.asList;
 import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
@@ -42,8 +43,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -1012,5 +1015,104 @@ public class FeatureManagerTests {
         assertTrue(listenerResponse.getProcessedFeatures().isPresent());
         assertEquals(listenerResponse.getProcessedFeatures().get().length, shingleSize);
         assertEquals(featureManager.getShingleSize(detector.getDetectorId()), shingleSize);
+    }
+
+    @Test
+    public void testGetShingledFeatureForHistoricalDetectorFromEmptyShingleWithoutMissingData() {
+        long millisecondsPerMinute = 60000;
+        int shingleSize = 8;
+        when(detector.getShingleSize()).thenReturn(shingleSize);
+
+        Deque<Entry<Long, Optional<double[]>>> shingle = new ArrayDeque<>();
+
+        long endTime = Instant.now().toEpochMilli();
+        int i = 0;
+        for (; i < shingleSize - MAX_IMPUTATION_NEIGHBOR_DISTANCE; i++) {
+            double[] testData = new double[] { i };
+            Optional<double[]> dataPoint = Optional.of(testData);
+            SinglePointFeatures feature = featureManager.getShingledFeatureForHistoricalDetector(detector, shingle, dataPoint, endTime);
+            endTime += millisecondsPerMinute;
+
+            assertTrue(Arrays.equals(testData, feature.getUnprocessedFeatures().get()));
+            assertFalse(feature.getProcessedFeatures().isPresent());
+        }
+
+        double[] testData = new double[] { i++ };
+        Optional<double[]> dataPoint = Optional.of(testData);
+        SinglePointFeatures feature = featureManager.getShingledFeatureForHistoricalDetector(detector, shingle, dataPoint, endTime);
+        assertTrue(feature.getProcessedFeatures().isPresent());
+        assertTrue(Arrays.equals(new double[] { 0.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 }, feature.getProcessedFeatures().get()));
+
+        endTime += millisecondsPerMinute;
+        testData = new double[] { i++ };
+        dataPoint = Optional.of(testData);
+        feature = featureManager.getShingledFeatureForHistoricalDetector(detector, shingle, dataPoint, endTime);
+        assertTrue(feature.getProcessedFeatures().isPresent());
+        assertTrue(Arrays.equals(new double[] { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 }, feature.getProcessedFeatures().get()));
+
+        for (; i < 2 * shingleSize; i++) {
+            endTime += millisecondsPerMinute;
+            SinglePointFeatures singlePointFeatures = featureManager
+                .getShingledFeatureForHistoricalDetector(detector, shingle, Optional.of(new double[] { i }), endTime);
+            assertTrue(singlePointFeatures.getProcessedFeatures().isPresent());
+            assertTrue(
+                Arrays
+                    .equals(
+                        new double[] { i - 7, i - 6, i - 5, i - 4, i - 3, i - 2, i - 1, i },
+                        singlePointFeatures.getProcessedFeatures().get()
+                    )
+            );
+        }
+    }
+
+    @Test
+    public void testGetShingledFeatureForHistoricalDetectorWithTooManyMissingData() {
+        long millisecondsPerMinute = 60000;
+        int shingleSize = 8;
+        when(detector.getShingleSize()).thenReturn(shingleSize);
+
+        Deque<Entry<Long, Optional<double[]>>> shingle = new ArrayDeque<>();
+
+        long endTime = Instant.now().toEpochMilli();
+        int i = 0;
+        for (; i < shingleSize; i++) {
+            featureManager.getShingledFeatureForHistoricalDetector(detector, shingle, Optional.of(new double[] { i }), endTime);
+            endTime += millisecondsPerMinute;
+        }
+
+        for (int j = 0; j < MAX_IMPUTATION_NEIGHBOR_DISTANCE + 1; j++) {
+            SinglePointFeatures feature = featureManager
+                .getShingledFeatureForHistoricalDetector(detector, shingle, Optional.empty(), endTime);
+            endTime += millisecondsPerMinute;
+            assertFalse(feature.getProcessedFeatures().isPresent());
+        }
+        SinglePointFeatures feature = featureManager
+            .getShingledFeatureForHistoricalDetector(detector, shingle, Optional.of(new double[] { i }), endTime);
+        assertFalse(feature.getProcessedFeatures().isPresent());
+    }
+
+    @Test
+    public void testGetShingledFeatureForHistoricalDetectorWithOneMissingData() {
+        long millisecondsPerMinute = 60000;
+        int shingleSize = 8;
+        when(detector.getShingleSize()).thenReturn(shingleSize);
+
+        Deque<Entry<Long, Optional<double[]>>> shingle = new ArrayDeque<>();
+
+        long endTime = Instant.now().toEpochMilli();
+        int i = 0;
+        for (; i < shingleSize; i++) {
+            featureManager.getShingledFeatureForHistoricalDetector(detector, shingle, Optional.of(new double[] { i }), endTime);
+            endTime += millisecondsPerMinute;
+        }
+
+        SinglePointFeatures feature1 = featureManager.getShingledFeatureForHistoricalDetector(detector, shingle, Optional.empty(), endTime);
+        assertFalse(feature1.getProcessedFeatures().isPresent());
+
+        endTime += millisecondsPerMinute;
+        SinglePointFeatures feature2 = featureManager
+            .getShingledFeatureForHistoricalDetector(detector, shingle, Optional.of(new double[] { i }), endTime);
+        assertTrue(feature2.getProcessedFeatures().isPresent());
+        assertTrue(Arrays.equals(new double[] { 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 8.0 }, feature2.getProcessedFeatures().get()));
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/feature/SearchFeatureDaoTests.java
@@ -237,7 +237,7 @@ public class SearchFeatureDaoTests {
         aggsMap = new HashMap<>();
         // aggsList = new ArrayList<>();
 
-        when(max.getName()).thenReturn(CommonName.AGG_NAME_MAX);
+        when(max.getName()).thenReturn(CommonName.AGG_NAME_MAX_TIME);
         List<Aggregation> list = new ArrayList<>();
         list.add(max);
         Aggregations aggregations = new Aggregations(list);
@@ -276,12 +276,12 @@ public class SearchFeatureDaoTests {
     public void test_getLatestDataTime_returnExpectedTime_givenData() {
         // pre-conditions
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX).field(detector.getTimeField()))
+            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX_TIME).field(detector.getTimeField()))
             .size(0);
         searchRequest.source(searchSourceBuilder);
 
         long epochTime = 100L;
-        aggsMap.put(CommonName.AGG_NAME_MAX, max);
+        aggsMap.put(CommonName.AGG_NAME_MAX_TIME, max);
         when(max.getValue()).thenReturn((double) epochTime);
 
         // test
@@ -295,7 +295,7 @@ public class SearchFeatureDaoTests {
     public void test_getLatestDataTime_returnEmpty_givenNoData() {
         // pre-conditions
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX).field(detector.getTimeField()))
+            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX_TIME).field(detector.getTimeField()))
             .size(0);
         searchRequest.source(searchSourceBuilder);
 
@@ -312,11 +312,11 @@ public class SearchFeatureDaoTests {
     @SuppressWarnings("unchecked")
     public void getLatestDataTime_returnExpectedToListener() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX).field(detector.getTimeField()))
+            .aggregation(AggregationBuilders.max(CommonName.AGG_NAME_MAX_TIME).field(detector.getTimeField()))
             .size(0);
         searchRequest.source(searchSourceBuilder);
         long epochTime = 100L;
-        aggsMap.put(CommonName.AGG_NAME_MAX, max);
+        aggsMap.put(CommonName.AGG_NAME_MAX_TIME, max);
         when(max.getValue()).thenReturn((double) epochTime);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/InitAnomalyDetectionIndicesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/InitAnomalyDetectionIndicesTests.java
@@ -49,7 +49,6 @@ import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
-import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 
@@ -177,7 +176,7 @@ public class InitAnomalyDetectionIndicesTests extends AbstractADTest {
         ActionListener<CreateIndexResponse> listener = mock(ActionListener.class);
         if (index.equals(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
             adIndices.initAnomalyDetectorIndexIfAbsent(listener);
-        } else if (index.equals(DetectorInternalState.DETECTOR_STATE_INDEX)) {
+        } else if (index.equals(CommonName.DETECTION_STATE_INDEX)) {
             adIndices.initDetectionStateIndex(listener);
         } else if (index.equals(CommonName.CHECKPOINT_INDEX_NAME)) {
             adIndices.initCheckpointIndex(listener);
@@ -206,7 +205,7 @@ public class InitAnomalyDetectionIndicesTests extends AbstractADTest {
     }
 
     public void testCreateState() throws IOException {
-        fixedPrimaryShardsIndexCreationTemplate(DetectorInternalState.DETECTOR_STATE_INDEX);
+        fixedPrimaryShardsIndexCreationTemplate(CommonName.DETECTION_STATE_INDEX);
     }
 
     public void testCreateJob() throws IOException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/InitAnomalyDetectionIndicesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/InitAnomalyDetectionIndicesTests.java
@@ -123,7 +123,7 @@ public class InitAnomalyDetectionIndicesTests extends AbstractADTest {
         if (index.equals(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
             adIndices.initAnomalyDetectorIndexIfAbsent(listener);
         } else {
-            adIndices.initDetectorStateIndex(listener);
+            adIndices.initDetectionStateIndex(listener);
         }
 
         ArgumentCaptor<CreateIndexResponse> captor = ArgumentCaptor.forClass(CreateIndexResponse.class);
@@ -178,7 +178,7 @@ public class InitAnomalyDetectionIndicesTests extends AbstractADTest {
         if (index.equals(AnomalyDetector.ANOMALY_DETECTORS_INDEX)) {
             adIndices.initAnomalyDetectorIndexIfAbsent(listener);
         } else if (index.equals(DetectorInternalState.DETECTOR_STATE_INDEX)) {
-            adIndices.initDetectorStateIndex(listener);
+            adIndices.initDetectionStateIndex(listener);
         } else if (index.equals(CommonName.CHECKPOINT_INDEX_NAME)) {
             adIndices.initCheckpointIndex(listener);
         } else if (index.equals(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX)) {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetectorTests.java
@@ -474,4 +474,27 @@ public class AnomalyDetectorTests extends AbstractADTest {
         );
         assertEquals((int) anomalyDetector.getShingleSize(), AnomalyDetectorSettings.DEFAULT_SHINGLE_SIZE);
     }
+
+    public void testNullFeatureAttributes() throws IOException {
+        AnomalyDetector anomalyDetector = new AnomalyDetector(
+            randomAlphaOfLength(5),
+            randomLong(),
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            ImmutableList.of(randomAlphaOfLength(5)),
+            null,
+            TestHelpers.randomQuery(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            TestHelpers.randomIntervalTimeConfiguration(),
+            null,
+            null,
+            1,
+            Instant.now(),
+            null,
+            TestHelpers.randomUser()
+        );
+        assertNotNull(anomalyDetector.getFeatureAttributes());
+        assertEquals(0, anomalyDetector.getFeatureAttributes().size());
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/plugin/MockReindexPlugin.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/plugin/MockReindexPlugin.java
@@ -49,7 +49,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
-import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.google.common.collect.ImmutableList;
 
 public class MockReindexPlugin extends Plugin implements ActionPlugin {
@@ -172,7 +172,7 @@ public class MockReindexPlugin extends Plugin implements ActionPlugin {
                 Iterator<SearchHit> iterator = r.getHits().iterator();
                 while (iterator.hasNext()) {
                     String id = iterator.next().getId();
-                    DeleteRequest deleteRequest = new DeleteRequest(ADTask.DETECTION_STATE_INDEX, id)
+                    DeleteRequest deleteRequest = new DeleteRequest(CommonName.DETECTION_STATE_INDEX, id)
                         .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
                     client.delete(deleteRequest, delegateListener);
                 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/plugin/MockReindexPlugin.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/plugin/MockReindexPlugin.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.plugin;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.BulkByScrollTask;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.UpdateByQueryAction;
+import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.google.common.collect.ImmutableList;
+
+public class MockReindexPlugin extends Plugin implements ActionPlugin {
+
+    @Override
+    public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        return Arrays
+            .asList(
+                new ActionHandler<>(UpdateByQueryAction.INSTANCE, MockTransportUpdateByQueryAction.class),
+                new ActionHandler<>(DeleteByQueryAction.INSTANCE, MockTransportDeleteByQueryAction.class)
+            );
+    }
+
+    public static class MockTransportUpdateByQueryAction extends HandledTransportAction<UpdateByQueryRequest, BulkByScrollResponse> {
+
+        @Inject
+        public MockTransportUpdateByQueryAction(ActionFilters actionFilters, TransportService transportService) {
+            super(UpdateByQueryAction.NAME, transportService, actionFilters, UpdateByQueryRequest::new);
+        }
+
+        @Override
+        protected void doExecute(Task task, UpdateByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
+            BulkByScrollResponse response = null;
+            try {
+                XContentParser parser = TestHelpers
+                    .parser(
+                        "{\"slice_id\":1,\"total\":2,\"updated\":3,\"created\":0,\"deleted\":0,\"batches\":6,"
+                            + "\"version_conflicts\":0,\"noops\":0,\"retries\":{\"bulk\":0,\"search\":10},"
+                            + "\"throttled_millis\":0,\"requests_per_second\":13.0,\"canceled\":\"reasonCancelled\","
+                            + "\"throttled_until_millis\":14}"
+                    );
+                parser.nextToken();
+                response = new BulkByScrollResponse(
+                    TimeValue.timeValueMillis(10),
+                    BulkByScrollTask.Status.innerFromXContent(parser),
+                    ImmutableList.of(),
+                    ImmutableList.of(),
+                    false
+                );
+            } catch (IOException exception) {
+                exception.printStackTrace();
+            }
+            listener.onResponse(response);
+        }
+    }
+
+    public static class MockTransportDeleteByQueryAction extends HandledTransportAction<DeleteByQueryRequest, BulkByScrollResponse> {
+
+        private Client client;
+
+        @Inject
+        public MockTransportDeleteByQueryAction(ActionFilters actionFilters, TransportService transportService, Client client) {
+            super(DeleteByQueryAction.NAME, transportService, actionFilters, DeleteByQueryRequest::new);
+            this.client = client;
+        }
+
+        private class MultiResponsesActionListener implements ActionListener<DeleteResponse> {
+            private final ActionListener<BulkByScrollResponse> delegate;
+            private final AtomicInteger collectedResponseCount;
+            private final AtomicLong maxResponseCount;
+            private final AtomicBoolean hasFailure;
+
+            MultiResponsesActionListener(ActionListener<BulkByScrollResponse> delegate, long maxResponseCount) {
+                this.delegate = delegate;
+                this.collectedResponseCount = new AtomicInteger(0);
+                this.maxResponseCount = new AtomicLong(maxResponseCount);
+                this.hasFailure = new AtomicBoolean(false);
+            }
+
+            @Override
+            public void onResponse(DeleteResponse deleteResponse) {
+                if (collectedResponseCount.incrementAndGet() >= maxResponseCount.get()) {
+                    finish();
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                this.hasFailure.set(true);
+                if (collectedResponseCount.incrementAndGet() >= maxResponseCount.get()) {
+                    finish();
+                }
+            }
+
+            private void finish() {
+                if (this.hasFailure.get()) {
+                    this.delegate.onFailure(new RuntimeException("failed to delete old AD tasks"));
+                } else {
+                    try {
+                        XContentParser parser = TestHelpers
+                            .parser(
+                                "{\"slice_id\":1,\"total\":2,\"updated\":0,\"created\":0,\"deleted\":"
+                                    + maxResponseCount
+                                    + ",\"batches\":6,\"version_conflicts\":0,\"noops\":0,\"retries\":{\"bulk\":0,"
+                                    + "\"search\":10},\"throttled_millis\":0,\"requests_per_second\":13.0,\"canceled\":"
+                                    + "\"reasonCancelled\",\"throttled_until_millis\":14}"
+                            );
+                        parser.nextToken();
+                        BulkByScrollResponse response = new BulkByScrollResponse(
+                            TimeValue.timeValueMillis(10),
+                            BulkByScrollTask.Status.innerFromXContent(parser),
+                            ImmutableList.of(),
+                            ImmutableList.of(),
+                            false
+                        );
+                        this.delegate.onResponse(response);
+                    } catch (IOException exception) {
+                        this.delegate.onFailure(new RuntimeException("failed to parse BulkByScrollResponse"));
+                    }
+                }
+            }
+        }
+
+        @Override
+        protected void doExecute(Task task, DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
+            SearchRequest searchRequest = request.getSearchRequest();
+            client.search(searchRequest, ActionListener.wrap(r -> {
+                long totalHits = r.getHits().getTotalHits().value;
+                MultiResponsesActionListener delegateListener = new MultiResponsesActionListener(listener, totalHits);
+                Iterator<SearchHit> iterator = r.getHits().iterator();
+                while (iterator.hasNext()) {
+                    String id = iterator.next().getId();
+                    DeleteRequest deleteRequest = new DeleteRequest(ADTask.DETECTION_STATE_INDEX, id)
+                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                    client.delete(deleteRequest, delegateListener);
+                }
+            }, e -> listener.onFailure(e)));
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManagerTests.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.task;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomDetector;
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomFeature;
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomUser;
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.ANOMALY_RESULT_INDEX_ALIAS;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+
+import com.amazon.opendistroforelasticsearch.ad.ADUnitTestCase;
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
+import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobResponse;
+import com.google.common.collect.ImmutableList;
+
+public class ADTaskManagerTests extends ADUnitTestCase {
+
+    private Settings settings;
+    private Client client;
+    private ClusterSettings clusterSettings;
+    private AnomalyDetectionIndices anomalyDetectionIndices;
+    private ADTaskManager adTaskManager;
+
+    private Instant startTime;
+    private Instant endTime;
+    private ActionListener<AnomalyDetectorJobResponse> listener;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        Instant now = Instant.now();
+        startTime = now.minus(10, ChronoUnit.DAYS);
+        endTime = now.minus(1, ChronoUnit.DAYS);
+
+        settings = Settings.builder().put(MAX_OLD_AD_TASK_DOCS_PER_DETECTOR.getKey(), 2).build();
+
+        clusterSettings = clusterSetting(settings, MAX_OLD_AD_TASK_DOCS_PER_DETECTOR);
+
+        final ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+
+        client = mock(Client.class);
+        anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
+        adTaskManager = new ADTaskManager(settings, clusterService, client, NamedXContentRegistry.EMPTY, anomalyDetectionIndices);
+
+        listener = spy(new ActionListener<AnomalyDetectorJobResponse>() {
+            @Override
+            public void onResponse(AnomalyDetectorJobResponse bulkItemResponses) {}
+
+            @Override
+            public void onFailure(Exception e) {}
+        });
+    }
+
+    public void testCreateTaskIndexNotAcknowledged() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
+            listener.onResponse(new CreateIndexResponse(false, false, ANOMALY_RESULT_INDEX_ALIAS));
+            return null;
+        }).when(anomalyDetectionIndices).initDetectionStateIndex(any());
+        AnomalyDetector detector = randomDetector(
+            new DetectionDateRange(startTime, endTime),
+            ImmutableList.of(randomFeature(true)),
+            randomAlphaOfLength(5),
+            1,
+            randomAlphaOfLength(5)
+        );
+
+        adTaskManager.createADTaskIndex(detector, randomUser(), listener);
+        verify(listener, times(1)).onFailure(exceptionCaptor.capture());
+        assertEquals(
+            "Create index .opendistro-anomaly-detection-state with mappings not acknowledged",
+            exceptionCaptor.getValue().getMessage()
+        );
+    }
+
+    public void testCreateTaskIndexWithResourceAlreadyExistsException() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
+            listener.onFailure(new ResourceAlreadyExistsException("index created"));
+            return null;
+        }).when(anomalyDetectionIndices).initDetectionStateIndex(any());
+        AnomalyDetector detector = randomDetector(
+            new DetectionDateRange(startTime, endTime),
+            ImmutableList.of(randomFeature(true)),
+            randomAlphaOfLength(5),
+            1,
+            randomAlphaOfLength(5)
+        );
+
+        adTaskManager.createADTaskIndex(detector, randomUser(), listener);
+        verify(listener, never()).onFailure(any());
+    }
+
+    public void testCreateTaskIndexWithException() throws IOException {
+        String error = randomAlphaOfLength(5);
+        doAnswer(invocation -> {
+            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
+            listener.onFailure(new RuntimeException(error));
+            return null;
+        }).when(anomalyDetectionIndices).initDetectionStateIndex(any());
+        AnomalyDetector detector = randomDetector(
+            new DetectionDateRange(startTime, endTime),
+            ImmutableList.of(randomFeature(true)),
+            randomAlphaOfLength(5),
+            1,
+            randomAlphaOfLength(5)
+        );
+
+        adTaskManager.createADTaskIndex(detector, randomUser(), listener);
+        verify(listener, times(1)).onFailure(exceptionCaptor.capture());
+        assertEquals(error, exceptionCaptor.getValue().getMessage());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultTransportActionTests.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomFeature;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
+import static com.amazon.opendistroforelasticsearch.ad.settings.EnabledSetting.AD_PLUGIN_ENABLED;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.HistoricalDetectorIntegTestCase;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2)
+public class ADBatchAnomalyResultTransportActionTests extends HistoricalDetectorIntegTestCase {
+
+    private String testIndex;
+    private Instant startTime;
+    private Instant endTime;
+    private String type = "error";
+    private int detectionIntervalInMinutes = 1;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        testIndex = "test_historical_data";
+        startTime = Instant.now().minus(10, ChronoUnit.DAYS);
+        endTime = Instant.now();
+        ingestTestData(testIndex, startTime, detectionIntervalInMinutes, type);
+        createDetectionStateIndex();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings
+            .builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(BATCH_TASK_PIECE_INTERVAL_SECONDS.getKey(), 1)
+            .put(MAX_BATCH_TASK_PER_NODE.getKey(), 1)
+            .build();
+    }
+
+    public void testAnomalyDetectorWithNullDetector() throws IOException {
+        ADTask task = randomCreatedADTask(randomAlphaOfLength(5), null);
+        ADBatchAnomalyResultRequest request = new ADBatchAnomalyResultRequest(task);
+        ActionRequestValidationException exception = expectThrows(
+            ActionRequestValidationException.class,
+            () -> client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(30_000)
+        );
+        assertTrue(exception.getMessage().contains("Detector can't be null"));
+    }
+
+    public void testRealtimeAnomalyDetector() throws IOException {
+        AnomalyDetector detector = randomDetector(null, ImmutableList.of(randomFeature(true)));
+        ADTask task = randomCreatedADTask(randomAlphaOfLength(5), detector);
+        ADBatchAnomalyResultRequest request = new ADBatchAnomalyResultRequest(task);
+        ActionRequestValidationException exception = expectThrows(
+            ActionRequestValidationException.class,
+            () -> client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(30_000)
+        );
+        assertTrue(exception.getMessage().contains("Can't run batch task for realtime detector"));
+    }
+
+    public void testAnomalyDetectorWithNullTaskId() throws IOException {
+        AnomalyDetector detector = randomDetector(null, ImmutableList.of(randomFeature(true)));
+        ADTask task = randomCreatedADTask(null, detector);
+        ADBatchAnomalyResultRequest request = new ADBatchAnomalyResultRequest(task);
+        ActionRequestValidationException exception = expectThrows(
+            ActionRequestValidationException.class,
+            () -> client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(30_000)
+        );
+        assertTrue(exception.getMessage().contains("Can't run batch task for realtime detector"));
+        assertTrue(exception.getMessage().contains("Task id can't be null"));
+    }
+
+    public void testHistoricalDetectorWithFutureDateRange() throws IOException, InterruptedException {
+        DetectionDateRange dateRange = new DetectionDateRange(endTime, endTime.plus(10, ChronoUnit.DAYS));
+        testInvalidDetectionDateRange(dateRange);
+    }
+
+    public void testHistoricalDetectorWithInvalidHistoricalDateRange() throws IOException, InterruptedException {
+        DetectionDateRange dateRange = new DetectionDateRange(startTime.minus(10, ChronoUnit.DAYS), startTime);
+        testInvalidDetectionDateRange(dateRange);
+    }
+
+    public void testHistoricalDetectorWithSmallHistoricalDateRange() throws IOException, InterruptedException {
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, startTime.plus(10, ChronoUnit.MINUTES));
+        testInvalidDetectionDateRange(dateRange, "There is no enough data to train model");
+    }
+
+    public void testHistoricalDetectorWithValidDateRange() throws IOException, InterruptedException {
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
+        ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(dateRange);
+        client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(5000);
+        Thread.sleep(10000);
+        GetResponse doc = getDoc(ADTask.DETECTION_STATE_INDEX, request.getAdTask().getTaskId());
+        assertEquals(ADTaskState.FINISHED.name(), doc.getSourceAsMap().get(ADTask.STATE_FIELD));
+    }
+
+    public void testHistoricalDetectorWithNonExistingIndex() throws IOException {
+        ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(
+            new DetectionDateRange(startTime, endTime),
+            randomAlphaOfLength(5)
+        );
+        client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(5000);
+    }
+
+    public void testHistoricalDetectorExceedsMaxRunningTaskLimit() throws IOException, InterruptedException {
+        updateTransientSettings(ImmutableMap.of(MAX_BATCH_TASK_PER_NODE.getKey(), 1));
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
+        for (int i = 0; i < getDataNodes().size(); i++) {
+            client().execute(ADBatchAnomalyResultAction.INSTANCE, adBatchAnomalyResultRequest(dateRange));
+        }
+
+        ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(dateRange);
+
+        RuntimeException exception = expectThrowsAnyOf(
+            ImmutableList.of(LimitExceededException.class, NotSerializableExceptionWrapper.class),
+            () -> client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(5000)
+        );
+        assertTrue(
+            exception
+                .getMessage()
+                .contains("All nodes' executing historical detector count exceeds limitation. No eligible node to run detector")
+        );
+    }
+
+    public void testDisableADPlugin() throws IOException {
+        updateTransientSettings(ImmutableMap.of(AD_PLUGIN_ENABLED, false));
+
+        ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(new DetectionDateRange(startTime, endTime));
+        RuntimeException exception = expectThrowsAnyOf(
+            ImmutableList.of(NotSerializableExceptionWrapper.class, EndRunException.class),
+            () -> client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(10000)
+        );
+        assertTrue(exception.getMessage().contains("AD plugin is disabled"));
+        updateTransientSettings(ImmutableMap.of(AD_PLUGIN_ENABLED, true));
+    }
+
+    public void testMultipleTasks() throws IOException, InterruptedException {
+        updateTransientSettings(ImmutableMap.of(MAX_BATCH_TASK_PER_NODE.getKey(), 2));
+
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
+        for (int i = 0; i < getDataNodes().size(); i++) {
+            client().execute(ADBatchAnomalyResultAction.INSTANCE, adBatchAnomalyResultRequest(dateRange));
+        }
+
+        ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(
+            new DetectionDateRange(startTime, startTime.plus(2000, ChronoUnit.MINUTES))
+        );
+        client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(5000);
+        Thread.sleep(10000);
+        GetResponse doc = getDoc(ADTask.DETECTION_STATE_INDEX, request.getAdTask().getTaskId());
+        assertEquals(ADTaskState.FINISHED.name(), doc.getSourceAsMap().get(ADTask.STATE_FIELD));
+        updateTransientSettings(ImmutableMap.of(MAX_BATCH_TASK_PER_NODE.getKey(), 1));
+    }
+
+    private ADBatchAnomalyResultRequest adBatchAnomalyResultRequest(DetectionDateRange dateRange) throws IOException {
+        return adBatchAnomalyResultRequest(dateRange, testIndex);
+    }
+
+    private ADBatchAnomalyResultRequest adBatchAnomalyResultRequest(DetectionDateRange dateRange, String indexName) throws IOException {
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), indexName, detectionIntervalInMinutes, timeField);
+        ADTask adTask = randomCreatedADTask(randomAlphaOfLength(5), detector);
+        adTask.setTaskId(createADTask(adTask));
+        return new ADBatchAnomalyResultRequest(adTask);
+    }
+
+    private void testInvalidDetectionDateRange(DetectionDateRange dateRange) throws IOException, InterruptedException {
+        testInvalidDetectionDateRange(dateRange, "There is no data in the detection date range");
+    }
+
+    private void testInvalidDetectionDateRange(DetectionDateRange dateRange, String error) throws IOException, InterruptedException {
+        ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(dateRange);
+        client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(5000);
+        Thread.sleep(5000);
+        GetResponse doc = getDoc(ADTask.DETECTION_STATE_INDEX, request.getAdTask().getTaskId());
+        assertEquals(error, doc.getSourceAsMap().get(ADTask.ERROR_FIELD));
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultTransportActionTests.java
@@ -35,6 +35,7 @@ import com.amazon.opendistroforelasticsearch.ad.HistoricalDetectorIntegTestCase;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.EndRunException;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
@@ -125,7 +126,7 @@ public class ADBatchAnomalyResultTransportActionTests extends HistoricalDetector
         ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(dateRange);
         client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(5000);
         Thread.sleep(10000);
-        GetResponse doc = getDoc(ADTask.DETECTION_STATE_INDEX, request.getAdTask().getTaskId());
+        GetResponse doc = getDoc(CommonName.DETECTION_STATE_INDEX, request.getAdTask().getTaskId());
         assertEquals(ADTaskState.FINISHED.name(), doc.getSourceAsMap().get(ADTask.STATE_FIELD));
     }
 
@@ -182,7 +183,7 @@ public class ADBatchAnomalyResultTransportActionTests extends HistoricalDetector
         );
         client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(5000);
         Thread.sleep(10000);
-        GetResponse doc = getDoc(ADTask.DETECTION_STATE_INDEX, request.getAdTask().getTaskId());
+        GetResponse doc = getDoc(CommonName.DETECTION_STATE_INDEX, request.getAdTask().getTaskId());
         assertEquals(ADTaskState.FINISHED.name(), doc.getSourceAsMap().get(ADTask.STATE_FIELD));
         updateTransientSettings(ImmutableMap.of(MAX_BATCH_TASK_PER_NODE.getKey(), 1));
     }
@@ -207,7 +208,7 @@ public class ADBatchAnomalyResultTransportActionTests extends HistoricalDetector
         ADBatchAnomalyResultRequest request = adBatchAnomalyResultRequest(dateRange);
         client().execute(ADBatchAnomalyResultAction.INSTANCE, request).actionGet(5000);
         Thread.sleep(5000);
-        GetResponse doc = getDoc(ADTask.DETECTION_STATE_INDEX, request.getAdTask().getTaskId());
+        GetResponse doc = getDoc(CommonName.DETECTION_STATE_INDEX, request.getAdTask().getTaskId());
         assertEquals(error, doc.getSourceAsMap().get(ADTask.ERROR_FIELD));
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobActionTests.java
@@ -43,6 +43,7 @@ import org.junit.Test;
 
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
 import com.amazon.opendistroforelasticsearch.commons.ConfigConstants;
 
 public class AnomalyDetectorJobActionTests extends ESIntegTestCase {
@@ -77,7 +78,8 @@ public class AnomalyDetectorJobActionTests extends ESIntegTestCase {
             clusterService,
             indexSettings(),
             mock(AnomalyDetectionIndices.class),
-            xContentRegistry()
+            xContentRegistry(),
+            mock(ADTaskManager.class)
         );
         task = mock(Task.class);
         request = new AnomalyDetectorJobRequest("1234", 4567, 7890, "_start");

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.START_JOB;
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.HistoricalDetectorIntegTestCase;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
+import com.amazon.opendistroforelasticsearch.ad.plugin.MockReindexPlugin;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2)
+public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIntegTestCase {
+    private Instant startTime;
+    private Instant endTime;
+    private String type = "error";
+    private int maxOldAdTaskDocsPerDetector = 2;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        startTime = Instant.now().minus(10, ChronoUnit.DAYS);
+        endTime = Instant.now();
+        ingestTestData(testIndex, startTime, detectionIntervalInMinutes, type, 2000);
+        createDetectorIndex();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings
+            .builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(BATCH_TASK_PIECE_INTERVAL_SECONDS.getKey(), 1)
+            .put(MAX_BATCH_TASK_PER_NODE.getKey(), 1)
+            .put(MAX_OLD_AD_TASK_DOCS_PER_DETECTOR.getKey(), maxOldAdTaskDocsPerDetector)
+            .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getMockPlugins() {
+        final ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>();
+        plugins.add(MockReindexPlugin.class);
+        plugins.addAll(super.getMockPlugins());
+        return Collections.unmodifiableList(plugins);
+    }
+
+    public void testDetectorIndexNotFound() {
+        deleteDetectorIndex();
+        String detectorId = randomAlphaOfLength(5);
+        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
+            detectorId,
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            START_JOB
+        );
+        IndexNotFoundException exception = expectThrows(
+            IndexNotFoundException.class,
+            () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(3000)
+        );
+        assertTrue(exception.getMessage().contains("no such index [.opendistro-anomaly-detectors]"));
+    }
+
+    public void testDetectorNotFound() {
+        String detectorId = randomAlphaOfLength(5);
+        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
+            detectorId,
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            START_JOB
+        );
+        ElasticsearchStatusException exception = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(3000)
+        );
+        assertTrue(exception.getMessage().contains("AnomalyDetector is not found"));
+    }
+
+    public void testValidHistoricalDetector() throws IOException, InterruptedException {
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
+        String detectorId = createDetector(detector);
+        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
+            detectorId,
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            START_JOB
+        );
+        AnomalyDetectorJobResponse response = client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
+        Thread.sleep(10000);
+        GetResponse doc = getDoc(ADTask.DETECTION_STATE_INDEX, response.getId());
+        assertEquals(ADTaskState.FINISHED.name(), doc.getSourceAsMap().get(ADTask.STATE_FIELD));
+    }
+
+    public void testRunMultipleTasksForHistoricalDetector() throws IOException, InterruptedException {
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
+        String detectorId = createDetector(detector);
+        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
+            detectorId,
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            START_JOB
+        );
+        AnomalyDetectorJobResponse response = client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
+        assertNotNull(response.getId());
+        ElasticsearchStatusException exception = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000)
+        );
+        assertTrue(exception.getMessage().contains("Detector is already running"));
+    }
+
+    public void testCleanOldTaskDocs() throws IOException, InterruptedException {
+        updateTransientSettings(ImmutableMap.of(BATCH_TASK_PIECE_INTERVAL_SECONDS.getKey(), 1));
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
+        String detectorId = createDetector(detector);
+
+        createDetectionStateIndex();
+        List<ADTaskState> states = ImmutableList.of(ADTaskState.FAILED, ADTaskState.FINISHED, ADTaskState.STOPPED);
+        for (ADTaskState state : states) {
+            ADTask task = randomADTask(randomAlphaOfLength(5), detector, detectorId, state);
+            createADTask(task);
+        }
+        long count = countDocs(ADTask.DETECTION_STATE_INDEX);
+        assertEquals(states.size(), count);
+
+        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(detectorId, randomLong(), randomLong(), START_JOB);
+        AtomicReference<AnomalyDetectorJobResponse> response = new AtomicReference<>();
+        CountDownLatch latch = new CountDownLatch(1);
+        client().execute(AnomalyDetectorJobAction.INSTANCE, request, ActionListener.wrap(r -> {
+            latch.countDown();
+            response.set(r);
+        }, e -> { latch.countDown(); }));
+        latch.await();
+
+        count = countDocs(ADTask.DETECTION_STATE_INDEX);
+        // we have one latest task, so total count should add 1
+        assertEquals(maxOldAdTaskDocsPerDetector + 1, count);
+    }
+
+    public void testStartRealtimeDetector() throws IOException {
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(null, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
+        String detectorId = createDetector(detector);
+        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
+            detectorId,
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            START_JOB
+        );
+        AnomalyDetectorJobResponse response = client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
+        assertEquals(detectorId, response.getId());
+        GetResponse doc = getDoc(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, detectorId);
+        AnomalyDetectorJob job = toADJob(doc);
+        assertTrue(job.isEnabled());
+        assertEquals(detectorId, job.getName());
+    }
+
+    public void testRealtimeDetectorWithoutFeature() throws IOException {
+        AnomalyDetector detector = TestHelpers.randomDetector(null, ImmutableList.of(), testIndex, detectionIntervalInMinutes, timeField);
+        testInvalidDetector(detector, "Can't start detector job as no features configured");
+    }
+
+    public void testHistoricalDetectorWithoutFeature() throws IOException {
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(
+                new DetectionDateRange(startTime, endTime),
+                ImmutableList.of(),
+                testIndex,
+                detectionIntervalInMinutes,
+                timeField
+            );
+        testInvalidDetector(detector, "Can't start detector job as no features configured");
+    }
+
+    public void testRealtimeDetectorWithoutEnabledFeature() throws IOException {
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(null, ImmutableList.of(TestHelpers.randomFeature(false)), testIndex, detectionIntervalInMinutes, timeField);
+        testInvalidDetector(detector, "Can't start detector job as no enabled features configured");
+    }
+
+    public void testHistoricalDetectorWithoutEnabledFeature() throws IOException {
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(
+                new DetectionDateRange(startTime, endTime),
+                ImmutableList.of(TestHelpers.randomFeature(false)),
+                testIndex,
+                detectionIntervalInMinutes,
+                timeField
+            );
+        testInvalidDetector(detector, "Can't start detector job as no enabled features configured");
+    }
+
+    private void testInvalidDetector(AnomalyDetector detector, String error) throws IOException {
+        String detectorId = createDetector(detector);
+        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
+            detectorId,
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            START_JOB
+        );
+        ElasticsearchStatusException exception = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000)
+        );
+        assertEquals(error, exception.getMessage());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
@@ -43,6 +43,7 @@ import org.junit.Before;
 
 import com.amazon.opendistroforelasticsearch.ad.HistoricalDetectorIntegTestCase;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
@@ -132,7 +133,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
         );
         AnomalyDetectorJobResponse response = client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
         Thread.sleep(10000);
-        GetResponse doc = getDoc(ADTask.DETECTION_STATE_INDEX, response.getId());
+        GetResponse doc = getDoc(CommonName.DETECTION_STATE_INDEX, response.getId());
         assertEquals(ADTaskState.FINISHED.name(), doc.getSourceAsMap().get(ADTask.STATE_FIELD));
     }
 
@@ -169,7 +170,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
             ADTask task = randomADTask(randomAlphaOfLength(5), detector, detectorId, state);
             createADTask(task);
         }
-        long count = countDocs(ADTask.DETECTION_STATE_INDEX);
+        long count = countDocs(CommonName.DETECTION_STATE_INDEX);
         assertEquals(states.size(), count);
 
         AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(detectorId, randomLong(), randomLong(), START_JOB);
@@ -181,7 +182,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
         }, e -> { latch.countDown(); }));
         latch.await();
 
-        count = countDocs(ADTask.DETECTION_STATE_INDEX);
+        count = countDocs(CommonName.DETECTION_STATE_INDEX);
         // we have one latest task, so total count should add 1
         assertEquals(maxOldAdTaskDocsPerDetector + 1, count);
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
@@ -181,7 +181,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
             response.set(r);
         }, e -> { latch.countDown(); }));
         latch.await();
-
+        Thread.sleep(10000);
         count = countDocs(CommonName.DETECTION_STATE_INDEX);
         // we have one latest task, so total count should add 1
         assertEquals(maxOldAdTaskDocsPerDetector + 1, count);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTests.java
@@ -284,14 +284,12 @@ public class AnomalyResultTests extends AbstractADTest {
             GetRequest request = (GetRequest) args[0];
             ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
 
-            if (request.index().equals(DetectorInternalState.DETECTOR_STATE_INDEX)) {
+            if (request.index().equals(CommonName.DETECTION_STATE_INDEX)) {
 
                 DetectorInternalState.Builder result = new DetectorInternalState.Builder().lastUpdateTime(Instant.now());
 
                 listener
-                    .onResponse(
-                        TestHelpers.createGetResponse(result.build(), detector.getDetectorId(), DetectorInternalState.DETECTOR_STATE_INDEX)
-                    );
+                    .onResponse(TestHelpers.createGetResponse(result.build(), detector.getDetectorId(), CommonName.DETECTION_STATE_INDEX));
 
             }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyResultTransportActionTests.java
@@ -43,8 +43,6 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
     private Instant testDataTimeStamp;
     private long start;
     private long end;
-    private String timeField = "timestamp";
-    private String categoryField = "type";
 
     @Override
     @Before
@@ -58,14 +56,7 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
     }
 
     private void ingestTestData() throws IOException {
-        String mappings = "{\"properties\":{\""
-            + timeField
-            + "\":{\"type\":\"date\",\"format\":\"strict_date_time||epoch_millis\"},"
-            + "\"value\":{\"type\":\"double\"}, \""
-            + categoryField
-            + "\":{\"type\":\"keyword\"},"
-            + "\"is_error\":{\"type\":\"boolean\"}, \"message\":{\"type\":\"text\"}}}";
-        createIndex(testIndex, mappings);
+        createTestDataIndex(testIndex);
         double value = randomDouble();
         String type = randomAlphaOfLength(5);
         boolean isError = randomBoolean();
@@ -205,7 +196,7 @@ public class AnomalyResultTransportActionTests extends ADIntegTestCase {
         AnomalyDetector detector = hcDetector
             ? randomHCDetector(ImmutableList.of(testIndex), ImmutableList.of(feature))
             : randomDetector(ImmutableList.of(testIndex), ImmutableList.of(feature));
-        String adId = createDetectors(detector);
+        String adId = createDetector(detector);
         return adId;
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultBulkIndexHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/AnomalyResultBulkIndexHandlerTests.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport.handler;
+
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.ANOMALY_RESULT_INDEX_ALIAS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.time.Clock;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import com.amazon.opendistroforelasticsearch.ad.ADUnitTestCase;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyResult;
+import com.amazon.opendistroforelasticsearch.ad.util.ClientUtil;
+import com.amazon.opendistroforelasticsearch.ad.util.IndexUtils;
+import com.amazon.opendistroforelasticsearch.ad.util.Throttler;
+import com.amazon.opendistroforelasticsearch.ad.util.ThrowingConsumerWrapper;
+import com.google.common.collect.ImmutableList;
+
+public class AnomalyResultBulkIndexHandlerTests extends ADUnitTestCase {
+
+    private AnomalyResultBulkIndexHandler bulkIndexHandler;
+    private Client client;
+    private IndexUtils indexUtils;
+    private ActionListener<BulkResponse> listener;
+    private AnomalyDetectionIndices anomalyDetectionIndices;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
+        client = mock(Client.class);
+        Settings settings = Settings.EMPTY;
+        Clock clock = mock(Clock.class);
+        Throttler throttler = new Throttler(clock);
+        ThreadPool threadpool = mock(ThreadPool.class);
+        ClientUtil clientUtil = new ClientUtil(Settings.EMPTY, client, throttler, threadpool);
+        indexUtils = mock(IndexUtils.class);
+        ClusterService clusterService = mock(ClusterService.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        bulkIndexHandler = new AnomalyResultBulkIndexHandler(
+            client,
+            settings,
+            threadPool,
+            ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initDetectionStateIndex),
+            anomalyDetectionIndices::doesDetectorStateIndexExist,
+            clientUtil,
+            indexUtils,
+            clusterService,
+            anomalyDetectionIndices
+        );
+        listener = spy(new ActionListener<BulkResponse>() {
+            @Override
+            public void onResponse(BulkResponse bulkItemResponses) {}
+
+            @Override
+            public void onFailure(Exception e) {}
+        });
+    }
+
+    public void testNullAnomalyResults() {
+        bulkIndexHandler.bulkIndexAnomalyResult(null, listener);
+        verify(listener, times(1)).onResponse(null);
+        verify(anomalyDetectionIndices, never()).doesAnomalyDetectorIndexExist();
+    }
+
+    public void testCreateADResultIndexNotAcknowledged() throws IOException {
+        doAnswer(invocation -> {
+            ActionListener<CreateIndexResponse> listener = invocation.getArgument(0);
+            listener.onResponse(new CreateIndexResponse(false, false, ANOMALY_RESULT_INDEX_ALIAS));
+            return null;
+        }).when(anomalyDetectionIndices).initAnomalyResultIndexDirectly(any());
+        bulkIndexHandler.bulkIndexAnomalyResult(ImmutableList.of(mock(AnomalyResult.class)), listener);
+        verify(listener, times(1)).onFailure(exceptionCaptor.capture());
+        assertEquals("Creating anomaly result index with mappings call not acknowledged", exceptionCaptor.getValue().getMessage());
+    }
+
+    public void testWrongAnomalyResult() {
+        BulkRequestBuilder bulkRequestBuilder = mock(BulkRequestBuilder.class);
+        doReturn(bulkRequestBuilder).when(client).prepareBulk();
+        doReturn(true).when(anomalyDetectionIndices).doesAnomalyResultIndexExist();
+        bulkIndexHandler.bulkIndexAnomalyResult(ImmutableList.of(wrongAnomalyResult(), TestHelpers.randomAnomalyDetectResult()), listener);
+        verify(listener, times(1)).onFailure(exceptionCaptor.capture());
+        assertEquals("Failed to prepare request to bulk index anomaly results", exceptionCaptor.getValue().getMessage());
+    }
+
+    public void testBulkSaveException() {
+        BulkRequestBuilder bulkRequestBuilder = mock(BulkRequestBuilder.class);
+        doReturn(bulkRequestBuilder).when(client).prepareBulk();
+        doReturn(true).when(anomalyDetectionIndices).doesAnomalyResultIndexExist();
+
+        String testError = randomAlphaOfLength(5);
+        doAnswer(invocation -> {
+            ActionListener<CreateIndexResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new RuntimeException(testError));
+            return null;
+        }).when(client).bulk(any(), any());
+
+        bulkIndexHandler.bulkIndexAnomalyResult(ImmutableList.of(TestHelpers.randomAnomalyDetectResult()), listener);
+        verify(listener, times(1)).onFailure(exceptionCaptor.capture());
+        assertEquals(testError, exceptionCaptor.getValue().getMessage());
+    }
+
+    private AnomalyResult wrongAnomalyResult() {
+        return new AnomalyResult(
+            randomAlphaOfLength(5),
+            randomDouble(),
+            randomDouble(),
+            randomDouble(),
+            null,
+            null,
+            null,
+            null,
+            null,
+            randomAlphaOfLength(5),
+            null,
+            null,
+            null
+        );
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectorStateHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectorStateHandlerTests.java
@@ -72,7 +72,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
             client,
             settings,
             threadPool,
-            ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initDetectorStateIndex),
+            ThrowingConsumerWrapper.throwingConsumerWrapper(anomalyDetectionIndices::initDetectionStateIndex),
             anomalyDetectionIndices::doesDetectorStateIndexExist,
             clientUtil,
             indexUtils,

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectorStateHandlerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/handler/DetectorStateHandlerTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import com.amazon.opendistroforelasticsearch.ad.NodeStateManager;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.transport.handler.DetectionStateHandler.ErrorStrategy;
@@ -119,7 +120,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
             @SuppressWarnings("unchecked")
             ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
             DetectorInternalState.Builder result = new DetectorInternalState.Builder().lastUpdateTime(Instant.now()).error(error);
-            listener.onResponse(TestHelpers.createGetResponse(result.build(), detectorId, DetectorInternalState.DETECTOR_STATE_INDEX));
+            listener.onResponse(TestHelpers.createGetResponse(result.build(), detectorId, CommonName.DETECTION_STATE_INDEX));
             return null;
         }).when(client).get(any(), any());
 
@@ -135,7 +136,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
             @SuppressWarnings("unchecked")
             ActionListener<GetResponse> listener = (ActionListener<GetResponse>) args[1];
             DetectorInternalState.Builder result = new DetectorInternalState.Builder().lastUpdateTime(Instant.now()).error("blah");
-            listener.onResponse(TestHelpers.createGetResponse(result.build(), detectorId, DetectorInternalState.DETECTOR_STATE_INDEX));
+            listener.onResponse(TestHelpers.createGetResponse(result.build(), detectorId, CommonName.DETECTION_STATE_INDEX));
             return null;
         }).when(client).get(any(), any());
 
@@ -153,7 +154,7 @@ public class DetectorStateHandlerTests extends ESTestCase {
             DetectorInternalState.Builder result = new DetectorInternalState.Builder()
                 .lastUpdateTime(Instant.ofEpochMilli(1))
                 .error("blah");
-            listener.onResponse(TestHelpers.createGetResponse(result.build(), detectorId, DetectorInternalState.DETECTOR_STATE_INDEX));
+            listener.onResponse(TestHelpers.createGetResponse(result.build(), detectorId, CommonName.DETECTION_STATE_INDEX));
             return null;
         }).when(client).get(any(), any());
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/ExceptionUtilsTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/ExceptionUtilsTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.util;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESTestCase;
+
+import com.amazon.opendistroforelasticsearch.ad.common.exception.AnomalyDetectionException;
+
+public class ExceptionUtilsTests extends ESTestCase {
+
+    public void testGetShardsFailure() {
+        ShardId shardId = new ShardId(randomAlphaOfLength(5), randomAlphaOfLength(5), 1);
+        ReplicationResponse.ShardInfo.Failure failure = new ReplicationResponse.ShardInfo.Failure(
+            shardId,
+            randomAlphaOfLength(5),
+            new RuntimeException("test"),
+            RestStatus.BAD_REQUEST,
+            false
+        );
+        ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(2, 1, failure);
+        IndexResponse indexResponse = new IndexResponse(
+            shardId,
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            randomLong(),
+            randomLong(),
+            randomLong(),
+            randomBoolean()
+        );
+        indexResponse.setShardInfo(shardInfo);
+        String shardsFailure = ExceptionUtil.getShardsFailure(indexResponse);
+        assertEquals("RuntimeException[test]", shardsFailure);
+    }
+
+    public void testGetShardsFailureWithoutError() {
+        ShardId shardId = new ShardId(randomAlphaOfLength(5), randomAlphaOfLength(5), 1);
+        IndexResponse indexResponse = new IndexResponse(
+            shardId,
+            randomAlphaOfLength(5),
+            randomAlphaOfLength(5),
+            randomLong(),
+            randomLong(),
+            randomLong(),
+            randomBoolean()
+        );
+        assertNull(ExceptionUtil.getShardsFailure(indexResponse));
+
+        ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(2, 1, ReplicationResponse.EMPTY);
+        indexResponse.setShardInfo(shardInfo);
+        assertNull(ExceptionUtil.getShardsFailure(indexResponse));
+    }
+
+    public void testCountInStats() {
+        assertTrue(ExceptionUtil.countInStats(new AnomalyDetectionException("test")));
+        assertFalse(ExceptionUtil.countInStats(new AnomalyDetectionException("test").countedInStats(false)));
+        assertTrue(ExceptionUtil.countInStats(new RuntimeException("test")));
+    }
+
+    public void testGetErrorMessage() {
+        assertEquals("test", ExceptionUtil.getErrorMessage(new AnomalyDetectionException("test")));
+        assertEquals("test", ExceptionUtil.getErrorMessage(new IllegalArgumentException("test")));
+        assertEquals("org.elasticsearch.ElasticsearchException: test", ExceptionUtil.getErrorMessage(new ElasticsearchException("test")));
+        assertTrue(
+            ExceptionUtil
+                .getErrorMessage(new RuntimeException("test"))
+                .contains("at com.amazon.opendistroforelasticsearch.ad.util.ExceptionUtilsTests.testGetErrorMessage")
+        );
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtilsTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtilsTests.java
@@ -60,12 +60,6 @@ public class RestHandlerUtilsTests extends ESTestCase {
         parser.close();
     }
 
-    public void testValidateAnomalyDetectorWithNullFeatures() throws IOException {
-        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(null);
-        String error = RestHandlerUtils.validateAnomalyDetector(detector, 1);
-        assertNull(error);
-    }
-
     public void testValidateAnomalyDetectorWithTooManyFeatures() throws IOException {
         AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableList.of(randomFeature(), randomFeature()));
         String error = RestHandlerUtils.validateAnomalyDetector(detector, 1);

--- a/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityProfileTests.java
+++ b/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityProfileTests.java
@@ -50,7 +50,6 @@ import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
-import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileNodeResponse;
@@ -109,7 +108,7 @@ public class CardinalityProfileTests extends AbstractProfileRunnerTests {
                         assertTrue("should not reach here", false);
                         break;
                 }
-            } else if (request.index().equals(DetectorInternalState.DETECTOR_STATE_INDEX)) {
+            } else if (request.index().equals(CommonName.DETECTION_STATE_INDEX)) {
                 switch (errorResultStatus) {
                     case NO_ERROR:
                         listener.onResponse(null);


### PR DESCRIPTION
*Issue #, if available:*

## Description of changes:
If a detector has detection date range, we call it "historical detector".

Use the same start detector API to start both realtime and historical detector. 
1. We don't change realtime detector execution logic.
2. For historical detector, we will start an AD task and return the task id to client, then dispatch the task to a node with least load. The AD task will be split into smaller pieces, one piece has 1000 detection intervals by default, user can tune the piece size dynamically. AD task runner will execute the pieces sequentially. 

### AD task states
![ad_workbench_task_lifecycle (2) (1)](https://user-images.githubusercontent.com/49084640/103683082-96b5de00-4f3e-11eb-940c-ed29aad52be3.png)


## Test
1. `./gradlew build`
2. `./gradlew integTest -PnumNodes=3`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
