### PR TITLE
Change release workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,8 +1,11 @@
 name: Build and Release AD
 on:
+  # push:
+  #   tags:
+  #     - v*
   push:
-    tags:
-      - v*
+    branches:
+      - "release-workflow-patch"
 
 jobs:
   Build-AD:
@@ -20,8 +23,8 @@ jobs:
       - name: Configure AWS
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
       - name: Setup Java ${{ matrix.java }}
@@ -32,11 +35,26 @@ jobs:
       - name: Run build
         run: |
           ./gradlew buildPackages --console=plain -Dbuild.snapshot=false
-          artifact=`ls build/distributions/*.zip`
-          rpm_artifact=`ls build/distributions/*.rpm`
-          deb_artifact=`ls build/distributions/*.deb`
+          
+      - name: Upload to S3
+        shell: bash
+        run: |
+          zip=`ls build/distributions/*.zip`
+          rpm=`ls build/distributions/*.rpm`
+          deb=`ls build/distributions/*.deb`
 
-          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-anomaly-detection/
-          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-anomaly-detection/
-          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-anomaly-detection/
-          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/downloads/*"
+          # Inject the build number before the suffix
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
+
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/elasticsearch-plugins/anomaly-detection/"
+
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+
+          echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
+          aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
+          
+          echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
+          aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run build
         run: |
           ./gradlew buildPackages --console=plain -Dbuild.snapshot=false
+          
       - name: Upload to S3
         shell: bash
         run: |

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Run build
         run: |
           ./gradlew buildPackages --console=plain -Dbuild.snapshot=false
-          
       - name: Upload to S3
         shell: bash
         run: |

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,11 +1,8 @@
 name: Build and Release AD
 on:
-  # push:
-  #   tags:
-  #     - v*
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - v*
 
 jobs:
   Build-AD:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations.

This PR changes the CD workflow to add a build number and write the zip, deb, and rpm plugin artifacts to staging.artifacts.opendistroforelasticsearch.amazon.com.

Test Results:
https://github.com/gaiksaya/anomaly-detection/runs/1684584738?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.