### PR TITLE
stop historical detector; support return AD task in get detector API

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -115,10 +115,14 @@ import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchAnomalyResultAc
 import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchAnomalyResultTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchTaskRemoteExecutionAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchTaskRemoteExecutionTransportAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADCancelTaskAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADCancelTaskTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADResultBulkAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADResultBulkTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsNodesAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADStatsNodesTransportAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADTaskProfileAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADTaskProfileTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyResultAction;
@@ -133,6 +137,8 @@ import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.EntityProfileTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.EntityResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.EntityResultTransportAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ForwardADTaskAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ForwardADTaskTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorTransportAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.IndexAnomalyDetectorAction;
@@ -508,7 +514,16 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
         );
 
         adTaskCacheManager = new ADTaskCacheManager(settings, clusterService, memoryTracker);
-        adTaskManager = new ADTaskManager(settings, clusterService, client, xContentRegistry, anomalyDetectionIndices);
+        adTaskManager = new ADTaskManager(
+            settings,
+            clusterService,
+            client,
+            xContentRegistry,
+            anomalyDetectionIndices,
+            nodeFilter,
+            hashRing,
+            adTaskCacheManager
+        );
         AnomalyResultBulkIndexHandler anomalyResultBulkIndexHandler = new AnomalyResultBulkIndexHandler(
             client,
             settings,
@@ -671,7 +686,10 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
                 new ActionHandler<>(SearchAnomalyDetectorInfoAction.INSTANCE, SearchAnomalyDetectorInfoTransportAction.class),
                 new ActionHandler<>(PreviewAnomalyDetectorAction.INSTANCE, PreviewAnomalyDetectorTransportAction.class),
                 new ActionHandler<>(ADBatchAnomalyResultAction.INSTANCE, ADBatchAnomalyResultTransportAction.class),
-                new ActionHandler<>(ADBatchTaskRemoteExecutionAction.INSTANCE, ADBatchTaskRemoteExecutionTransportAction.class)
+                new ActionHandler<>(ADBatchTaskRemoteExecutionAction.INSTANCE, ADBatchTaskRemoteExecutionTransportAction.class),
+                new ActionHandler<>(ADTaskProfileAction.INSTANCE, ADTaskProfileTransportAction.class),
+                new ActionHandler<>(ADCancelTaskAction.INSTANCE, ADCancelTaskTransportAction.class),
+                new ActionHandler<>(ForwardADTaskAction.INSTANCE, ForwardADTaskTransportAction.class)
             );
     }
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorPlugin.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -61,7 +62,7 @@ import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ExecutorBuilder;
-import org.elasticsearch.threadpool.FixedExecutorBuilder;
+import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
 
@@ -594,18 +595,18 @@ public class AnomalyDetectorPlugin extends Plugin implements ActionPlugin, Scrip
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
         return ImmutableList
             .of(
-                new FixedExecutorBuilder(
-                    settings,
+                new ScalingExecutorBuilder(
                     AD_THREAD_POOL_NAME,
+                    1,
                     Math.max(1, EsExecutors.allocatedProcessors(settings) / 4),
-                    AnomalyDetectorSettings.AD_THEAD_POOL_QUEUE_SIZE,
+                    TimeValue.timeValueMinutes(10),
                     AD_THREAD_POOL_PREFIX + AD_THREAD_POOL_NAME
                 ),
-                new FixedExecutorBuilder(
-                    settings,
+                new ScalingExecutorBuilder(
                     AD_BATCH_TASK_THREAD_POOL_NAME,
+                    1,
                     Math.max(1, EsExecutors.allocatedProcessors(settings) / 8),
-                    AnomalyDetectorSettings.AD_THEAD_POOL_QUEUE_SIZE,
+                    TimeValue.timeValueMinutes(10),
                     AD_THREAD_POOL_PREFIX + AD_BATCH_TASK_THREAD_POOL_NAME
                 )
             );

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunner.java
@@ -62,6 +62,7 @@ import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfileName;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorState;
 import com.amazon.opendistroforelasticsearch.ad.model.InitProgressProfile;
 import com.amazon.opendistroforelasticsearch.ad.model.IntervalTimeConfiguration;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileRequest;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileResponse;
@@ -77,12 +78,14 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
     private Client client;
     private NamedXContentRegistry xContentRegistry;
     private DiscoveryNodeFilterer nodeFilter;
+    private final ADTaskManager adTaskManager;
 
     public AnomalyDetectorProfileRunner(
         Client client,
         NamedXContentRegistry xContentRegistry,
         DiscoveryNodeFilterer nodeFilter,
-        long requiredSamples
+        long requiredSamples,
+        ADTaskManager adTaskManager
     ) {
         super(requiredSamples);
         this.client = client;
@@ -91,6 +94,7 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
         if (requiredSamples <= 0) {
             throw new IllegalArgumentException("required samples should be a positive number, but was " + requiredSamples);
         }
+        this.adTaskManager = adTaskManager;
     }
 
     public void profile(String detectorId, ActionListener<DetectorProfile> listener, Set<DetectorProfileName> profilesToCollect) {
@@ -117,7 +121,10 @@ public class AnomalyDetectorProfileRunner extends AbstractProfileRunner {
                 ) {
                     ensureExpectedToken(XContentParser.Token.START_OBJECT, xContentParser.nextToken(), xContentParser);
                     AnomalyDetector detector = AnomalyDetector.parse(xContentParser, detectorId);
-
+                    if (!detector.isRealTimeDetector() && profilesToCollect.contains(DetectorProfileName.AD_TASK)) {
+                        adTaskManager.getLatestADTaskProfile(detectorId, listener);
+                        return;
+                    }
                     prepareProfile(detector, listener, profilesToCollect);
                 } catch (Exception e) {
                     listener.onFailure(new RuntimeException(CommonErrorMessages.FAIL_TO_FIND_DETECTOR_MSG + detectorId, e));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/MemoryTracker.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/MemoryTracker.java
@@ -194,7 +194,7 @@ public class MemoryTracker {
      * @param numSamples The number of samples in RCF
      * @return estimated model size in bytes
      */
-    private long estimateModelSize(int dimension, int numberOfTrees, int numSamples) {
+    public long estimateModelSize(int dimension, int numberOfTrees, int numSamples) {
         long totalSamples = (long) numberOfTrees * (long) numSamples;
         long rcfSize = totalSamples * (40 * dimension + 132);
         long samplerSize = totalSamples * 36;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/DuplicateTaskException.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/common/exception/DuplicateTaskException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.common.exception;
+
+public class DuplicateTaskException extends AnomalyDetectionException {
+
+    public DuplicateTaskException(String msg) {
+        super(msg);
+        this.countedInStats(false);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java
@@ -35,7 +35,7 @@ public class CommonErrorMessages {
     public static String CATEGORICAL_FIELD_NUMBER_SURPASSED = "We don't support categorical fields more than ";
     public static String EMPTY_PROFILES_COLLECT = "profiles to collect are missing or invalid";
     public static String FAIL_FETCH_ERR_MSG = "Fail to fetch profile for ";
-    public static String DETECTOR_ALREADY_RUNNING = "Detector is already running";
-    public static String AD_TASK_ID_MISSING = "AD task ID is missing";
+    public static String DETECTOR_IS_RUNNING = "Detector is already running";
     public static String DETECTOR_MISSING = "Detector is missing";
+    public static String AD_TASK_ACTION_MISSING = "AD task action is missing";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonErrorMessages.java
@@ -35,4 +35,7 @@ public class CommonErrorMessages {
     public static String CATEGORICAL_FIELD_NUMBER_SURPASSED = "We don't support categorical fields more than ";
     public static String EMPTY_PROFILES_COLLECT = "profiles to collect are missing or invalid";
     public static String FAIL_FETCH_ERR_MSG = "Fail to fetch profile for ";
+    public static String DETECTOR_ALREADY_RUNNING = "Detector is already running";
+    public static String AD_TASK_ID_MISSING = "AD task ID is missing";
+    public static String DETECTOR_MISSING = "Detector is missing";
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
@@ -68,6 +68,8 @@ public class CommonName {
     public static final String ENTITY_INFO = "entity_info";
     public static final String TOTAL_UPDATES = "total_updates";
     public static final String AD_TASK = "ad_task";
+    public static final String AD_TASK_REMOTE = "ad_task_remote";
+    public static final String CANCEL_TASK = "_cancel_task";
 
     // ======================================
     // Index mapping

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
@@ -69,7 +69,7 @@ public class CommonName {
     public static final String TOTAL_UPDATES = "total_updates";
     public static final String AD_TASK = "ad_task";
     public static final String AD_TASK_REMOTE = "ad_task_remote";
-    public static final String CANCEL_TASK = "_cancel_task";
+    public static final String CANCEL_TASK = "cancel_task";
 
     // ======================================
     // Index mapping

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/constant/CommonName.java
@@ -67,6 +67,7 @@ public class CommonName {
     public static final String ACTIVE_ENTITIES = "active_entities";
     public static final String ENTITY_INFO = "entity_info";
     public static final String TOTAL_UPDATES = "total_updates";
+    public static final String AD_TASK = "ad_task";
 
     // ======================================
     // Index mapping

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
@@ -51,6 +51,8 @@ public class ADTask implements ToXContentObject, Writeable {
     public static final String IS_LATEST_FIELD = "is_latest";
     public static final String TASK_TYPE_FIELD = "task_type";
     public static final String CHECKPOINT_ID_FIELD = "checkpoint_id";
+    public static final String COORDINATING_NODE_FIELD = "coordinating_node";
+    public static final String WORKER_NODE_FIELD = "worker_node";
     public static final String DETECTOR_FIELD = "detector";
 
     private String taskId = null;
@@ -69,6 +71,9 @@ public class ADTask implements ToXContentObject, Writeable {
     private String taskType = null;
     private String checkpointId = null;
     private AnomalyDetector detector = null;
+
+    private String coordinatingNode = null;
+    private String workerNode = null;
 
     private ADTask() {}
 
@@ -93,6 +98,8 @@ public class ADTask implements ToXContentObject, Writeable {
         this.lastUpdateTime = input.readOptionalInstant();
         this.startedBy = input.readOptionalString();
         this.stoppedBy = input.readOptionalString();
+        this.coordinatingNode = input.readOptionalString();
+        this.workerNode = input.readOptionalString();
     }
 
     @Override
@@ -118,6 +125,8 @@ public class ADTask implements ToXContentObject, Writeable {
         out.writeOptionalInstant(lastUpdateTime);
         out.writeOptionalString(startedBy);
         out.writeOptionalString(stoppedBy);
+        out.writeOptionalString(coordinatingNode);
+        out.writeOptionalString(workerNode);
     }
 
     public static Builder builder() {
@@ -141,6 +150,8 @@ public class ADTask implements ToXContentObject, Writeable {
         private Instant lastUpdateTime = null;
         private String startedBy = null;
         private String stoppedBy = null;
+        private String coordinatingNode = null;
+        private String workerNode = null;
 
         public Builder() {}
 
@@ -224,6 +235,16 @@ public class ADTask implements ToXContentObject, Writeable {
             return this;
         }
 
+        public Builder coordinatingNode(String coordinatingNode) {
+            this.coordinatingNode = coordinatingNode;
+            return this;
+        }
+
+        public Builder workerNode(String workerNode) {
+            this.workerNode = workerNode;
+            return this;
+        }
+
         public ADTask build() {
             ADTask adTask = new ADTask();
             adTask.taskId = this.taskId;
@@ -242,6 +263,8 @@ public class ADTask implements ToXContentObject, Writeable {
             adTask.detector = this.detector;
             adTask.startedBy = this.startedBy;
             adTask.stoppedBy = this.stoppedBy;
+            adTask.coordinatingNode = this.coordinatingNode;
+            adTask.workerNode = this.workerNode;
 
             return adTask;
         }
@@ -296,6 +319,12 @@ public class ADTask implements ToXContentObject, Writeable {
         if (checkpointId != null) {
             xContentBuilder.field(CHECKPOINT_ID_FIELD, checkpointId);
         }
+        if (coordinatingNode != null) {
+            xContentBuilder.field(COORDINATING_NODE_FIELD, coordinatingNode);
+        }
+        if (workerNode != null) {
+            xContentBuilder.field(WORKER_NODE_FIELD, workerNode);
+        }
         if (detector != null) {
             xContentBuilder.field(DETECTOR_FIELD, detector);
         }
@@ -323,6 +352,8 @@ public class ADTask implements ToXContentObject, Writeable {
         String checkpointId = null;
         AnomalyDetector detector = null;
         String parsedTaskId = taskId;
+        String coordinatingNode = null;
+        String workerNode = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -378,11 +409,39 @@ public class ADTask implements ToXContentObject, Writeable {
                 case TASK_ID_FIELD:
                     parsedTaskId = parser.text();
                     break;
+                case COORDINATING_NODE_FIELD:
+                    coordinatingNode = parser.text();
+                    break;
+                case WORKER_NODE_FIELD:
+                    workerNode = parser.text();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
             }
         }
+        AnomalyDetector anomalyDetector = detector == null
+            ? null
+            : new AnomalyDetector(
+                detectorId,
+                detector.getVersion(),
+                detector.getName(),
+                detector.getDescription(),
+                detector.getTimeField(),
+                detector.getIndices(),
+                detector.getFeatureAttributes(),
+                detector.getFilterQuery(),
+                detector.getDetectionInterval(),
+                detector.getWindowDelay(),
+                detector.getShingleSize(),
+                detector.getUiMetadata(),
+                detector.getSchemaVersion(),
+                detector.getLastUpdateTime(),
+                detector.getCategoryField(),
+                detector.getUser(),
+                detector.getDetectorType(),
+                detector.getDetectionDateRange()
+            );
         return new Builder()
             .taskId(parsedTaskId)
             .lastUpdateTime(lastUpdateTime)
@@ -399,7 +458,9 @@ public class ADTask implements ToXContentObject, Writeable {
             .isLatest(isLatest)
             .taskType(taskType)
             .checkpointId(checkpointId)
-            .detector(detector)
+            .coordinatingNode(coordinatingNode)
+            .workerNode(workerNode)
+            .detector(anomalyDetector)
             .build();
     }
 
@@ -426,6 +487,8 @@ public class ADTask implements ToXContentObject, Writeable {
             && Objects.equal(getLatest(), that.getLatest())
             && Objects.equal(getTaskType(), that.getTaskType())
             && Objects.equal(getCheckpointId(), that.getCheckpointId())
+            && Objects.equal(getCoordinatingNode(), that.getCoordinatingNode())
+            && Objects.equal(getWorkerNode(), that.getWorkerNode())
             && Objects.equal(getDetector(), that.getDetector());
     }
 
@@ -449,6 +512,8 @@ public class ADTask implements ToXContentObject, Writeable {
                 isLatest,
                 taskType,
                 checkpointId,
+                coordinatingNode,
+                workerNode,
                 detector
             );
     }
@@ -524,4 +589,13 @@ public class ADTask implements ToXContentObject, Writeable {
     public AnomalyDetector getDetector() {
         return detector;
     }
+
+    public String getCoordinatingNode() {
+        return coordinatingNode;
+    }
+
+    public String getWorkerNode() {
+        return workerNode;
+    }
+
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
@@ -322,6 +322,7 @@ public class ADTask implements ToXContentObject, Writeable {
         String taskType = null;
         String checkpointId = null;
         AnomalyDetector detector = null;
+        String parsedTaskId = taskId;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -374,13 +375,16 @@ public class ADTask implements ToXContentObject, Writeable {
                 case DETECTOR_FIELD:
                     detector = AnomalyDetector.parse(parser);
                     break;
+                case TASK_ID_FIELD:
+                    parsedTaskId = parser.text();
+                    break;
                 default:
                     parser.skipChildren();
                     break;
             }
         }
         return new Builder()
-            .taskId(taskId)
+            .taskId(parsedTaskId)
             .lastUpdateTime(lastUpdateTime)
             .startedBy(startedBy)
             .stoppedBy(stoppedBy)
@@ -475,6 +479,10 @@ public class ADTask implements ToXContentObject, Writeable {
 
     public String getState() {
         return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
     }
 
     public String getDetectorId() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskAction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+public enum ADTaskAction {
+    START,
+    STOP
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskProfile.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskProfile.java
@@ -34,28 +34,31 @@ import com.google.common.base.Objects;
  */
 public class ADTaskProfile implements ToXContentObject, Writeable {
 
-    public static final String AD_Task_FIELD = "ad_task";
+    public static final String AD_TASK_FIELD = "ad_task";
     public static final String SHINGLE_SIZE_FIELD = "shingle_size";
     public static final String RCF_TOTAL_UPDATES_FIELD = "rcf_total_updates";
     public static final String THRESHOLD_MODEL_TRAINED_FIELD = "threshold_model_trained";
     public static final String THRESHOLD_MODEL_TRAINING_DATA_SIZE_FIELD = "threshold_model_training_data_size";
+    public static final String MODEL_SIZE_IN_BYTES = "model_size_in_bytes";
     public static final String NODE_ID_FIELD = "node_id";
 
     private ADTask adTask;
     private Integer shingleSize;
     private Long rcfTotalUpdates;
     private Boolean thresholdModelTrained;
-    private Integer thresholdNodelTrainingDataSize;
+    private Integer thresholdModelTrainingDataSize;
+    private Long modelSizeInBytes;
     private String nodeId;
 
     public ADTaskProfile(
         Integer shingleSize,
         Long rcfTotalUpdates,
         Boolean thresholdModelTrained,
-        Integer thresholdNodelTrainingDataSize,
+        Integer thresholdModelTrainingDataSize,
+        Long modelSizeInBytes,
         String nodeId
     ) {
-        this(null, shingleSize, rcfTotalUpdates, thresholdModelTrained, thresholdNodelTrainingDataSize, nodeId);
+        this(null, shingleSize, rcfTotalUpdates, thresholdModelTrained, thresholdModelTrainingDataSize, modelSizeInBytes, nodeId);
     }
 
     public ADTaskProfile(
@@ -63,14 +66,16 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         Integer shingleSize,
         Long rcfTotalUpdates,
         Boolean thresholdModelTrained,
-        Integer thresholdNodelTrainingDataSize,
+        Integer thresholdModelTrainingDataSize,
+        Long modelSizeInBytes,
         String nodeId
     ) {
         this.adTask = adTask;
         this.shingleSize = shingleSize;
         this.rcfTotalUpdates = rcfTotalUpdates;
         this.thresholdModelTrained = thresholdModelTrained;
-        this.thresholdNodelTrainingDataSize = thresholdNodelTrainingDataSize;
+        this.thresholdModelTrainingDataSize = thresholdModelTrainingDataSize;
+        this.modelSizeInBytes = modelSizeInBytes;
         this.nodeId = nodeId;
     }
 
@@ -83,7 +88,8 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         this.shingleSize = input.readOptionalInt();
         this.rcfTotalUpdates = input.readOptionalLong();
         this.thresholdModelTrained = input.readOptionalBoolean();
-        this.thresholdNodelTrainingDataSize = input.readOptionalInt();
+        this.thresholdModelTrainingDataSize = input.readOptionalInt();
+        this.modelSizeInBytes = input.readOptionalLong();
         this.nodeId = input.readOptionalString();
     }
 
@@ -99,7 +105,8 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         out.writeOptionalInt(shingleSize);
         out.writeOptionalLong(rcfTotalUpdates);
         out.writeOptionalBoolean(thresholdModelTrained);
-        out.writeOptionalInt(thresholdNodelTrainingDataSize);
+        out.writeOptionalInt(thresholdModelTrainingDataSize);
+        out.writeOptionalLong(modelSizeInBytes);
         out.writeOptionalString(nodeId);
     }
 
@@ -107,7 +114,7 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject();
         if (adTask != null) {
-            xContentBuilder.field(AD_Task_FIELD, adTask);
+            xContentBuilder.field(AD_TASK_FIELD, adTask);
         }
         if (shingleSize != null) {
             xContentBuilder.field(SHINGLE_SIZE_FIELD, shingleSize);
@@ -118,8 +125,11 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         if (thresholdModelTrained != null) {
             xContentBuilder.field(THRESHOLD_MODEL_TRAINED_FIELD, thresholdModelTrained);
         }
-        if (thresholdNodelTrainingDataSize != null) {
-            xContentBuilder.field(THRESHOLD_MODEL_TRAINING_DATA_SIZE_FIELD, thresholdNodelTrainingDataSize);
+        if (thresholdModelTrainingDataSize != null) {
+            xContentBuilder.field(THRESHOLD_MODEL_TRAINING_DATA_SIZE_FIELD, thresholdModelTrainingDataSize);
+        }
+        if (modelSizeInBytes != null) {
+            xContentBuilder.field(MODEL_SIZE_IN_BYTES, modelSizeInBytes);
         }
         if (nodeId != null) {
             xContentBuilder.field(NODE_ID_FIELD, nodeId);
@@ -133,6 +143,7 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         Long rcfTotalUpdates = null;
         Boolean thresholdModelTrained = null;
         Integer thresholdNodelTrainingDataSize = null;
+        Long modelSizeInBytes = null;
         String nodeId = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
@@ -141,7 +152,7 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
             parser.nextToken();
 
             switch (fieldName) {
-                case AD_Task_FIELD:
+                case AD_TASK_FIELD:
                     adTask = ADTask.parse(parser);
                     break;
                 case SHINGLE_SIZE_FIELD:
@@ -156,6 +167,9 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
                 case THRESHOLD_MODEL_TRAINING_DATA_SIZE_FIELD:
                     thresholdNodelTrainingDataSize = parser.intValue();
                     break;
+                case MODEL_SIZE_IN_BYTES:
+                    modelSizeInBytes = parser.longValue();
+                    break;
                 case NODE_ID_FIELD:
                     nodeId = parser.text();
                     break;
@@ -164,7 +178,15 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
                     break;
             }
         }
-        return new ADTaskProfile(adTask, shingleSize, rcfTotalUpdates, thresholdModelTrained, thresholdNodelTrainingDataSize, nodeId);
+        return new ADTaskProfile(
+            adTask,
+            shingleSize,
+            rcfTotalUpdates,
+            thresholdModelTrained,
+            thresholdNodelTrainingDataSize,
+            modelSizeInBytes,
+            nodeId
+        );
     }
 
     @Generated
@@ -179,14 +201,24 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
             && Objects.equal(getShingleSize(), that.getShingleSize())
             && Objects.equal(getRcfTotalUpdates(), that.getRcfTotalUpdates())
             && Objects.equal(getThresholdModelTrained(), that.getThresholdModelTrained())
+            && Objects.equal(getModelSizeInBytes(), that.getModelSizeInBytes())
             && Objects.equal(getNodeId(), that.getNodeId())
-            && Objects.equal(getThresholdNodelTrainingDataSize(), that.getThresholdNodelTrainingDataSize());
+            && Objects.equal(getThresholdModelTrainingDataSize(), that.getThresholdModelTrainingDataSize());
     }
 
     @Generated
     @Override
     public int hashCode() {
-        return Objects.hashCode(adTask, shingleSize, rcfTotalUpdates, thresholdModelTrained, thresholdNodelTrainingDataSize, nodeId);
+        return Objects
+            .hashCode(
+                adTask,
+                shingleSize,
+                rcfTotalUpdates,
+                thresholdModelTrained,
+                thresholdModelTrainingDataSize,
+                modelSizeInBytes,
+                nodeId
+            );
     }
 
     public ADTask getAdTask() {
@@ -221,12 +253,12 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
         this.thresholdModelTrained = thresholdModelTrained;
     }
 
-    public Integer getThresholdNodelTrainingDataSize() {
-        return thresholdNodelTrainingDataSize;
+    public Integer getThresholdModelTrainingDataSize() {
+        return thresholdModelTrainingDataSize;
     }
 
-    public void setThresholdNodelTrainingDataSize(Integer thresholdNodelTrainingDataSize) {
-        this.thresholdNodelTrainingDataSize = thresholdNodelTrainingDataSize;
+    public void setThresholdModelTrainingDataSize(Integer thresholdModelTrainingDataSize) {
+        this.thresholdModelTrainingDataSize = thresholdModelTrainingDataSize;
     }
 
     public String getNodeId() {
@@ -235,6 +267,14 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
 
     public void setNodeId(String nodeId) {
         this.nodeId = nodeId;
+    }
+
+    public Long getModelSizeInBytes() {
+        return modelSizeInBytes;
+    }
+
+    public void setModelSizeInBytes(Long modelSizeInBytes) {
+        this.modelSizeInBytes = modelSizeInBytes;
     }
 
     @Override
@@ -249,7 +289,9 @@ public class ADTaskProfile implements ToXContentObject, Writeable {
             + ", thresholdModelTrained="
             + thresholdModelTrained
             + ", thresholdNodelTrainingDataSize="
-            + thresholdNodelTrainingDataSize
+            + thresholdModelTrainingDataSize
+            + ", modelSizeInBytes="
+            + modelSizeInBytes
             + ", nodeId='"
             + nodeId
             + '\''

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskProfile.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTaskProfile.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.model;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+import java.io.IOException;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import com.amazon.opendistroforelasticsearch.ad.annotation.Generated;
+import com.google.common.base.Objects;
+
+/**
+ * One anomaly detection task means one detector starts to run until stopped.
+ */
+public class ADTaskProfile implements ToXContentObject, Writeable {
+
+    public static final String AD_Task_FIELD = "ad_task";
+    public static final String SHINGLE_SIZE_FIELD = "shingle_size";
+    public static final String RCF_TOTAL_UPDATES_FIELD = "rcf_total_updates";
+    public static final String THRESHOLD_MODEL_TRAINED_FIELD = "threshold_model_trained";
+    public static final String THRESHOLD_MODEL_TRAINING_DATA_SIZE_FIELD = "threshold_model_training_data_size";
+    public static final String NODE_ID_FIELD = "node_id";
+
+    private ADTask adTask;
+    private Integer shingleSize;
+    private Long rcfTotalUpdates;
+    private Boolean thresholdModelTrained;
+    private Integer thresholdNodelTrainingDataSize;
+    private String nodeId;
+
+    public ADTaskProfile(
+        Integer shingleSize,
+        Long rcfTotalUpdates,
+        Boolean thresholdModelTrained,
+        Integer thresholdNodelTrainingDataSize,
+        String nodeId
+    ) {
+        this(null, shingleSize, rcfTotalUpdates, thresholdModelTrained, thresholdNodelTrainingDataSize, nodeId);
+    }
+
+    public ADTaskProfile(
+        ADTask adTask,
+        Integer shingleSize,
+        Long rcfTotalUpdates,
+        Boolean thresholdModelTrained,
+        Integer thresholdNodelTrainingDataSize,
+        String nodeId
+    ) {
+        this.adTask = adTask;
+        this.shingleSize = shingleSize;
+        this.rcfTotalUpdates = rcfTotalUpdates;
+        this.thresholdModelTrained = thresholdModelTrained;
+        this.thresholdNodelTrainingDataSize = thresholdNodelTrainingDataSize;
+        this.nodeId = nodeId;
+    }
+
+    public ADTaskProfile(StreamInput input) throws IOException {
+        if (input.readBoolean()) {
+            this.adTask = new ADTask(input);
+        } else {
+            this.adTask = null;
+        }
+        this.shingleSize = input.readOptionalInt();
+        this.rcfTotalUpdates = input.readOptionalLong();
+        this.thresholdModelTrained = input.readOptionalBoolean();
+        this.thresholdNodelTrainingDataSize = input.readOptionalInt();
+        this.nodeId = input.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        if (adTask != null) {
+            out.writeBoolean(true);
+            adTask.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+
+        out.writeOptionalInt(shingleSize);
+        out.writeOptionalLong(rcfTotalUpdates);
+        out.writeOptionalBoolean(thresholdModelTrained);
+        out.writeOptionalInt(thresholdNodelTrainingDataSize);
+        out.writeOptionalString(nodeId);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        if (adTask != null) {
+            xContentBuilder.field(AD_Task_FIELD, adTask);
+        }
+        if (shingleSize != null) {
+            xContentBuilder.field(SHINGLE_SIZE_FIELD, shingleSize);
+        }
+        if (rcfTotalUpdates != null) {
+            xContentBuilder.field(RCF_TOTAL_UPDATES_FIELD, rcfTotalUpdates);
+        }
+        if (thresholdModelTrained != null) {
+            xContentBuilder.field(THRESHOLD_MODEL_TRAINED_FIELD, thresholdModelTrained);
+        }
+        if (thresholdNodelTrainingDataSize != null) {
+            xContentBuilder.field(THRESHOLD_MODEL_TRAINING_DATA_SIZE_FIELD, thresholdNodelTrainingDataSize);
+        }
+        if (nodeId != null) {
+            xContentBuilder.field(NODE_ID_FIELD, nodeId);
+        }
+        return xContentBuilder.endObject();
+    }
+
+    public static ADTaskProfile parse(XContentParser parser) throws IOException {
+        ADTask adTask = null;
+        Integer shingleSize = null;
+        Long rcfTotalUpdates = null;
+        Boolean thresholdModelTrained = null;
+        Integer thresholdNodelTrainingDataSize = null;
+        String nodeId = null;
+
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+
+            switch (fieldName) {
+                case AD_Task_FIELD:
+                    adTask = ADTask.parse(parser);
+                    break;
+                case SHINGLE_SIZE_FIELD:
+                    shingleSize = parser.intValue();
+                    break;
+                case RCF_TOTAL_UPDATES_FIELD:
+                    rcfTotalUpdates = parser.longValue();
+                    break;
+                case THRESHOLD_MODEL_TRAINED_FIELD:
+                    thresholdModelTrained = parser.booleanValue();
+                    break;
+                case THRESHOLD_MODEL_TRAINING_DATA_SIZE_FIELD:
+                    thresholdNodelTrainingDataSize = parser.intValue();
+                    break;
+                case NODE_ID_FIELD:
+                    nodeId = parser.text();
+                    break;
+                default:
+                    parser.skipChildren();
+                    break;
+            }
+        }
+        return new ADTaskProfile(adTask, shingleSize, rcfTotalUpdates, thresholdModelTrained, thresholdNodelTrainingDataSize, nodeId);
+    }
+
+    @Generated
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ADTaskProfile that = (ADTaskProfile) o;
+        return Objects.equal(getAdTask(), that.getAdTask())
+            && Objects.equal(getShingleSize(), that.getShingleSize())
+            && Objects.equal(getRcfTotalUpdates(), that.getRcfTotalUpdates())
+            && Objects.equal(getThresholdModelTrained(), that.getThresholdModelTrained())
+            && Objects.equal(getNodeId(), that.getNodeId())
+            && Objects.equal(getThresholdNodelTrainingDataSize(), that.getThresholdNodelTrainingDataSize());
+    }
+
+    @Generated
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(adTask, shingleSize, rcfTotalUpdates, thresholdModelTrained, thresholdNodelTrainingDataSize, nodeId);
+    }
+
+    public ADTask getAdTask() {
+        return adTask;
+    }
+
+    public void setAdTask(ADTask adTask) {
+        this.adTask = adTask;
+    }
+
+    public Integer getShingleSize() {
+        return shingleSize;
+    }
+
+    public void setShingleSize(Integer shingleSize) {
+        this.shingleSize = shingleSize;
+    }
+
+    public Long getRcfTotalUpdates() {
+        return rcfTotalUpdates;
+    }
+
+    public void setRcfTotalUpdates(Long rcfTotalUpdates) {
+        this.rcfTotalUpdates = rcfTotalUpdates;
+    }
+
+    public Boolean getThresholdModelTrained() {
+        return thresholdModelTrained;
+    }
+
+    public void setThresholdModelTrained(Boolean thresholdModelTrained) {
+        this.thresholdModelTrained = thresholdModelTrained;
+    }
+
+    public Integer getThresholdNodelTrainingDataSize() {
+        return thresholdNodelTrainingDataSize;
+    }
+
+    public void setThresholdNodelTrainingDataSize(Integer thresholdNodelTrainingDataSize) {
+        this.thresholdNodelTrainingDataSize = thresholdNodelTrainingDataSize;
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public void setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    @Override
+    public String toString() {
+        return "ADTaskProfile{"
+            + "adTask="
+            + adTask
+            + ", shingleSize="
+            + shingleSize
+            + ", rcfTotalUpdates="
+            + rcfTotalUpdates
+            + ", thresholdModelTrained="
+            + thresholdModelTrained
+            + ", thresholdNodelTrainingDataSize="
+            + thresholdNodelTrainingDataSize
+            + ", nodeId='"
+            + nodeId
+            + '\''
+            + '}';
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -55,6 +55,9 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * An AnomalyDetector is used to represent anomaly detection model(RCF) related parameters.
+ * NOTE: If change detector config index mapping, you should change AD task index mapping as well.
+ * TODO: Will replace detector config mapping in AD task with detector config setting directly \
+ *      in code rather than config it in anomaly-detection-state.json file.
  */
 public class AnomalyDetector implements Writeable, ToXContentObject {
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/AnomalyDetector.java
@@ -227,10 +227,10 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
     }
 
     public AnomalyDetector(StreamInput input) throws IOException {
-        detectorId = input.readString();
-        version = input.readLong();
+        detectorId = input.readOptionalString();
+        version = input.readOptionalLong();
         name = input.readString();
-        description = input.readString();
+        description = input.readOptionalString();
         timeField = input.readString();
         indices = input.readStringList();
         featureAttributes = input.readList(Feature::new);
@@ -265,10 +265,10 @@ public class AnomalyDetector implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput output) throws IOException {
-        output.writeString(detectorId);
-        output.writeLong(version);
+        output.writeOptionalString(detectorId);
+        output.writeOptionalLong(version);
         output.writeString(name);
-        output.writeString(description);
+        output.writeOptionalString(description);
         output.writeString(timeField);
         output.writeStringCollection(indices);
         output.writeList(featureAttributes);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorProfileName.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/DetectorProfileName.java
@@ -30,7 +30,8 @@ public enum DetectorProfileName implements Name {
     MODELS(CommonName.MODELS),
     INIT_PROGRESS(CommonName.INIT_PROGRESS),
     TOTAL_ENTITIES(CommonName.TOTAL_ENTITIES),
-    ACTIVE_ENTITIES(CommonName.ACTIVE_ENTITIES);
+    ACTIVE_ENTITIES(CommonName.ACTIVE_ENTITIES),
+    AD_TASK(CommonName.AD_TASK);
 
     private String name;
 
@@ -68,6 +69,8 @@ public enum DetectorProfileName implements Name {
                 return TOTAL_ENTITIES;
             case CommonName.ACTIVE_ENTITIES:
                 return ACTIVE_ENTITIES;
+            case CommonName.AD_TASK:
+                return AD_TASK;
             default:
                 throw new IllegalArgumentException("Unsupported profile types");
         }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestGetAnomalyDetectorAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/RestGetAnomalyDetectorAction.java
@@ -64,11 +64,13 @@ public class RestGetAnomalyDetectorAction extends BaseRestHandler {
         String entityValue = request.param(ENTITY);
         String rawPath = request.rawPath();
         boolean returnJob = request.paramAsBoolean("job", false);
+        boolean returnTask = request.paramAsBoolean("task", false);
         boolean all = request.paramAsBoolean("_all", false);
         GetAnomalyDetectorRequest getAnomalyDetectorRequest = new GetAnomalyDetectorRequest(
             detectorId,
             RestActions.parseVersion(request),
             returnJob,
+            returnTask,
             typesStr,
             rawPath,
             all,

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/rest/handler/IndexAnomalyDetectorJobActionHandler.java
@@ -302,7 +302,13 @@ public class IndexAnomalyDetectorJobActionHandler {
             public void onResponse(StopDetectorResponse stopDetectorResponse) {
                 if (stopDetectorResponse.success()) {
                     logger.info("AD model deleted successfully for detector {}", detectorId);
-                    AnomalyDetectorJobResponse anomalyDetectorJobResponse = new AnomalyDetectorJobResponse(null, 0, 0, 0, RestStatus.OK);
+                    AnomalyDetectorJobResponse anomalyDetectorJobResponse = new AnomalyDetectorJobResponse(
+                        detectorId,
+                        0,
+                        0,
+                        0,
+                        RestStatus.OK
+                    );
                     listener.onResponse(anomalyDetectorJobResponse);
                 } else {
                     logger.error("Failed to delete AD model for detector {}", detectorId);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADBatchTaskCache.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADBatchTaskCache.java
@@ -41,6 +41,7 @@ import com.amazon.randomcutforest.RandomCutForest;
  */
 public class ADBatchTaskCache {
     private final String detectorId;
+    private final String taskId;
     private RandomCutForest rcfModel;
     private ThresholdingModel thresholdModel;
     private boolean thresholdModelTrained;
@@ -54,6 +55,7 @@ public class ADBatchTaskCache {
 
     protected ADBatchTaskCache(ADTask adTask) {
         this.detectorId = adTask.getDetectorId();
+        this.taskId = adTask.getTaskId();
 
         AnomalyDetector detector = adTask.getDetector();
         rcfModel = RandomCutForest
@@ -81,6 +83,10 @@ public class ADBatchTaskCache {
 
     protected String getDetectorId() {
         return detectorId;
+    }
+
+    protected String getTaskId() {
+        return taskId;
     }
 
     protected RandomCutForest getRcfModel() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADBatchTaskRunner.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADBatchTaskRunner.java
@@ -346,7 +346,7 @@ public class ADBatchTaskRunner {
         adStats.getStat(StatNames.AD_TOTAL_BATCH_TASK_EXECUTION_COUNT.getName()).increment();
 
         // put AD task into cache
-        adTaskCacheManager.put(adTask);
+        adTaskCacheManager.add(adTask);
 
         // start to run first piece
         Instant executeStartTime = Instant.now();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManager.java
@@ -85,7 +85,7 @@ public class ADTaskCacheManager {
      *
      * @param adTask AD task
      */
-    public synchronized void put(ADTask adTask) {
+    public synchronized void add(ADTask adTask) {
         String taskId = adTask.getTaskId();
         if (contains(taskId)) {
             throw new DuplicateTaskException(DETECTOR_IS_RUNNING);
@@ -110,7 +110,7 @@ public class ADTaskCacheManager {
      * @param detectorId detector id
      * @throws LimitExceededException throw limit exceed exception when the detector id already in cache
      */
-    public synchronized void put(String detectorId) {
+    public synchronized void add(String detectorId) {
         if (detectors.contains(detectorId)) {
             logger.debug("detector is already in running detector cache, detectorId: " + detectorId);
             throw new DuplicateTaskException(DETECTOR_IS_RUNNING);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCancellationState.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCancellationState.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.task;
+
+public enum ADTaskCancellationState {
+    NOT_FOUND,
+    CANCELLED,
+    ALREADY_CANCELLED
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.task;
 
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages.DETECTOR_ALREADY_RUNNING;
 import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.DETECTOR_ID_FIELD;
 import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.ERROR_FIELD;
 import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.EXECUTION_END_TIME_FIELD;
@@ -22,6 +23,8 @@ import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.EXECUTION_ST
 import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.IS_LATEST_FIELD;
 import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.LAST_UPDATE_TIME_FIELD;
 import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.STATE_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.model.ADTask.STOPPED_BY_FIELD;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
 import static com.amazon.opendistroforelasticsearch.ad.util.ExceptionUtil.getErrorMessage;
 import static com.amazon.opendistroforelasticsearch.ad.util.ExceptionUtil.getShardsFailure;
@@ -29,12 +32,15 @@ import static org.elasticsearch.action.DocWriteResponse.Result.CREATED;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,6 +48,7 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -51,12 +58,14 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
@@ -70,17 +79,36 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportService;
 
+import com.amazon.opendistroforelasticsearch.ad.cluster.HashRing;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.ADTaskCancelledException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.DuplicateTaskException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.InternalFailure;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.ResourceNotFoundException;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskProfile;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTaskType;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfile;
 import com.amazon.opendistroforelasticsearch.ad.rest.handler.IndexAnomalyDetectorJobActionHandler;
+import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchAnomalyResultAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ADBatchAnomalyResultRequest;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADCancelTaskAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADCancelTaskRequest;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADTaskProfileAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADTaskProfileNodeResponse;
+import com.amazon.opendistroforelasticsearch.ad.transport.ADTaskProfileRequest;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobResponse;
+import com.amazon.opendistroforelasticsearch.ad.transport.ForwardADTaskAction;
+import com.amazon.opendistroforelasticsearch.ad.transport.ForwardADTaskRequest;
+import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 import com.amazon.opendistroforelasticsearch.commons.authuser.User;
 
@@ -91,25 +119,48 @@ public class ADTaskManager {
     private final Logger logger = LogManager.getLogger(this.getClass());
 
     private final Client client;
+    private final ClusterService clusterService;
     private final NamedXContentRegistry xContentRegistry;
     private final AnomalyDetectionIndices detectionIndices;
+    private final DiscoveryNodeFilterer nodeFilter;
+    private final ADTaskCacheManager adTaskCacheManager;
+
+    private final HashRing hashRing;
+    private final TransportRequestOptions option;
     private volatile Integer maxAdTaskDocsPerDetector;
+    private volatile Integer pieceIntervalSeconds;
 
     public ADTaskManager(
         Settings settings,
         ClusterService clusterService,
         Client client,
         NamedXContentRegistry xContentRegistry,
-        AnomalyDetectionIndices detectionIndices
+        AnomalyDetectionIndices detectionIndices,
+        DiscoveryNodeFilterer nodeFilter,
+        HashRing hashRing,
+        ADTaskCacheManager adTaskCacheManager
     ) {
         this.client = client;
         this.xContentRegistry = xContentRegistry;
         this.detectionIndices = detectionIndices;
+        this.nodeFilter = nodeFilter;
+        this.clusterService = clusterService;
+        this.adTaskCacheManager = adTaskCacheManager;
+        this.hashRing = hashRing;
+
+        this.option = TransportRequestOptions
+            .builder()
+            .withType(TransportRequestOptions.Type.REG)
+            .withTimeout(AnomalyDetectorSettings.REQUEST_TIMEOUT.get(settings))
+            .build();
 
         this.maxAdTaskDocsPerDetector = MAX_OLD_AD_TASK_DOCS_PER_DETECTOR.get(settings);
         clusterService
             .getClusterSettings()
             .addSettingsUpdateConsumer(MAX_OLD_AD_TASK_DOCS_PER_DETECTOR, it -> maxAdTaskDocsPerDetector = it);
+
+        this.pieceIntervalSeconds = BATCH_TASK_PIECE_INTERVAL_SECONDS.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(BATCH_TASK_PIECE_INTERVAL_SECONDS, it -> pieceIntervalSeconds = it);
     }
 
     /**
@@ -119,9 +170,57 @@ public class ADTaskManager {
      * @param detectorId detector id
      * @param handler anomaly detector job action handler
      * @param user user
+     * @param transportService transport service
      * @param listener action listener
      */
     public void startDetector(
+        String detectorId,
+        IndexAnomalyDetectorJobActionHandler handler,
+        User user,
+        TransportService transportService,
+        ActionListener<AnomalyDetectorJobResponse> listener
+    ) {
+        getDetector(
+            detectorId,
+            (detector) -> handler.startAnomalyDetectorJob(detector), // run realtime detector
+            (detector) -> forwardToCoordinatingNode(detector, user, transportService, listener), // run historical detector
+            listener
+        );
+    }
+
+    private void forwardToCoordinatingNode(
+        AnomalyDetector detector,
+        User user,
+        TransportService transportService,
+        ActionListener<AnomalyDetectorJobResponse> listener
+    ) {
+        Optional<DiscoveryNode> owningNode = hashRing.getOwningNode(detector.getDetectorId());
+        if (!owningNode.isPresent()) {
+            logger.debug("Can't find eligible node to run as AD task's coordinating node");
+            listener.onFailure(new ElasticsearchStatusException("No eligible node to run detector", RestStatus.INTERNAL_SERVER_ERROR));
+            return;
+        }
+        transportService
+            .sendRequest(
+                owningNode.get(),
+                ForwardADTaskAction.NAME,
+                new ForwardADTaskRequest(detector, user),
+                this.option,
+                new ActionListenerResponseHandler<>(listener, AnomalyDetectorJobResponse::new)
+            );
+    }
+
+    /**
+     * Stop detector.
+     * For realtime detector, will set detector job as disabled.
+     * For historical detector, will set its AD task as cancelled.
+     *
+     * @param detectorId detector id
+     * @param handler AD job action handler
+     * @param user user
+     * @param listener action listener
+     */
+    public void stopDetector(
         String detectorId,
         IndexAnomalyDetectorJobActionHandler handler,
         User user,
@@ -129,8 +228,10 @@ public class ADTaskManager {
     ) {
         getDetector(
             detectorId,
-            (detector) -> handler.startAnomalyDetectorJob(detector), // run realtime detector
-            (detector) -> createADTaskIndex(detector, user, listener), // run historical detector
+            // stop realtime detector job
+            (detector) -> handler.stopAnomalyDetectorJob(detectorId),
+            // stop historical detector AD task
+            (detector) -> getLatestADTask(detectorId, (task) -> stopHistoricalDetector(detectorId, task, user, listener), listener),
             listener
         );
     }
@@ -144,10 +245,7 @@ public class ADTaskManager {
         GetRequest getRequest = new GetRequest(AnomalyDetector.ANOMALY_DETECTORS_INDEX).id(detectorId);
         client.get(getRequest, ActionListener.wrap(response -> {
             if (!response.isExists()) {
-                listener
-                    .onFailure(
-                        new ElasticsearchStatusException("AnomalyDetector is not found with id: " + detectorId, RestStatus.NOT_FOUND)
-                    );
+                listener.onFailure(new ElasticsearchStatusException("AnomalyDetector is not found", RestStatus.NOT_FOUND));
                 return;
             }
             try (
@@ -170,11 +268,213 @@ public class ADTaskManager {
                     historicalDetectorConsumer.accept(detector);
                 }
             } catch (Exception e) {
-                String message = "Failed to start anomaly detector";
+                String message = "Failed to start anomaly detector " + detectorId;
                 logger.error(message, e);
                 listener.onFailure(new ElasticsearchStatusException(message, RestStatus.INTERNAL_SERVER_ERROR));
             }
         }, exception -> listener.onFailure(exception)));
+    }
+
+    /**
+     * Get latest AD task and execute consumer function.
+     *
+     * @param detectorId detector id
+     * @param function consumer function
+     * @param listener action listener
+     */
+    public void getLatestADTask(String detectorId, Consumer<Optional<ADTask>> function, ActionListener listener) {
+        BoolQueryBuilder query = new BoolQueryBuilder();
+        query.filter(new TermQueryBuilder(DETECTOR_ID_FIELD, detectorId));
+        query.filter(new TermQueryBuilder(IS_LATEST_FIELD, true));
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(query);
+        SearchRequest searchRequest = new SearchRequest();
+        searchRequest.source(sourceBuilder);
+        searchRequest.indices(CommonName.DETECTION_STATE_INDEX);
+
+        client.search(searchRequest, ActionListener.wrap(r -> {
+            long totalTasks = r.getHits().getTotalHits().value;
+            if (totalTasks < 1) {
+                // don't throw exception here as consumer functions need to handle missing task
+                // in different way.
+                function.accept(Optional.empty());
+                return;
+            }
+            SearchHit searchHit = r.getHits().getAt(0);
+            try (XContentParser parser = RestHandlerUtils.createXContentParserFromRegistry(xContentRegistry, searchHit.getSourceRef())) {
+                ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+                ADTask adTask = ADTask.parse(parser, searchHit.getId());
+
+                if (!isADTaskEnded(adTask) && lastUpdateTimeExpired(adTask)) {
+                    // If AD task is still running, but its last updated time not refreshed
+                    // for 2 pieces intervals, we will get task profile to check if it's
+                    // really running and reset state as STOPPED if not running.
+                    // For example, ES process crashes, then all tasks running on it will stay
+                    // as running. We can reset the task state when next read happen.
+                    getADTaskProfile(adTask, ActionListener.wrap(taskProfile -> {
+                        if (taskProfile.getNodeId() == null) {
+                            // If no node is running this task, reset it as STOPPED.
+                            resetTaskStateAsStopped(adTask);
+                            adTask.setState(ADTaskState.STOPPED.name());
+                        }
+                        function.accept(Optional.of(adTask));
+                    }, e -> {
+                        logger.error("Failed to get AD task profile for task " + adTask.getTaskId(), e);
+                        listener.onFailure(e);
+                    }));
+                } else {
+                    function.accept(Optional.of(adTask));
+                }
+            } catch (Exception e) {
+                String message = "Failed to parse AD task for detector " + detectorId;
+                logger.error(message, e);
+                listener.onFailure(new ElasticsearchStatusException(message, RestStatus.INTERNAL_SERVER_ERROR));
+            }
+        }, e -> {
+            if (e instanceof IndexNotFoundException) {
+                function.accept(Optional.empty());
+            } else {
+                logger.error("Failed to search AD task for detector " + detectorId, e);
+                listener.onFailure(e);
+            }
+        }));
+    }
+
+    private void stopHistoricalDetector(
+        String detectorId,
+        Optional<ADTask> adTask,
+        User user,
+        ActionListener<AnomalyDetectorJobResponse> listener
+    ) {
+        if (!adTask.isPresent()) {
+            listener.onFailure(new ResourceNotFoundException(detectorId, "Detector not started"));
+            return;
+        }
+
+        if (isADTaskEnded(adTask.get())) {
+            listener.onFailure(new ResourceNotFoundException(detectorId, "No running task found"));
+            return;
+        }
+
+        String taskId = adTask.get().getTaskId();
+        DiscoveryNode[] dataNodes = nodeFilter.getEligibleDataNodes();
+        String userName = user == null ? null : user.getName();
+
+        ADCancelTaskRequest cancelTaskRequest = new ADCancelTaskRequest(detectorId, userName, dataNodes);
+        client
+            .execute(
+                ADCancelTaskAction.INSTANCE,
+                cancelTaskRequest,
+                ActionListener
+                    .wrap(response -> { listener.onResponse(new AnomalyDetectorJobResponse(taskId, 0, 0, 0, RestStatus.OK)); }, e -> {
+                        logger.error("Failed to cancel AD task " + taskId + ", detector id: " + detectorId, e);
+                        listener.onFailure(e);
+                    })
+            );
+    }
+
+    private boolean lastUpdateTimeExpired(ADTask adTask) {
+        return adTask.getLastUpdateTime().plus(2 * pieceIntervalSeconds, ChronoUnit.SECONDS).isBefore(Instant.now());
+    }
+
+    private boolean isADTaskEnded(ADTask adTask) {
+        return ADTaskState.STOPPED.name().equals(adTask.getState())
+            || ADTaskState.FINISHED.name().equals(adTask.getState())
+            || ADTaskState.FAILED.name().equals(adTask.getState());
+    }
+
+    private void resetTaskStateAsStopped(ADTask adTask) {
+        if (!isADTaskEnded(adTask)) {
+            Map<String, Object> updatedFields = new HashMap<>();
+            updatedFields.put(STATE_FIELD, ADTaskState.STOPPED.name());
+            updateADTask(adTask.getTaskId(), updatedFields);
+        }
+    }
+
+    /**
+     * Get AD task profile data.
+     *
+     * @param detectorId detector id
+     * @param listener action listener
+     */
+    public void getLatestADTaskProfile(String detectorId, ActionListener<DetectorProfile> listener) {
+        getLatestADTask(detectorId, adTask -> {
+            if (adTask.isPresent()) {
+                getADTaskProfile(adTask.get(), ActionListener.wrap(adTaskProfile -> {
+                    DetectorProfile.Builder profileBuilder = new DetectorProfile.Builder();
+                    profileBuilder.adTaskProfile(adTaskProfile);
+                    listener.onResponse(profileBuilder.build());
+                }, e -> {
+                    logger.error("Failed to get AD task profile for task " + adTask.get().getTaskId(), e);
+                    listener.onFailure(e);
+                }));
+            } else {
+                listener.onFailure(new ResourceNotFoundException(detectorId, "Can't find task for detector"));
+            }
+        }, listener);
+    }
+
+    private void getADTaskProfile(ADTask adTask, ActionListener<ADTaskProfile> listener) {
+        String taskId = adTask.getTaskId();
+
+        if (adTaskCacheManager.contains(taskId)) {
+            ADTaskProfile adTaskProfile = getLocalADTaskProfile(taskId);
+            adTaskProfile.setAdTask(adTask);
+            listener.onResponse(adTaskProfile);
+        } else {
+            DiscoveryNode[] dataNodes = nodeFilter.getEligibleDataNodes();
+            ADTaskProfileRequest adTaskProfileRequest = new ADTaskProfileRequest(taskId, dataNodes);
+            client.execute(ADTaskProfileAction.INSTANCE, adTaskProfileRequest, ActionListener.wrap(response -> {
+                List<ADTaskProfile> nodeResponses = response
+                    .getNodes()
+                    .stream()
+                    .filter(r -> r.getAdTaskProfile() != null)
+                    .map(ADTaskProfileNodeResponse::getAdTaskProfile)
+                    .collect(Collectors.toList());
+
+                if (nodeResponses.size() > 1) {
+                    String error = nodeResponses.size()
+                        + " tasks running for detector "
+                        + adTask.getDetectorId()
+                        + ". Please stop detector to kill all running tasks.";
+                    logger.error(error);
+                    listener.onFailure(new InternalFailure(adTask.getDetectorId(), error));
+                    return;
+                }
+                if (nodeResponses.size() == 0) {
+                    ADTaskProfile adTaskProfile = new ADTaskProfile(adTask, null, null, null, null, null);
+                    listener.onResponse(adTaskProfile);
+                } else {
+                    ADTaskProfile nodeResponse = nodeResponses.get(0);
+                    ADTaskProfile adTaskProfile = new ADTaskProfile(
+                        adTask,
+                        nodeResponse.getShingleSize(),
+                        nodeResponse.getRcfTotalUpdates(),
+                        nodeResponse.getThresholdModelTrained(),
+                        nodeResponse.getThresholdNodelTrainingDataSize(),
+                        nodeResponse.getNodeId()
+                    );
+                    listener.onResponse(adTaskProfile);
+                }
+            }, e -> {
+                logger.error("Failed to get task profile for task " + adTask.getTaskId(), e);
+                listener.onFailure(e);
+            }));
+        }
+    }
+
+    public ADTaskProfile getLocalADTaskProfile(String taskId) {
+        ADTaskProfile adTaskProfile = null;
+        if (adTaskCacheManager.contains(taskId)) {
+            adTaskProfile = new ADTaskProfile(
+                adTaskCacheManager.getShingle(taskId).size(),
+                adTaskCacheManager.getRcfModel(taskId).getTotalUpdates(),
+                adTaskCacheManager.isThresholdModelTrained(taskId),
+                adTaskCacheManager.getThresholdModelTrainingDataSize(taskId),
+                clusterService.localNode().getId()
+            );
+        }
+        return adTaskProfile;
     }
 
     private String validateDetector(AnomalyDetector detector) {
@@ -187,27 +487,38 @@ public class ADTaskManager {
         return null;
     }
 
-    protected void createADTaskIndex(AnomalyDetector detector, User user, ActionListener<AnomalyDetectorJobResponse> listener) {
-        if (detectionIndices.doesDetectorStateIndexExist()) {
-            checkCurrentTaskState(detector, user, listener);
-        } else {
-            detectionIndices.initDetectionStateIndex(ActionListener.wrap(r -> {
-                if (r.isAcknowledged()) {
-                    logger.info("Created {} with mappings.", CommonName.DETECTION_STATE_INDEX);
-                    executeHistoricalDetector(detector, user, listener);
-                } else {
-                    String error = "Create index " + CommonName.DETECTION_STATE_INDEX + " with mappings not acknowledged";
-                    logger.warn(error);
-                    listener.onFailure(new ElasticsearchStatusException(error, RestStatus.INTERNAL_SERVER_ERROR));
-                }
-            }, e -> {
-                if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
-                    executeHistoricalDetector(detector, user, listener);
-                } else {
-                    logger.error("Failed to init anomaly detection state index", e);
-                    listener.onFailure(e);
-                }
-            }));
+    public void startHistoricalDetector(AnomalyDetector detector, User user, ActionListener<AnomalyDetectorJobResponse> listener) {
+        try {
+            adTaskCacheManager.put(detector.getDetectorId());
+            if (detectionIndices.doesDetectorStateIndexExist()) {
+                checkCurrentTaskState(detector, user, listener);
+            } else {
+                detectionIndices.initDetectionStateIndex(ActionListener.wrap(r -> {
+                    if (r.isAcknowledged()) {
+                        logger.info("Created {} with mappings.", CommonName.DETECTION_STATE_INDEX);
+                        executeHistoricalDetector(detector, user, listener);
+                    } else {
+                        String error = "Create index " + CommonName.DETECTION_STATE_INDEX + " with mappings not acknowledged";
+                        logger.warn(error);
+                        listener.onFailure(new ElasticsearchStatusException(error, RestStatus.INTERNAL_SERVER_ERROR));
+                    }
+                }, e -> {
+                    if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
+                        executeHistoricalDetector(detector, user, listener);
+                    } else {
+                        logger.error("Failed to init anomaly detection state index", e);
+                        listener.onFailure(e);
+                    }
+                }));
+            }
+        } catch (Exception e) {
+            if (e instanceof LimitExceededException && DETECTOR_ALREADY_RUNNING.equals(e.getMessage())) {
+                logger.debug(DETECTOR_ALREADY_RUNNING + ", detector id: " + detector.getDetectorId());
+                listener.onFailure(new ElasticsearchStatusException(DETECTOR_ALREADY_RUNNING, RestStatus.BAD_REQUEST));
+            } else {
+                logger.error("Failed to start historical detector " + detector.getDetectorId(), e);
+                listener.onFailure(e);
+            }
         }
     }
 
@@ -223,7 +534,7 @@ public class ADTaskManager {
 
         client.search(searchRequest, ActionListener.wrap(r -> {
             if (r.getHits().getTotalHits().value > 0) {
-                listener.onFailure(new ElasticsearchStatusException("Detector is already running", RestStatus.BAD_REQUEST));
+                listener.onFailure(new ElasticsearchStatusException(DETECTOR_ALREADY_RUNNING, RestStatus.BAD_REQUEST));
             } else {
                 executeHistoricalDetector(detector, user, listener);
             }
@@ -414,12 +725,27 @@ public class ADTaskManager {
      * @param e exception
      */
     public void handleADTaskException(ADTask adTask, Exception e) {
+        // TODO: remove task execution from map if execution fails
         // TODO: handle timeout exception
-        // TODO: handle TaskCancelledException
+        String state = ADTaskState.FAILED.name();
         Map<String, Object> updatedFields = new HashMap<>();
-        logger.error("Failed to execute AD batch task, task id: " + adTask.getTaskId() + ", detector id: " + adTask.getDetectorId(), e);
-        updatedFields.put(STATE_FIELD, ADTaskState.FAILED.name());
+        if (e instanceof ADTaskCancelledException) {
+            logger.warn("AD task cancelled: " + adTask.getTaskId());
+            state = ADTaskState.STOPPED.name();
+            String stoppedBy = ((ADTaskCancelledException) e).getCancelledBy();
+            if (stoppedBy != null) {
+                updatedFields.put(STOPPED_BY_FIELD, stoppedBy);
+            }
+        } else if (e instanceof DuplicateTaskException) {
+            // If any race condition, user start another task while there is one running task.
+            // Cache manager will throw DuplicateTaskException, then we will set the second
+            // task as failed and set it as not latest.
+            updatedFields.put(IS_LATEST_FIELD, false);
+        } else {
+            logger.error("Failed to execute AD batch task, task id: " + adTask.getTaskId() + ", detector id: " + adTask.getDetectorId(), e);
+        }
         updatedFields.put(ERROR_FIELD, getErrorMessage(e));
+        updatedFields.put(STATE_FIELD, state);
         updatedFields.put(EXECUTION_END_TIME_FIELD, Instant.now().toEpochMilli());
         updateADTask(adTask.getTaskId(), updatedFields);
     }
@@ -427,11 +753,11 @@ public class ADTaskManager {
     private void updateADTask(String taskId, Map<String, Object> updatedFields) {
         updateADTask(taskId, updatedFields, ActionListener.wrap(response -> {
             if (response.status() == RestStatus.OK) {
-                logger.info("Updated AD task successfully: {}", response.status());
+                logger.debug("Updated AD task successfully: {}", response.status());
             } else {
                 logger.error("Failed to update AD task {}, status: {}", taskId, response.status());
             }
-        }, e -> logger.error("Failed to update task: " + taskId, e)));
+        }, e -> { logger.error("Failed to update task: " + taskId, e); }));
     }
 
     /**
@@ -453,6 +779,18 @@ public class ADTaskManager {
                 updateRequest,
                 ActionListener.wrap(response -> listener.onResponse(response), exception -> listener.onFailure(exception))
             );
+    }
+
+    /**
+     * Cancel running task by detector id.
+     *
+     * @param detectorId detector id
+     * @param reason reason to cancel AD task
+     * @param userName which user cancel the AD task
+     * @return AD task cancellation state
+     */
+    public ADTaskCancellationState cancelLocalTaskByDetectorId(String detectorId, String reason, String userName) {
+        return adTaskCacheManager.cancelByDetectorId(detectorId, reason, userName);
     }
 
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
@@ -737,7 +737,7 @@ public class ADTaskManager {
         });
         try {
             // Put detector id in cache. If detector id already in cache, will throw
-            // LimitExceededException. This is to solve race condition when user send
+            // DuplicateTaskException. This is to solve race condition when user send
             // multiple start request for one historical detector.
             adTaskCacheManager.put(adTask.getDetectorId());
         } catch (Exception e) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
@@ -339,8 +339,10 @@ public class ADTaskManager {
         searchRequest.indices(CommonName.DETECTION_STATE_INDEX);
 
         client.search(searchRequest, ActionListener.wrap(r -> {
-            long totalTasks = r.getHits().getTotalHits().value;
-            if (totalTasks < 1) {
+            // https://github.com/opendistro-for-elasticsearch/anomaly-detection/pull/359#discussion_r558653132
+            // getTotalHits will be null when we track_total_hits is false in the query request.
+            // Add more checking here to cover some unknown cases.
+            if (r == null || r.getHits().getTotalHits() == null || r.getHits().getTotalHits().value == 0) {
                 // don't throw exception here as consumer functions need to handle missing task
                 // in different way.
                 function.accept(Optional.empty());

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchAnomalyResultAction.java
@@ -15,12 +15,14 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.AD_TASK;
+
 import org.elasticsearch.action.ActionType;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
 
 public class ADBatchAnomalyResultAction extends ActionType<ADBatchAnomalyResultResponse> {
-    public static final String NAME = CommonValue.EXTERNAL_ACTION_PREFIX + "detector/ad_task";
+    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detector/" + AD_TASK;
     public static final ADBatchAnomalyResultAction INSTANCE = new ADBatchAnomalyResultAction();
 
     private ADBatchAnomalyResultAction() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchTaskRemoteExecutionAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchTaskRemoteExecutionAction.java
@@ -15,12 +15,14 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.AD_TASK_REMOTE;
+
 import org.elasticsearch.action.ActionType;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
 
 public class ADBatchTaskRemoteExecutionAction extends ActionType<ADBatchAnomalyResultResponse> {
-    public static final String NAME = CommonValue.EXTERNAL_ACTION_PREFIX + "detector/ad_task_remote";
+    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detector/" + AD_TASK_REMOTE;
     public static final ADBatchTaskRemoteExecutionAction INSTANCE = new ADBatchTaskRemoteExecutionAction();
 
     private ADBatchTaskRemoteExecutionAction() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchTaskRemoteExecutionTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADBatchTaskRemoteExecutionTransportAction.java
@@ -28,6 +28,7 @@ public class ADBatchTaskRemoteExecutionTransportAction extends
     HandledTransportAction<ADBatchAnomalyResultRequest, ADBatchAnomalyResultResponse> {
 
     private final ADBatchTaskRunner adBatchTaskRunner;
+    private final TransportService transportService;
 
     @Inject
     public ADBatchTaskRemoteExecutionTransportAction(
@@ -37,10 +38,11 @@ public class ADBatchTaskRemoteExecutionTransportAction extends
     ) {
         super(ADBatchTaskRemoteExecutionAction.NAME, transportService, actionFilters, ADBatchAnomalyResultRequest::new);
         this.adBatchTaskRunner = adBatchTaskRunner;
+        this.transportService = transportService;
     }
 
     @Override
     protected void doExecute(Task task, ADBatchAnomalyResultRequest request, ActionListener<ADBatchAnomalyResultResponse> listener) {
-        adBatchTaskRunner.startADBatchTask(request.getAdTask(), true, listener);
+        adBatchTaskRunner.startADBatchTask(request.getAdTask(), true, transportService, listener);
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskAction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
+
+public class ADCancelTaskAction extends ActionType<ADCancelTaskResponse> {
+
+    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detectors/_cancel_task";
+    public static final ADCancelTaskAction INSTANCE = new ADCancelTaskAction();
+
+    private ADCancelTaskAction() {
+        super(NAME, ADCancelTaskResponse::new);
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskAction.java
@@ -15,13 +15,15 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.CANCEL_TASK;
+
 import org.elasticsearch.action.ActionType;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
 
 public class ADCancelTaskAction extends ActionType<ADCancelTaskResponse> {
 
-    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detectors/_cancel_task";
+    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detectors/" + CANCEL_TASK;
     public static final ADCancelTaskAction INSTANCE = new ADCancelTaskAction();
 
     private ADCancelTaskAction() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskNodeRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskNodeRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+public class ADCancelTaskNodeRequest extends BaseNodeRequest {
+    private String detectorId;
+    private String userName;
+
+    public ADCancelTaskNodeRequest(StreamInput in) throws IOException {
+        super(in);
+        this.detectorId = in.readOptionalString();
+        this.userName = in.readOptionalString();
+    }
+
+    public ADCancelTaskNodeRequest(ADCancelTaskRequest request) {
+        this.detectorId = request.getDetectorId();
+        this.userName = request.getUserName();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(detectorId);
+        out.writeOptionalString(userName);
+    }
+
+    public String getDetectorId() {
+        return detectorId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskNodeResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskNodeResponse.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskCancellationState;
+
+public class ADCancelTaskNodeResponse extends BaseNodeResponse {
+
+    private ADTaskCancellationState state;
+
+    public ADCancelTaskNodeResponse(DiscoveryNode node, ADTaskCancellationState state) {
+        super(node);
+        this.state = state;
+    }
+
+    public ADCancelTaskNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        this.state = in.readEnum(ADTaskCancellationState.class);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeEnum(state);
+    }
+
+    public static ADCancelTaskNodeResponse readNodeResponse(StreamInput in) throws IOException {
+        return new ADCancelTaskNodeResponse(in);
+    }
+
+    public ADTaskCancellationState getState() {
+        return state;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+
+public class ADCancelTaskRequest extends BaseNodesRequest<ADCancelTaskRequest> {
+
+    private String detectorId;
+    private String userName;
+
+    public ADCancelTaskRequest(StreamInput in) throws IOException {
+        super(in);
+        this.detectorId = in.readOptionalString();
+        this.userName = in.readOptionalString();
+    }
+
+    public ADCancelTaskRequest(String detectorId, String userName, DiscoveryNode... nodes) {
+        super(nodes);
+        this.detectorId = detectorId;
+        this.userName = userName;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (Strings.isEmpty(detectorId)) {
+            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeOptionalString(detectorId);
+        out.writeOptionalString(userName);
+    }
+
+    public String getDetectorId() {
+        return detectorId;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskResponse.java
@@ -43,9 +43,4 @@ public class ADCancelTaskResponse extends BaseNodesResponse<ADCancelTaskNodeResp
     public List<ADCancelTaskNodeResponse> readNodesFrom(StreamInput in) throws IOException {
         return in.readList(ADCancelTaskNodeResponse::readNodeResponse);
     }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+public class ADCancelTaskResponse extends BaseNodesResponse<ADCancelTaskNodeResponse> {
+
+    public ADCancelTaskResponse(StreamInput in) throws IOException {
+        super(new ClusterName(in), in.readList(ADCancelTaskNodeResponse::readNodeResponse), in.readList(FailedNodeException::new));
+    }
+
+    public ADCancelTaskResponse(ClusterName clusterName, List<ADCancelTaskNodeResponse> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    public void writeNodesTo(StreamOutput out, List<ADCancelTaskNodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    @Override
+    public List<ADCancelTaskNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(ADCancelTaskNodeResponse::readNodeResponse);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskTransportAction.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskCancellationState;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
+
+public class ADCancelTaskTransportAction extends
+    TransportNodesAction<ADCancelTaskRequest, ADCancelTaskResponse, ADCancelTaskNodeRequest, ADCancelTaskNodeResponse> {
+    private final Logger logger = LogManager.getLogger(ADCancelTaskTransportAction.class);
+    private Client client;
+    private ADTaskManager adTaskManager;
+
+    @Inject
+    public ADCancelTaskTransportAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ADTaskManager adTaskManager,
+        Client client
+    ) {
+        super(
+            ADCancelTaskAction.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            ADCancelTaskRequest::new,
+            ADCancelTaskNodeRequest::new,
+            ThreadPool.Names.MANAGEMENT,
+            ADCancelTaskNodeResponse.class
+        );
+        this.adTaskManager = adTaskManager;
+        this.client = client;
+    }
+
+    @Override
+    protected ADCancelTaskResponse newResponse(
+        ADCancelTaskRequest request,
+        List<ADCancelTaskNodeResponse> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new ADCancelTaskResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected ADCancelTaskNodeRequest newNodeRequest(ADCancelTaskRequest request) {
+        return new ADCancelTaskNodeRequest(request);
+    }
+
+    @Override
+    protected ADCancelTaskNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new ADCancelTaskNodeResponse(in);
+    }
+
+    @Override
+    protected ADCancelTaskNodeResponse nodeOperation(ADCancelTaskNodeRequest request) {
+        String reason = "Task cancelled by user";
+        String userName = request.getUserName();
+        String detectorId = request.getDetectorId();
+        ADTaskCancellationState state = adTaskManager.cancelLocalTaskByDetectorId(detectorId, reason, userName);
+        logger.debug("Cancelled AD task for detector: {}", request.getDetectorId());
+        return new ADCancelTaskNodeResponse(clusterService.localNode(), state);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileAction.java
@@ -15,13 +15,15 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.AD_TASK;
+
 import org.elasticsearch.action.ActionType;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
 
 public class ADTaskProfileAction extends ActionType<ADTaskProfileResponse> {
 
-    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detectors/profile/ad_task";
+    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detectors/profile/" + AD_TASK;
     public static final ADTaskProfileAction INSTANCE = new ADTaskProfileAction();
 
     private ADTaskProfileAction() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileAction.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
+
+public class ADTaskProfileAction extends ActionType<ADTaskProfileResponse> {
+
+    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detectors/profile/ad_task";
+    public static final ADTaskProfileAction INSTANCE = new ADTaskProfileAction();
+
+    private ADTaskProfileAction() {
+        super(NAME, ADTaskProfileResponse::new);
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileNodeRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileNodeRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.support.nodes.BaseNodeRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+public class ADTaskProfileNodeRequest extends BaseNodeRequest {
+    private String adTaskId;
+
+    public ADTaskProfileNodeRequest(StreamInput in) throws IOException {
+        super(in);
+        this.adTaskId = in.readString();
+    }
+
+    public ADTaskProfileNodeRequest(ADTaskProfileRequest request) {
+        this.adTaskId = request.getAdTaskId();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(adTaskId);
+    }
+
+    public String getAdTaskId() {
+        return adTaskId;
+    }
+
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileNodeRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileNodeRequest.java
@@ -22,25 +22,25 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 public class ADTaskProfileNodeRequest extends BaseNodeRequest {
-    private String adTaskId;
+    private String detectorId;
 
     public ADTaskProfileNodeRequest(StreamInput in) throws IOException {
         super(in);
-        this.adTaskId = in.readString();
+        this.detectorId = in.readString();
     }
 
     public ADTaskProfileNodeRequest(ADTaskProfileRequest request) {
-        this.adTaskId = request.getAdTaskId();
+        this.detectorId = request.getDetectorId();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(adTaskId);
+        out.writeString(detectorId);
     }
 
-    public String getAdTaskId() {
-        return adTaskId;
+    public String getDetectorId() {
+        return detectorId;
     }
 
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileNodeResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileNodeResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskProfile;
+
+public class ADTaskProfileNodeResponse extends BaseNodeResponse {
+
+    private ADTaskProfile adTaskProfile;
+
+    public ADTaskProfileNodeResponse(DiscoveryNode node, ADTaskProfile adTaskProfile) {
+        super(node);
+        this.adTaskProfile = adTaskProfile;
+    }
+
+    public ADTaskProfileNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        if (in.readBoolean()) {
+            this.adTaskProfile = new ADTaskProfile(in);
+        } else {
+            this.adTaskProfile = null;
+        }
+    }
+
+    public ADTaskProfile getAdTaskProfile() {
+        return adTaskProfile;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        if (adTaskProfile != null) {
+            out.writeBoolean(true);
+            adTaskProfile.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    public static ADTaskProfileNodeResponse readNodeResponse(StreamInput in) throws IOException {
+        return new ADTaskProfileNodeResponse(in);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileRequest.java
@@ -30,28 +30,23 @@ import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 
 public class ADTaskProfileRequest extends BaseNodesRequest<ADTaskProfileRequest> {
 
-    private String adTaskId;
+    private String detectorId;
 
     public ADTaskProfileRequest(StreamInput in) throws IOException {
         super(in);
-        this.adTaskId = in.readString();
+        this.detectorId = in.readString();
     }
 
-    public ADTaskProfileRequest(String adTaskId, String... nodeIds) {
-        super(nodeIds);
-        this.adTaskId = adTaskId;
-    }
-
-    public ADTaskProfileRequest(String adTaskId, DiscoveryNode... nodes) {
+    public ADTaskProfileRequest(String detectorId, DiscoveryNode... nodes) {
         super(nodes);
-        this.adTaskId = adTaskId;
+        this.detectorId = detectorId;
     }
 
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (Strings.isEmpty(adTaskId)) {
-            validationException = addValidationError(CommonErrorMessages.AD_TASK_ID_MISSING, validationException);
+        if (Strings.isEmpty(detectorId)) {
+            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
         }
         return validationException;
     }
@@ -59,10 +54,10 @@ public class ADTaskProfileRequest extends BaseNodesRequest<ADTaskProfileRequest>
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeString(adTaskId);
+        out.writeString(detectorId);
     }
 
-    public String getAdTaskId() {
-        return adTaskId;
+    public String getDetectorId() {
+        return detectorId;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileRequest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.nodes.BaseNodesRequest;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+
+public class ADTaskProfileRequest extends BaseNodesRequest<ADTaskProfileRequest> {
+
+    private String adTaskId;
+
+    public ADTaskProfileRequest(StreamInput in) throws IOException {
+        super(in);
+        this.adTaskId = in.readString();
+    }
+
+    public ADTaskProfileRequest(String adTaskId, String... nodeIds) {
+        super(nodeIds);
+        this.adTaskId = adTaskId;
+    }
+
+    public ADTaskProfileRequest(String adTaskId, DiscoveryNode... nodes) {
+        super(nodes);
+        this.adTaskId = adTaskId;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (Strings.isEmpty(adTaskId)) {
+            validationException = addValidationError(CommonErrorMessages.AD_TASK_ID_MISSING, validationException);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(adTaskId);
+    }
+
+    public String getAdTaskId() {
+        return adTaskId;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileResponse.java
@@ -44,8 +44,4 @@ public class ADTaskProfileResponse extends BaseNodesResponse<ADTaskProfileNodeRe
         return in.readList(ADTaskProfileNodeResponse::readNodeResponse);
     }
 
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+public class ADTaskProfileResponse extends BaseNodesResponse<ADTaskProfileNodeResponse> {
+
+    public ADTaskProfileResponse(StreamInput in) throws IOException {
+        super(new ClusterName(in), in.readList(ADTaskProfileNodeResponse::readNodeResponse), in.readList(FailedNodeException::new));
+    }
+
+    public ADTaskProfileResponse(ClusterName clusterName, List<ADTaskProfileNodeResponse> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    public void writeNodesTo(StreamOutput out, List<ADTaskProfileNodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    @Override
+    public List<ADTaskProfileNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(ADTaskProfileNodeResponse::readNodeResponse);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTransportAction.java
@@ -78,7 +78,7 @@ public class ADTaskProfileTransportAction extends
 
     @Override
     protected ADTaskProfileNodeResponse nodeOperation(ADTaskProfileNodeRequest request) {
-        ADTaskProfile adTaskProfile = adTaskManager.getLocalADTaskProfile(request.getAdTaskId());
+        ADTaskProfile adTaskProfile = adTaskManager.getLocalADTaskProfileByDetectorId(request.getDetectorId());
 
         return new ADTaskProfileNodeResponse(clusterService.localNode(), adTaskProfile);
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTransportAction.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.action.FailedNodeException;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskProfile;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
+
+public class ADTaskProfileTransportAction extends
+    TransportNodesAction<ADTaskProfileRequest, ADTaskProfileResponse, ADTaskProfileNodeRequest, ADTaskProfileNodeResponse> {
+
+    private ADTaskManager adTaskManager;
+
+    @Inject
+    public ADTaskProfileTransportAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ADTaskManager adTaskManager
+    ) {
+        super(
+            ADTaskProfileAction.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            ADTaskProfileRequest::new,
+            ADTaskProfileNodeRequest::new,
+            ThreadPool.Names.MANAGEMENT,
+            ADTaskProfileNodeResponse.class
+        );
+        this.adTaskManager = adTaskManager;
+    }
+
+    @Override
+    protected ADTaskProfileResponse newResponse(
+        ADTaskProfileRequest request,
+        List<ADTaskProfileNodeResponse> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new ADTaskProfileResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected ADTaskProfileNodeRequest newNodeRequest(ADTaskProfileRequest request) {
+        return new ADTaskProfileNodeRequest(request);
+    }
+
+    @Override
+    protected ADTaskProfileNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new ADTaskProfileNodeResponse(in);
+    }
+
+    @Override
+    protected ADTaskProfileNodeResponse nodeOperation(ADTaskProfileNodeRequest request) {
+        ADTaskProfile adTaskProfile = adTaskManager.getLocalADTaskProfile(request.getAdTaskId());
+
+        return new ADTaskProfileNodeResponse(clusterService.localNode(), adTaskProfile);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -125,7 +125,7 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
         if (rawPath.endsWith(RestHandlerUtils.START_JOB)) {
             adTaskManager.startDetector(detectorId, handler, user, transportService, listener);
         } else if (rawPath.endsWith(RestHandlerUtils.STOP_JOB)) {
-            adTaskManager.stopDetector(detectorId, handler, user, listener);
+            adTaskManager.stopDetector(detectorId, handler, user, transportService, listener);
         }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportAction.java
@@ -51,6 +51,7 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
     private final NamedXContentRegistry xContentRegistry;
     private volatile Boolean filterByEnabled;
     private final ADTaskManager adTaskManager;
+    private final TransportService transportService;
 
     @Inject
     public AnomalyDetectorJobTransportAction(
@@ -64,6 +65,7 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
         ADTaskManager adTaskManager
     ) {
         super(AnomalyDetectorJobAction.NAME, transportService, actionFilters, AnomalyDetectorJobRequest::new);
+        this.transportService = transportService;
         this.client = client;
         this.clusterService = clusterService;
         this.settings = settings;
@@ -121,10 +123,9 @@ public class AnomalyDetectorJobTransportAction extends HandledTransportAction<An
             xContentRegistry
         );
         if (rawPath.endsWith(RestHandlerUtils.START_JOB)) {
-            adTaskManager.startDetector(detectorId, handler, user, listener);
+            adTaskManager.startDetector(detectorId, handler, user, transportService, listener);
         } else if (rawPath.endsWith(RestHandlerUtils.STOP_JOB)) {
-            // TODO: change to adTaskManager.stopDetector
-            handler.stopAnomalyDetectorJob(detectorId);
+            adTaskManager.stopDetector(detectorId, handler, user, listener);
         }
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskAction.java
@@ -15,13 +15,15 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.AD_TASK;
+
 import org.elasticsearch.action.ActionType;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
 
 public class ForwardADTaskAction extends ActionType<AnomalyDetectorJobResponse> {
     // Internal Action which is not used for public facing RestAPIs.
-    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "task/forward";
+    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detector/" + AD_TASK + "/_forward";
     public static final ForwardADTaskAction INSTANCE = new ForwardADTaskAction();
 
     private ForwardADTaskAction() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskAction.java
@@ -23,7 +23,7 @@ import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
 
 public class ForwardADTaskAction extends ActionType<AnomalyDetectorJobResponse> {
     // Internal Action which is not used for public facing RestAPIs.
-    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detector/" + AD_TASK + "/_forward";
+    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "detector/" + AD_TASK + "/forward";
     public static final ForwardADTaskAction INSTANCE = new ForwardADTaskAction();
 
     private ForwardADTaskAction() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskAction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionType;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
+
+public class ForwardADTaskAction extends ActionType<AnomalyDetectorJobResponse> {
+    // Internal Action which is not used for public facing RestAPIs.
+    public static final String NAME = CommonValue.INTERNAL_ACTION_PREFIX + "task/forward";
+    public static final ForwardADTaskAction INSTANCE = new ForwardADTaskAction();
+
+    private ForwardADTaskAction() {
+        super(NAME, AnomalyDetectorJobResponse::new);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskRequest.java
@@ -25,16 +25,19 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskAction;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.commons.authuser.User;
 
 public class ForwardADTaskRequest extends ActionRequest {
     private AnomalyDetector detector;
     private User user;
+    private ADTaskAction adTaskAction;
 
-    public ForwardADTaskRequest(AnomalyDetector detector, User user) {
+    public ForwardADTaskRequest(AnomalyDetector detector, User user, ADTaskAction adTaskAction) {
         this.detector = detector;
         this.user = user;
+        this.adTaskAction = adTaskAction;
     }
 
     public ForwardADTaskRequest(StreamInput in) throws IOException {
@@ -43,6 +46,7 @@ public class ForwardADTaskRequest extends ActionRequest {
         if (in.readBoolean()) {
             this.user = new User(in);
         }
+        this.adTaskAction = in.readEnum(ADTaskAction.class);
     }
 
     @Override
@@ -55,6 +59,7 @@ public class ForwardADTaskRequest extends ActionRequest {
         } else {
             out.writeBoolean(false);
         }
+        out.writeEnum(adTaskAction);
     }
 
     @Override
@@ -62,6 +67,11 @@ public class ForwardADTaskRequest extends ActionRequest {
         ActionRequestValidationException validationException = null;
         if (detector == null) {
             validationException = addValidationError(CommonErrorMessages.DETECTOR_MISSING, validationException);
+        } else if (detector.getDetectorId() == null) {
+            validationException = addValidationError(CommonErrorMessages.AD_ID_MISSING_MSG, validationException);
+        }
+        if (adTaskAction == null) {
+            validationException = addValidationError(CommonErrorMessages.AD_TASK_ACTION_MISSING, validationException);
         }
         return validationException;
     }
@@ -72,5 +82,9 @@ public class ForwardADTaskRequest extends ActionRequest {
 
     public User getUser() {
         return user;
+    }
+
+    public ADTaskAction getAdTaskAction() {
+        return adTaskAction;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskRequest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+import java.io.IOException;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.commons.authuser.User;
+
+public class ForwardADTaskRequest extends ActionRequest {
+    private AnomalyDetector detector;
+    private User user;
+
+    public ForwardADTaskRequest(AnomalyDetector detector, User user) {
+        this.detector = detector;
+        this.user = user;
+    }
+
+    public ForwardADTaskRequest(StreamInput in) throws IOException {
+        super(in);
+        this.detector = new AnomalyDetector(in);
+        if (in.readBoolean()) {
+            this.user = new User(in);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        detector.writeTo(out);
+        if (user != null) {
+            out.writeBoolean(true);
+            user.writeTo(out);
+        } else {
+            out.writeBoolean(false);
+        }
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (detector == null) {
+            validationException = addValidationError(CommonErrorMessages.DETECTOR_MISSING, validationException);
+        }
+        return validationException;
+    }
+
+    public AnomalyDetector getDetector() {
+        return detector;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskTransportAction.java
@@ -15,27 +15,48 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskAction;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
 
 public class ForwardADTaskTransportAction extends HandledTransportAction<ForwardADTaskRequest, AnomalyDetectorJobResponse> {
 
     private final ADTaskManager adTaskManager;
+    private final TransportService transportService;
 
     @Inject
     public ForwardADTaskTransportAction(ActionFilters actionFilters, TransportService transportService, ADTaskManager adTaskManager) {
         super(ForwardADTaskAction.NAME, transportService, actionFilters, ForwardADTaskRequest::new);
         this.adTaskManager = adTaskManager;
+        this.transportService = transportService;
     }
 
     @Override
     protected void doExecute(Task task, ForwardADTaskRequest request, ActionListener<AnomalyDetectorJobResponse> listener) {
-        adTaskManager.startHistoricalDetector(request.getDetector(), request.getUser(), listener);
+        ADTaskAction adTaskAction = request.getAdTaskAction();
+        AnomalyDetector detector = request.getDetector();
+
+        switch (adTaskAction) {
+            case START:
+                adTaskManager.startHistoricalDetector(request.getDetector(), request.getUser(), transportService, listener);
+                break;
+            case STOP:
+                adTaskManager.removeDetectorFromCache(request.getDetector().getDetectorId());
+                listener.onResponse(new AnomalyDetectorJobResponse(detector.getDetectorId(), 0, 0, 0, RestStatus.OK));
+                break;
+            default:
+                listener.onFailure(new ElasticsearchStatusException("Unsupported AD task action " + adTaskAction, RestStatus.BAD_REQUEST));
+                break;
+        }
+
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskTransportAction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
+
+public class ForwardADTaskTransportAction extends HandledTransportAction<ForwardADTaskRequest, AnomalyDetectorJobResponse> {
+
+    private final ADTaskManager adTaskManager;
+
+    @Inject
+    public ForwardADTaskTransportAction(ActionFilters actionFilters, TransportService transportService, ADTaskManager adTaskManager) {
+        super(ForwardADTaskAction.NAME, transportService, actionFilters, ForwardADTaskRequest::new);
+        this.adTaskManager = adTaskManager;
+    }
+
+    @Override
+    protected void doExecute(Task task, ForwardADTaskRequest request, ActionListener<AnomalyDetectorJobResponse> listener) {
+        adTaskManager.startHistoricalDetector(request.getDetector(), request.getUser(), listener);
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorRequest.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorRequest.java
@@ -27,6 +27,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
     private String detectorID;
     private long version;
     private boolean returnJob;
+    private boolean returnTask;
     private String typeStr;
     private String rawPath;
     private boolean all;
@@ -37,6 +38,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         detectorID = in.readString();
         version = in.readLong();
         returnJob = in.readBoolean();
+        returnTask = in.readBoolean();
         typeStr = in.readString();
         rawPath = in.readString();
         all = in.readBoolean();
@@ -49,16 +51,17 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         String detectorID,
         long version,
         boolean returnJob,
+        boolean returnTask,
         String typeStr,
         String rawPath,
         boolean all,
         String entityValue
-    )
-        throws IOException {
+    ) {
         super();
         this.detectorID = detectorID;
         this.version = version;
         this.returnJob = returnJob;
+        this.returnTask = returnTask;
         this.typeStr = typeStr;
         this.rawPath = rawPath;
         this.all = all;
@@ -75,6 +78,10 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
 
     public boolean isReturnJob() {
         return returnJob;
+    }
+
+    public boolean isReturnTask() {
+        return returnTask;
     }
 
     public String getTypeStr() {
@@ -99,6 +106,7 @@ public class GetAnomalyDetectorRequest extends ActionRequest {
         out.writeString(detectorID);
         out.writeLong(version);
         out.writeBoolean(returnJob);
+        out.writeBoolean(returnTask);
         out.writeString(typeStr);
         out.writeString(rawPath);
         out.writeBoolean(all);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorResponse.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorResponse.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.RestStatus;
 
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfile;
@@ -39,11 +40,13 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
     private long seqNo;
     private AnomalyDetector detector;
     private AnomalyDetectorJob adJob;
+    private ADTask adTask;
     private RestStatus restStatus;
     private DetectorProfile detectorProfile;
     private EntityProfile entityProfile;
     private boolean profileResponse;
     private boolean returnJob;
+    private boolean returnTask;
 
     public GetAnomalyDetectorResponse(StreamInput in) throws IOException {
         super(in);
@@ -70,6 +73,12 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
             } else {
                 adJob = null;
             }
+            returnTask = in.readBoolean();
+            if (returnTask) {
+                adTask = new ADTask(in);
+            } else {
+                adTask = null;
+            }
         }
     }
 
@@ -81,6 +90,8 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
         AnomalyDetector detector,
         AnomalyDetectorJob adJob,
         boolean returnJob,
+        ADTask adTask,
+        boolean returnTask,
         RestStatus restStatus,
         DetectorProfile detectorProfile,
         EntityProfile entityProfile,
@@ -93,10 +104,17 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
         this.detector = detector;
         this.restStatus = restStatus;
         this.returnJob = returnJob;
+
         if (this.returnJob) {
             this.adJob = adJob;
         } else {
             this.adJob = null;
+        }
+        this.returnTask = returnTask;
+        if (this.returnTask) {
+            this.adTask = adTask;
+        } else {
+            this.adTask = null;
         }
         this.detectorProfile = detectorProfile;
         this.entityProfile = entityProfile;
@@ -128,6 +146,12 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
             } else {
                 out.writeBoolean(false); // returnJob is false
             }
+            if (returnTask) {
+                out.writeBoolean(true);
+                adTask.writeTo(out);
+            } else {
+                out.writeBoolean(false);
+            }
         }
     }
 
@@ -149,8 +173,15 @@ public class GetAnomalyDetectorResponse extends ActionResponse implements ToXCon
             if (returnJob) {
                 builder.field(RestHandlerUtils.ANOMALY_DETECTOR_JOB, adJob);
             }
+            if (returnTask) {
+                builder.field(RestHandlerUtils.ANOMALY_DETECTION_TASK, adTask);
+            }
             builder.endObject();
         }
         return builder;
+    }
+
+    public DetectorProfile getDetectorProfile() {
+        return detectorProfile;
     }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -146,7 +146,6 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
 
     protected void getExecute(GetAnomalyDetectorRequest request, ActionListener<GetAnomalyDetectorResponse> listener) {
         String detectorID = request.getDetectorID();
-        Long version = request.getVersion();
         String typesStr = request.getTypeStr();
         String rawPath = request.getRawPath();
         String entityValue = request.getEntityValue();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -84,6 +84,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
     private final Set<EntityProfileName> defaultEntityProfileTypes;
     private final NamedXContentRegistry xContentRegistry;
     private final DiscoveryNodeFilterer nodeFilter;
+    private final TransportService transportService;
     private volatile Boolean filterByEnabled;
     private final ADTaskManager adTaskManager;
 
@@ -118,6 +119,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         this.nodeFilter = nodeFilter;
         filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+        this.transportService = transportService;
         this.adTaskManager = adTaskManager;
     }
 
@@ -198,6 +200,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                         xContentRegistry,
                         nodeFilter,
                         AnomalyDetectorSettings.NUM_MIN_SAMPLES,
+                        transportService,
                         adTaskManager
                     );
                     profileRunner.profile(detectorID, getProfileActionListener(listener), profilesToCollect);
@@ -208,6 +211,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                         .getLatestADTask(
                             detectorID,
                             (adTask) -> getDetectorAndJob(detectorID, returnJob, returnTask, adTask, listener),
+                            transportService,
                             listener
                         );
                 } else {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportAction.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTransportAction.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -55,12 +56,14 @@ import org.elasticsearch.transport.TransportService;
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorProfileRunner;
 import com.amazon.opendistroforelasticsearch.ad.EntityProfileRunner;
 import com.amazon.opendistroforelasticsearch.ad.Name;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfile;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfileName;
 import com.amazon.opendistroforelasticsearch.ad.model.EntityProfileName;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
 import com.amazon.opendistroforelasticsearch.commons.authuser.User;
@@ -82,6 +85,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
     private final NamedXContentRegistry xContentRegistry;
     private final DiscoveryNodeFilterer nodeFilter;
     private volatile Boolean filterByEnabled;
+    private final ADTaskManager adTaskManager;
 
     @Inject
     public GetAnomalyDetectorTransportAction(
@@ -91,7 +95,8 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         ClusterService clusterService,
         Client client,
         Settings settings,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        ADTaskManager adTaskManager
     ) {
         super(GetAnomalyDetectorAction.NAME, transportService, actionFilters, GetAnomalyDetectorRequest::new);
         this.clusterService = clusterService;
@@ -113,6 +118,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         this.nodeFilter = nodeFilter;
         filterByEnabled = AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+        this.adTaskManager = adTaskManager;
     }
 
     @Override
@@ -144,6 +150,7 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         String entityValue = request.getEntityValue();
         boolean all = request.isAll();
         boolean returnJob = request.isReturnJob();
+        boolean returnTask = request.isReturnTask();
 
         try {
             if (!Strings.isEmpty(typesStr) || rawPath.endsWith(PROFILE) || rawPath.endsWith(PROFILE + "/")) {
@@ -164,7 +171,21 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                                     profile -> {
                                         listener
                                             .onResponse(
-                                                new GetAnomalyDetectorResponse(0, null, 0, 0, null, null, false, null, null, profile, true)
+                                                new GetAnomalyDetectorResponse(
+                                                    0,
+                                                    null,
+                                                    0,
+                                                    0,
+                                                    null,
+                                                    null,
+                                                    false,
+                                                    null,
+                                                    false,
+                                                    null,
+                                                    null,
+                                                    profile,
+                                                    true
+                                                )
                                             );
                                     },
                                     e -> listener.onFailure(e)
@@ -176,18 +197,22 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                         client,
                         xContentRegistry,
                         nodeFilter,
-                        AnomalyDetectorSettings.NUM_MIN_SAMPLES
+                        AnomalyDetectorSettings.NUM_MIN_SAMPLES,
+                        adTaskManager
                     );
-                    profileRunner.profile(detectorID, getProfileActionListener(listener, detectorID), profilesToCollect);
+                    profileRunner.profile(detectorID, getProfileActionListener(listener), profilesToCollect);
                 }
             } else {
-                MultiGetRequest.Item adItem = new MultiGetRequest.Item(ANOMALY_DETECTORS_INDEX, detectorID).version(version);
-                MultiGetRequest multiGetRequest = new MultiGetRequest().add(adItem);
-                if (returnJob) {
-                    MultiGetRequest.Item adJobItem = new MultiGetRequest.Item(ANOMALY_DETECTOR_JOB_INDEX, detectorID).version(version);
-                    multiGetRequest.add(adJobItem);
+                if (returnTask) {
+                    adTaskManager
+                        .getLatestADTask(
+                            detectorID,
+                            (adTask) -> getDetectorAndJob(detectorID, returnJob, returnTask, adTask, listener),
+                            listener
+                        );
+                } else {
+                    getDetectorAndJob(detectorID, returnJob, returnTask, Optional.empty(), listener);
                 }
-                client.multiGet(multiGetRequest, onMultiGetResponse(listener, returnJob, detectorID));
             }
         } catch (Exception e) {
             LOG.error(e);
@@ -195,9 +220,27 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         }
     }
 
+    private void getDetectorAndJob(
+        String detectorID,
+        boolean returnJob,
+        boolean returnTask,
+        Optional<ADTask> adTask,
+        ActionListener<GetAnomalyDetectorResponse> listener
+    ) {
+        MultiGetRequest.Item adItem = new MultiGetRequest.Item(ANOMALY_DETECTORS_INDEX, detectorID);
+        MultiGetRequest multiGetRequest = new MultiGetRequest().add(adItem);
+        if (returnJob) {
+            MultiGetRequest.Item adJobItem = new MultiGetRequest.Item(ANOMALY_DETECTOR_JOB_INDEX, detectorID);
+            multiGetRequest.add(adJobItem);
+        }
+        client.multiGet(multiGetRequest, onMultiGetResponse(listener, returnJob, returnTask, adTask, detectorID));
+    }
+
     private ActionListener<MultiGetResponse> onMultiGetResponse(
         ActionListener<GetAnomalyDetectorResponse> listener,
         boolean returnJob,
+        boolean returnTask,
+        Optional<ADTask> adTask,
         String detectorId
     ) {
         return new ActionListener<MultiGetResponse>() {
@@ -267,6 +310,8 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
                             detector,
                             adJob,
                             returnJob,
+                            adTask.orElse(null),
+                            returnTask,
                             RestStatus.OK,
                             null,
                             null,
@@ -282,14 +327,12 @@ public class GetAnomalyDetectorTransportAction extends HandledTransportAction<Ge
         };
     }
 
-    private ActionListener<DetectorProfile> getProfileActionListener(
-        ActionListener<GetAnomalyDetectorResponse> listener,
-        String detectorId
-    ) {
+    private ActionListener<DetectorProfile> getProfileActionListener(ActionListener<GetAnomalyDetectorResponse> listener) {
         return ActionListener.wrap(new CheckedConsumer<DetectorProfile, Exception>() {
             @Override
             public void accept(DetectorProfile profile) throws Exception {
-                listener.onResponse(new GetAnomalyDetectorResponse(0, null, 0, 0, null, null, false, null, profile, null, true));
+                listener
+                    .onResponse(new GetAnomalyDetectorResponse(0, null, 0, 0, null, null, false, null, false, null, profile, null, true));
             }
         }, exception -> { listener.onFailure(exception); });
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/RestHandlerUtils.java
@@ -51,6 +51,7 @@ public final class RestHandlerUtils {
     public static final String DETECTOR_ID = "detectorID";
     public static final String ANOMALY_DETECTOR = "anomaly_detector";
     public static final String ANOMALY_DETECTOR_JOB = "anomaly_detector_job";
+    public static final String ANOMALY_DETECTION_TASK = "anomaly_detection_task";
     public static final String RUN = "_run";
     public static final String PREVIEW = "_preview";
     public static final String START_JOB = "_start";

--- a/src/main/resources/mappings/anomaly-detection-state.json
+++ b/src/main/resources/mappings/anomaly-detection-state.json
@@ -53,6 +53,12 @@
     "checkpoint_id": {
       "type": "keyword"
     },
+    "coordinating_node": {
+      "type": "keyword"
+    },
+    "worker_node": {
+      "type": "keyword"
+    },
     "detector": {
       "properties": {
         "schema_version": {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AbstractProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AbstractProfileRunnerTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 import org.junit.BeforeClass;
 
@@ -66,6 +67,7 @@ public class AbstractProfileRunnerTests extends AbstractADTest {
     protected DiscoveryNodeFilterer nodeFilter;
     protected AnomalyDetector detector;
     protected ClusterService clusterService;
+    protected TransportService transportService;
     protected ADTaskManager adTaskManager;
 
     protected static Set<DetectorProfileName> stateOnly;
@@ -152,7 +154,7 @@ public class AbstractProfileRunnerTests extends AbstractADTest {
         requiredSamples = 128;
         neededSamples = 5;
 
-        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples, adTaskManager);
+        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples, transportService, adTaskManager);
 
         detectorIntervalMin = 3;
         detectorGetReponse = mock(GetResponse.class);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AbstractProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AbstractProfileRunnerTests.java
@@ -37,6 +37,7 @@ import org.junit.BeforeClass;
 
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfileName;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 
 public class AbstractProfileRunnerTests extends AbstractADTest {
@@ -65,6 +66,7 @@ public class AbstractProfileRunnerTests extends AbstractADTest {
     protected DiscoveryNodeFilterer nodeFilter;
     protected AnomalyDetector detector;
     protected ClusterService clusterService;
+    protected ADTaskManager adTaskManager;
 
     protected static Set<DetectorProfileName> stateOnly;
     protected static Set<DetectorProfileName> stateNError;
@@ -150,7 +152,7 @@ public class AbstractProfileRunnerTests extends AbstractADTest {
         requiredSamples = 128;
         neededSamples = 5;
 
-        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples);
+        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples, adTaskManager);
 
         detectorIntervalMin = 3;
         detectorGetReponse = mock(GetResponse.class);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunnerTests.java
@@ -579,7 +579,7 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
     public void testInvalidRequiredSamples() {
         expectThrows(
             IllegalArgumentException.class,
-            () -> new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, 0, adTaskManager)
+            () -> new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, 0, transportService, adTaskManager)
         );
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/AnomalyDetectorProfileRunnerTests.java
@@ -577,7 +577,10 @@ public class AnomalyDetectorProfileRunnerTests extends AbstractProfileRunnerTest
     }
 
     public void testInvalidRequiredSamples() {
-        expectThrows(IllegalArgumentException.class, () -> new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, 0));
+        expectThrows(
+            IllegalArgumentException.class,
+            () -> new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, 0, adTaskManager)
+        );
     }
 
     public void testFailRCFPolling() throws IOException, InterruptedException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/HistoricalDetectorIntegTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/HistoricalDetectorIntegTestCase.java
@@ -163,6 +163,16 @@ public abstract class HistoricalDetectorIntegTestCase extends ADIntegTestCase {
         return adTasks;
     }
 
+    public ADTask getADTask(String taskId) throws IOException {
+        ADTask adTask = toADTask(getDoc(CommonName.DETECTION_STATE_INDEX, taskId));
+        adTask.setTaskId(taskId);
+        return adTask;
+    }
+
+    public AnomalyDetectorJob getADJob(String detectorId) throws IOException {
+        return toADJob(getDoc(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, detectorId));
+    }
+
     public ADTask toADTask(GetResponse doc) throws IOException {
         return ADTask.parse(TestHelpers.parser(doc.getSourceAsString()));
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/HistoricalDetectorRestTestCase.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/HistoricalDetectorRestTestCase.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.AD_BASE_DETECTORS_URI;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.function.ToDoubleFunction;
+import java.util.function.ToIntFunction;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.mock.model.MockSimpleLog;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskProfile;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
+import com.amazon.opendistroforelasticsearch.ad.model.Feature;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public abstract class HistoricalDetectorRestTestCase extends AnomalyDetectorRestTestCase {
+
+    protected String historicalDetectorTestIndex = "test_historical_detector_data";
+    protected int detectionIntervalInMinutes = 1;
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        updateClusterSettings(BATCH_TASK_PIECE_INTERVAL_SECONDS.getKey(), 1);
+        // ingest test data
+        ingestTestDataForHistoricalDetector(historicalDetectorTestIndex, detectionIntervalInMinutes);
+    }
+
+    public ToXContentObject[] getHistoricalAnomalyDetector(String detectorId, boolean returnTask, RestClient client) throws IOException {
+        BasicHeader header = new BasicHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+        return getAnomalyDetector(detectorId, header, false, returnTask, client);
+    }
+
+    public ADTaskProfile getADTaskProfile(String detectorId) throws IOException {
+        Response profileResponse = TestHelpers
+            .makeRequest(client(), "GET", AD_BASE_DETECTORS_URI + "/" + detectorId + "/_profile/ad_task", ImmutableMap.of(), "", null);
+        return parseADTaskProfile(profileResponse);
+    }
+
+    public Response ingestSimpleMockLog(
+        String indexName,
+        int startDays,
+        int totalDoc,
+        long intervalInMinutes,
+        ToDoubleFunction<Integer> valueFunc,
+        ToIntFunction<Integer> categoryFunc
+    ) throws IOException {
+        TestHelpers
+            .makeRequest(
+                client(),
+                "PUT",
+                indexName,
+                null,
+                toHttpEntity(MockSimpleLog.INDEX_MAPPING),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            );
+
+        Response statsResponse = TestHelpers.makeRequest(client(), "GET", indexName, ImmutableMap.of(), "", null);
+        assertEquals(RestStatus.OK, restStatus(statsResponse));
+        String result = EntityUtils.toString(statsResponse.getEntity());
+        assertTrue(result.contains(indexName));
+
+        StringBuilder bulkRequestBuilder = new StringBuilder();
+        Instant startTime = Instant.now().minus(startDays, ChronoUnit.DAYS);
+        for (int i = 0; i < totalDoc; i++) {
+            bulkRequestBuilder.append("{ \"index\" : { \"_index\" : \"" + indexName + "\", \"_id\" : \"" + i + "\" } }\n");
+            MockSimpleLog simpleLog = new MockSimpleLog(
+                startTime,
+                valueFunc.applyAsDouble(i),
+                "category" + categoryFunc.applyAsInt(i),
+                randomBoolean(),
+                randomAlphaOfLength(5)
+            );
+            bulkRequestBuilder.append(TestHelpers.toJsonString(simpleLog));
+            bulkRequestBuilder.append("\n");
+            startTime = startTime.plus(intervalInMinutes, ChronoUnit.MINUTES);
+        }
+        Response bulkResponse = TestHelpers
+            .makeRequest(
+                client(),
+                "POST",
+                "_bulk?refresh=true",
+                null,
+                toHttpEntity(bulkRequestBuilder.toString()),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, "Kibana"))
+            );
+        return bulkResponse;
+    }
+
+    public ADTaskProfile parseADTaskProfile(Response profileResponse) throws IOException {
+        String profileResult = EntityUtils.toString(profileResponse.getEntity());
+        XContentParser parser = TestHelpers.parser(profileResult);
+        ADTaskProfile adTaskProfile = null;
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            String fieldName = parser.currentName();
+            parser.nextToken();
+            if ("ad_task".equals(fieldName)) {
+                adTaskProfile = ADTaskProfile.parse(parser);
+            } else {
+                parser.skipChildren();
+            }
+        }
+        return adTaskProfile;
+    }
+
+    protected void ingestTestDataForHistoricalDetector(String indexName, int detectionIntervalInMinutes) throws IOException {
+        ingestSimpleMockLog(indexName, 10, 3000, detectionIntervalInMinutes, (i) -> {
+            if (i % 500 == 0) {
+                return randomDoubleBetween(100, 1000, true);
+            } else {
+                return randomDoubleBetween(1, 10, true);
+            }
+        }, (i) -> 1);
+    }
+
+    protected AnomalyDetector createHistoricalDetector() throws IOException {
+        AggregationBuilder aggregationBuilder = TestHelpers
+            .parseAggregation("{\"test\":{\"max\":{\"field\":\"" + MockSimpleLog.VALUE_FIELD + "\"}}}");
+        Feature feature = new Feature(randomAlphaOfLength(5), randomAlphaOfLength(10), true, aggregationBuilder);
+        Instant endTime = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        Instant startTime = endTime.minus(10, ChronoUnit.DAYS).truncatedTo(ChronoUnit.SECONDS);
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(
+                dateRange,
+                ImmutableList.of(feature),
+                historicalDetectorTestIndex,
+                detectionIntervalInMinutes,
+                MockSimpleLog.TIME_FIELD
+            );
+        return createAnomalyDetector(detector, true, client());
+    }
+
+    protected String startHistoricalDetector(String detectorId) throws IOException {
+        Response startDetectorResponse = startAnomalyDetector(detectorId, client());
+        Map<String, Object> startDetectorResponseMap = responseAsMap(startDetectorResponse);
+        String taskId = (String) startDetectorResponseMap.get("_id");
+        assertNotNull(taskId);
+        return taskId;
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/MultiEntityProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/MultiEntityProfileRunnerTests.java
@@ -45,6 +45,7 @@ import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
@@ -84,6 +85,7 @@ public class MultiEntityProfileRunnerTests extends AbstractADTest {
 
     private int shingleSize;
     private AnomalyDetectorJob job;
+    private TransportService transportService;
     private ADTaskManager adTaskManager;
 
     enum InittedEverResultStatus {
@@ -105,8 +107,8 @@ public class MultiEntityProfileRunnerTests extends AbstractADTest {
         result = new DetectorInternalState.Builder().lastUpdateTime(Instant.now());
         job = TestHelpers.randomAnomalyDetectorJob(true);
         adTaskManager = mock(ADTaskManager.class);
-
-        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples, adTaskManager);
+        transportService = mock(TransportService.class);
+        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples, transportService, adTaskManager);
 
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/MultiEntityProfileRunnerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/MultiEntityProfileRunnerTests.java
@@ -55,6 +55,7 @@ import com.amazon.opendistroforelasticsearch.ad.model.DetectorInternalState;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfile;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfileName;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorState;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileAction;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileNodeResponse;
 import com.amazon.opendistroforelasticsearch.ad.transport.ProfileResponse;
@@ -83,6 +84,7 @@ public class MultiEntityProfileRunnerTests extends AbstractADTest {
 
     private int shingleSize;
     private AnomalyDetectorJob job;
+    private ADTaskManager adTaskManager;
 
     enum InittedEverResultStatus {
         INITTED,
@@ -102,8 +104,9 @@ public class MultiEntityProfileRunnerTests extends AbstractADTest {
         detector = TestHelpers.randomAnomalyDetectorUsingCategoryFields(detectorId, Arrays.asList("a"));
         result = new DetectorInternalState.Builder().lastUpdateTime(Instant.now());
         job = TestHelpers.randomAnomalyDetectorJob(true);
+        adTaskManager = mock(ADTaskManager.class);
 
-        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples);
+        runner = new AnomalyDetectorProfileRunner(client, xContentRegistry(), nodeFilter, requiredSamples, adTaskManager);
 
         doAnswer(invocation -> {
             Object[] args = invocation.getArguments();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/TestHelpers.java
@@ -19,6 +19,7 @@ import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.BUILT_IN_ROLES;
 import static org.elasticsearch.index.query.AbstractQueryBuilder.parseInnerQueryBuilder;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.elasticsearch.test.ESTestCase.buildNewFakeTransportAddress;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomDouble;
@@ -135,6 +136,7 @@ import com.amazon.opendistroforelasticsearch.commons.authuser.User;
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule.IntervalSchedule;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 public class TestHelpers {
 
@@ -142,6 +144,8 @@ public class TestHelpers {
     public static final String AD_BASE_RESULT_URI = "/_opendistro/_anomaly_detection/detectors/results";
     public static final String AD_BASE_PREVIEW_URI = "/_opendistro/_anomaly_detection/detectors/%s/_preview";
     public static final String AD_BASE_STATS_URI = "/_opendistro/_anomaly_detection/stats";
+    public static ImmutableSet<String> historicalDetectorRunningStats = ImmutableSet
+        .of(ADTaskState.CREATED.name(), ADTaskState.INIT.name(), ADTaskState.RUNNING.name());
     private static final Logger logger = LogManager.getLogger(TestHelpers.class);
     public static final Random random = new Random(42);
 
@@ -938,5 +942,9 @@ public class TestHelpers {
         IntStream.range(0, totalHits).forEach(i -> hitList.add(new SearchHit(i)));
         SearchHit[] hitArray = new SearchHit[hitList.size()];
         return new SearchHits(hitList.toArray(hitArray), new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), 1.0F);
+    }
+
+    public static DiscoveryNode randomDiscoveryNode() {
+        return new DiscoveryNode(UUIDs.randomBase64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/model/MockSimpleLog.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/model/MockSimpleLog.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.mock.model;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+
+public class MockSimpleLog implements ToXContentObject, Writeable {
+
+    public static final String TIME_FIELD = "timestamp";
+    public static final String VALUE_FIELD = "value";
+    public static final String CATEGORY_FIELD = "category";
+    public static final String IS_ERROR_FIELD = "is_error";
+    public static final String MESSAGE_FIELD = "message";
+
+    public static final String INDEX_MAPPING = "{\"mappings\":{\"properties\":{"
+        + "\""
+        + TIME_FIELD
+        + "\":{\"type\":\"date\",\"format\":\"strict_date_time||epoch_millis\"},"
+        + "\""
+        + VALUE_FIELD
+        + "\":{\"type\":\"double\"},"
+        + "\""
+        + CATEGORY_FIELD
+        + "\":{\"type\":\"keyword\"},"
+        + "\""
+        + IS_ERROR_FIELD
+        + "\":{\"type\":\"boolean\"},"
+        + "\""
+        + MESSAGE_FIELD
+        + "\":{\"type\":\"text\"}}}}";
+
+    private Instant timestamp;
+    private Double value;
+    private String category;
+    private Boolean isError;
+    private String message;
+
+    public MockSimpleLog(Instant timestamp, Double value, String category, Boolean isError, String message) {
+        this.timestamp = timestamp;
+        this.value = value;
+        this.category = category;
+        this.isError = isError;
+        this.message = message;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalInstant(timestamp);
+        out.writeOptionalDouble(value);
+        out.writeOptionalString(category);
+        out.writeOptionalBoolean(isError);
+        out.writeOptionalString(message);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        if (timestamp != null) {
+            xContentBuilder.field(TIME_FIELD, timestamp.toEpochMilli());
+        }
+        if (value != null) {
+            xContentBuilder.field(VALUE_FIELD, value);
+        }
+        if (category != null) {
+            xContentBuilder.field(CATEGORY_FIELD, category);
+        }
+        if (isError != null) {
+            xContentBuilder.field(IS_ERROR_FIELD, isError);
+        }
+        if (message != null) {
+            xContentBuilder.field(MESSAGE_FIELD, message);
+        }
+        return xContentBuilder.endObject();
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Double getValue() {
+        return value;
+    }
+
+    public void setValue(Double value) {
+        this.value = value;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public Boolean getError() {
+        return isError;
+    }
+
+    public void setError(Boolean error) {
+        isError = error;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/plugin/MockReindexPlugin.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/plugin/MockReindexPlugin.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.mock.plugin;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.bulk.BulkAction;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkRequestBuilder;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.BulkByScrollTask;
+import org.elasticsearch.index.reindex.DeleteByQueryAction;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.index.reindex.UpdateByQueryAction;
+import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.mock.transport.MockAnomalyDetectorJobAction;
+import com.amazon.opendistroforelasticsearch.ad.mock.transport.MockAnomalyDetectorJobTransportActionWithUser;
+import com.google.common.collect.ImmutableList;
+
+public class MockReindexPlugin extends Plugin implements ActionPlugin {
+
+    @Override
+    public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        return Arrays
+            .asList(
+                new ActionHandler<>(UpdateByQueryAction.INSTANCE, MockTransportUpdateByQueryAction.class),
+                new ActionHandler<>(DeleteByQueryAction.INSTANCE, MockTransportDeleteByQueryAction.class),
+                new ActionHandler<>(MockAnomalyDetectorJobAction.INSTANCE, MockAnomalyDetectorJobTransportActionWithUser.class)
+            );
+    }
+
+    public static class MockTransportUpdateByQueryAction extends HandledTransportAction<UpdateByQueryRequest, BulkByScrollResponse> {
+
+        @Inject
+        public MockTransportUpdateByQueryAction(ActionFilters actionFilters, TransportService transportService) {
+            super(UpdateByQueryAction.NAME, transportService, actionFilters, UpdateByQueryRequest::new);
+        }
+
+        @Override
+        protected void doExecute(Task task, UpdateByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
+            BulkByScrollResponse response = null;
+            try {
+                XContentParser parser = TestHelpers
+                    .parser(
+                        "{\"slice_id\":1,\"total\":2,\"updated\":3,\"created\":0,\"deleted\":0,\"batches\":6,"
+                            + "\"version_conflicts\":0,\"noops\":0,\"retries\":{\"bulk\":0,\"search\":10},"
+                            + "\"throttled_millis\":0,\"requests_per_second\":13.0,\"canceled\":\"reasonCancelled\","
+                            + "\"throttled_until_millis\":14}"
+                    );
+                parser.nextToken();
+                response = new BulkByScrollResponse(
+                    TimeValue.timeValueMillis(10),
+                    BulkByScrollTask.Status.innerFromXContent(parser),
+                    ImmutableList.of(),
+                    ImmutableList.of(),
+                    false
+                );
+            } catch (IOException exception) {
+                exception.printStackTrace();
+            }
+            listener.onResponse(response);
+        }
+    }
+
+    public static class MockTransportDeleteByQueryAction extends HandledTransportAction<DeleteByQueryRequest, BulkByScrollResponse> {
+
+        private Client client;
+
+        @Inject
+        public MockTransportDeleteByQueryAction(ActionFilters actionFilters, TransportService transportService, Client client) {
+            super(DeleteByQueryAction.NAME, transportService, actionFilters, DeleteByQueryRequest::new);
+            this.client = client;
+        }
+
+        @Override
+        protected void doExecute(Task task, DeleteByQueryRequest request, ActionListener<BulkByScrollResponse> listener) {
+            try {
+                SearchRequest searchRequest = request.getSearchRequest();
+                client.search(searchRequest, ActionListener.wrap(r -> {
+                    long totalHits = r.getHits().getTotalHits().value;
+                    Iterator<SearchHit> iterator = r.getHits().iterator();
+                    BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
+                    while (iterator.hasNext()) {
+                        String id = iterator.next().getId();
+                        DeleteRequest deleteRequest = new DeleteRequest(CommonName.DETECTION_STATE_INDEX, id);
+                        bulkRequestBuilder.add(deleteRequest);
+                    }
+                    BulkRequest bulkRequest = bulkRequestBuilder.request().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                    client
+                        .execute(
+                            BulkAction.INSTANCE,
+                            bulkRequest,
+                            ActionListener
+                                .wrap(
+                                    res -> { listener.onResponse(mockBulkByScrollResponse(totalHits)); },
+                                    ex -> { listener.onFailure(ex); }
+                                )
+                        );
+
+                }, e -> { listener.onFailure(e); }));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }
+
+        private BulkByScrollResponse mockBulkByScrollResponse(long totalHits) throws IOException {
+            XContentParser parser = TestHelpers
+                .parser(
+                    "{\"slice_id\":1,\"total\":2,\"updated\":0,\"created\":0,\"deleted\":"
+                        + totalHits
+                        + ",\"batches\":6,\"version_conflicts\":0,\"noops\":0,\"retries\":{\"bulk\":0,"
+                        + "\"search\":10},\"throttled_millis\":0,\"requests_per_second\":13.0,\"canceled\":"
+                        + "\"reasonCancelled\",\"throttled_until_millis\":14}"
+                );
+            parser.nextToken();
+            BulkByScrollResponse response = new BulkByScrollResponse(
+                TimeValue.timeValueMillis(10),
+                BulkByScrollTask.Status.innerFromXContent(parser),
+                ImmutableList.of(),
+                ImmutableList.of(),
+                false
+            );
+            return response;
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/transport/MockAnomalyDetectorJobAction.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/transport/MockAnomalyDetectorJobAction.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.mock.transport;
+
+import org.elasticsearch.action.ActionType;
+
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonValue;
+import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobResponse;
+
+public class MockAnomalyDetectorJobAction extends ActionType<AnomalyDetectorJobResponse> {
+    // External Action which used for public facing RestAPIs.
+    public static final String NAME = CommonValue.EXTERNAL_ACTION_PREFIX + "detector/mockjobmanagement";
+    public static final MockAnomalyDetectorJobAction INSTANCE = new MockAnomalyDetectorJobAction();
+
+    private MockAnomalyDetectorJobAction() {
+        super(NAME, AnomalyDetectorJobResponse::new);
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
@@ -129,7 +129,7 @@ public class MockAnomalyDetectorJobTransportActionWithUser extends
             adTaskManager.startDetector(detectorId, handler, user, transportService, listener);
         } else if (rawPath.endsWith(RestHandlerUtils.STOP_JOB)) {
             // Stop detector
-            adTaskManager.stopDetector(detectorId, handler, user, listener);
+            adTaskManager.stopDetector(detectorId, handler, user, transportService, listener);
         }
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/mock/transport/MockAnomalyDetectorJobTransportActionWithUser.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.mock.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.FILTER_BY_BACKEND_ROLES;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.REQUEST_TIMEOUT;
+import static com.amazon.opendistroforelasticsearch.ad.util.ParseUtils.resolveUserAndExecute;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
+import com.amazon.opendistroforelasticsearch.ad.rest.handler.IndexAnomalyDetectorJobActionHandler;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
+import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobRequest;
+import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobResponse;
+import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobTransportAction;
+import com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils;
+import com.amazon.opendistroforelasticsearch.commons.authuser.User;
+
+public class MockAnomalyDetectorJobTransportActionWithUser extends
+    HandledTransportAction<AnomalyDetectorJobRequest, AnomalyDetectorJobResponse> {
+    private final Logger logger = LogManager.getLogger(AnomalyDetectorJobTransportAction.class);
+
+    private final Client client;
+    private final ClusterService clusterService;
+    private final Settings settings;
+    private final AnomalyDetectionIndices anomalyDetectionIndices;
+    private final NamedXContentRegistry xContentRegistry;
+    private volatile Boolean filterByEnabled;
+    private final ADTaskManager adTaskManager;
+    private final TransportService transportService;
+
+    @Inject
+    public MockAnomalyDetectorJobTransportActionWithUser(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Client client,
+        ClusterService clusterService,
+        Settings settings,
+        AnomalyDetectionIndices anomalyDetectionIndices,
+        NamedXContentRegistry xContentRegistry,
+        ADTaskManager adTaskManager
+    ) {
+        super(MockAnomalyDetectorJobAction.NAME, transportService, actionFilters, AnomalyDetectorJobRequest::new);
+        this.transportService = transportService;
+        this.client = client;
+        this.clusterService = clusterService;
+        this.settings = settings;
+        this.anomalyDetectionIndices = anomalyDetectionIndices;
+        this.xContentRegistry = xContentRegistry;
+        this.adTaskManager = adTaskManager;
+        filterByEnabled = FILTER_BY_BACKEND_ROLES.get(settings);
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(FILTER_BY_BACKEND_ROLES, it -> filterByEnabled = it);
+    }
+
+    @Override
+    protected void doExecute(Task task, AnomalyDetectorJobRequest request, ActionListener<AnomalyDetectorJobResponse> listener) {
+        String detectorId = request.getDetectorID();
+        long seqNo = request.getSeqNo();
+        long primaryTerm = request.getPrimaryTerm();
+        String rawPath = request.getRawPath();
+        TimeValue requestTimeout = REQUEST_TIMEOUT.get(settings);
+        String userStr = "user_name|backendrole1,backendrole2|roles1,role2";
+        // By the time request reaches here, the user permissions are validated by Security plugin.
+        User user = User.parse(userStr);
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            resolveUserAndExecute(
+                user,
+                detectorId,
+                filterByEnabled,
+                listener,
+                () -> executeDetector(listener, detectorId, seqNo, primaryTerm, rawPath, requestTimeout, user),
+                client,
+                clusterService,
+                xContentRegistry
+            );
+        } catch (Exception e) {
+            logger.error(e);
+            listener.onFailure(e);
+        }
+    }
+
+    private void executeDetector(
+        ActionListener<AnomalyDetectorJobResponse> listener,
+        String detectorId,
+        long seqNo,
+        long primaryTerm,
+        String rawPath,
+        TimeValue requestTimeout,
+        User user
+    ) {
+        IndexAnomalyDetectorJobActionHandler handler = new IndexAnomalyDetectorJobActionHandler(
+            client,
+            listener,
+            anomalyDetectionIndices,
+            detectorId,
+            seqNo,
+            primaryTerm,
+            requestTimeout,
+            xContentRegistry
+        );
+        if (rawPath.endsWith(RestHandlerUtils.START_JOB)) {
+            adTaskManager.startDetector(detectorId, handler, user, transportService, listener);
+        } else if (rawPath.endsWith(RestHandlerUtils.STOP_JOB)) {
+            // Stop detector
+            adTaskManager.stopDetector(detectorId, handler, user, listener);
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/AnomalyDetectorRestApiIT.java
@@ -823,7 +823,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
-                "AnomalyDetector is not found with id",
+                "AnomalyDetector is not found",
                 () -> TestHelpers
                     .makeRequest(
                         client(),
@@ -892,6 +892,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
     }
 
     public void testStopNonExistingAdJobIndex() throws Exception {
+        AnomalyDetector detector = createRandomAnomalyDetector(true, true, client());
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
@@ -900,7 +901,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
                     .makeRequest(
                         client(),
                         "POST",
-                        TestHelpers.AD_BASE_DETECTORS_URI + "/" + randomAlphaOfLength(10) + "/_stop",
+                        TestHelpers.AD_BASE_DETECTORS_URI + "/" + detector.getDetectorId() + "/_stop",
                         ImmutableMap.of(),
                         "",
                         null
@@ -924,7 +925,7 @@ public class AnomalyDetectorRestApiIT extends AnomalyDetectorRestTestCase {
         TestHelpers
             .assertFailWith(
                 ResponseException.class,
-                "Anomaly detector job not exist",
+                "AnomalyDetector is not found",
                 () -> TestHelpers
                     .makeRequest(
                         client(),

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/HistoricalDetectorRestApiIT.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/rest/HistoricalDetectorRestApiIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.rest;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.AD_BASE_STATS_URI;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
+
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.xcontent.ToXContentObject;
+import org.elasticsearch.rest.RestStatus;
+
+import com.amazon.opendistroforelasticsearch.ad.HistoricalDetectorRestTestCase;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskProfile;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
+import com.google.common.collect.ImmutableMap;
+
+public class HistoricalDetectorRestApiIT extends HistoricalDetectorRestTestCase {
+
+    public void testHistoricalDetectorWorkflow() throws Exception {
+        // create historical detector
+        AnomalyDetector detector = createHistoricalDetector();
+        String detectorId = detector.getDetectorId();
+
+        // start historical detector
+        String taskId = startHistoricalDetector(detectorId);
+
+        // get task stats
+        Response statsResponse = TestHelpers.makeRequest(client(), "GET", AD_BASE_STATS_URI, ImmutableMap.of(), "", null);
+        String statsResult = EntityUtils.toString(statsResponse.getEntity());
+        assertTrue(statsResult.contains("\"ad_executing_batch_task_count\":1"));
+
+        // get task profile
+        ADTaskProfile adTaskProfile = getADTaskProfile(detectorId);
+        ADTask adTask = adTaskProfile.getAdTask();
+        assertEquals(taskId, adTask.getTaskId());
+        assertTrue(TestHelpers.historicalDetectorRunningStats.contains(adTask.getState()));
+
+        // get historical detector with AD task
+        ToXContentObject[] result = getHistoricalAnomalyDetector(detectorId, true, client());
+        AnomalyDetector parsedDetector = (AnomalyDetector) result[0];
+        AnomalyDetectorJob parsedJob = (AnomalyDetectorJob) result[1];
+        ADTask parsedADTask = (ADTask) result[2];
+        assertNull(parsedJob);
+        assertNotNull(parsedDetector);
+        assertNotNull(parsedADTask);
+        assertEquals(taskId, parsedADTask.getTaskId());
+
+        // stop historical detector
+        Response stopDetectorResponse = stopAnomalyDetector(detectorId, client());
+        assertEquals(RestStatus.OK, restStatus(stopDetectorResponse));
+
+        // get task profile
+        ADTaskProfile stoppedAdTaskProfile = getADTaskProfile(detectorId);
+        int i = 0;
+        while (TestHelpers.historicalDetectorRunningStats.contains(stoppedAdTaskProfile.getAdTask().getState()) && i < 10) {
+            stoppedAdTaskProfile = getADTaskProfile(detectorId);
+            Thread.sleep(2000);
+            i++;
+        }
+        ADTask stoppedAdTask = stoppedAdTaskProfile.getAdTask();
+        assertEquals(taskId, stoppedAdTask.getTaskId());
+        assertEquals(ADTaskState.STOPPED.name(), stoppedAdTask.getState());
+        updateClusterSettings(BATCH_TASK_PIECE_INTERVAL_SECONDS.getKey(), 1);
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManagerTests.java
@@ -40,6 +40,7 @@ import org.junit.Before;
 
 import com.amazon.opendistroforelasticsearch.ad.MemoryTracker;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.common.exception.DuplicateTaskException;
 import com.amazon.opendistroforelasticsearch.ad.common.exception.LimitExceededException;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
@@ -108,7 +109,7 @@ public class ADTaskCacheManagerTests extends ESTestCase {
                 adTask1.getDetectorId(),
                 adTask1.getDetector()
             );
-        IllegalArgumentException e2 = expectThrows(IllegalArgumentException.class, () -> adTaskCacheManager.put(adTask2));
+        DuplicateTaskException e2 = expectThrows(DuplicateTaskException.class, () -> adTaskCacheManager.put(adTask2));
         assertEquals("There is one task executing for detector", e2.getMessage());
     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManagerTests.java
@@ -80,7 +80,7 @@ public class ADTaskCacheManagerTests extends ESTestCase {
     public void testPutTask() throws IOException {
         when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
         ADTask adTask = TestHelpers.randomAdTask();
-        adTaskCacheManager.put(adTask);
+        adTaskCacheManager.add(adTask);
         assertEquals(1, adTaskCacheManager.size());
         assertTrue(adTaskCacheManager.contains(adTask.getTaskId()));
         assertTrue(adTaskCacheManager.containsTaskOfDetector(adTask.getDetectorId()));
@@ -96,9 +96,9 @@ public class ADTaskCacheManagerTests extends ESTestCase {
     public void testPutDuplicateTask() throws IOException {
         when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
         ADTask adTask1 = TestHelpers.randomAdTask();
-        adTaskCacheManager.put(adTask1);
+        adTaskCacheManager.add(adTask1);
         assertEquals(1, adTaskCacheManager.size());
-        DuplicateTaskException e1 = expectThrows(DuplicateTaskException.class, () -> adTaskCacheManager.put(adTask1));
+        DuplicateTaskException e1 = expectThrows(DuplicateTaskException.class, () -> adTaskCacheManager.add(adTask1));
         assertEquals(DETECTOR_IS_RUNNING, e1.getMessage());
 
         ADTask adTask2 = TestHelpers
@@ -110,7 +110,7 @@ public class ADTaskCacheManagerTests extends ESTestCase {
                 adTask1.getDetectorId(),
                 adTask1.getDetector()
             );
-        DuplicateTaskException e2 = expectThrows(DuplicateTaskException.class, () -> adTaskCacheManager.put(adTask2));
+        DuplicateTaskException e2 = expectThrows(DuplicateTaskException.class, () -> adTaskCacheManager.add(adTask2));
         assertEquals(DETECTOR_IS_RUNNING, e2.getMessage());
     }
 
@@ -118,7 +118,7 @@ public class ADTaskCacheManagerTests extends ESTestCase {
         when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(false);
         LimitExceededException exception = expectThrows(
             LimitExceededException.class,
-            () -> adTaskCacheManager.put(TestHelpers.randomAdTask())
+            () -> adTaskCacheManager.add(TestHelpers.randomAdTask())
         );
         assertEquals("No enough memory to run detector", exception.getMessage());
     }
@@ -126,7 +126,7 @@ public class ADTaskCacheManagerTests extends ESTestCase {
     public void testThresholdModelTrained() throws IOException {
         when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
         ADTask adTask = TestHelpers.randomAdTask();
-        adTaskCacheManager.put(adTask);
+        adTaskCacheManager.add(adTask);
         assertEquals(1, adTaskCacheManager.size());
         int size = adTaskCacheManager.addThresholdModelTrainingData(adTask.getTaskId(), randomDouble(), randomDouble());
         long cacheSize = adTaskCacheManager.trainingDataMemorySize(size);
@@ -139,7 +139,7 @@ public class ADTaskCacheManagerTests extends ESTestCase {
     public void testCancel() throws IOException {
         when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
         ADTask adTask = TestHelpers.randomAdTask();
-        adTaskCacheManager.put(adTask);
+        adTaskCacheManager.add(adTask);
         assertEquals(1, adTaskCacheManager.size());
         assertEquals(false, adTaskCacheManager.isCancelled(adTask.getTaskId()));
         String cancelReason = randomAlphaOfLength(10);
@@ -165,10 +165,10 @@ public class ADTaskCacheManagerTests extends ESTestCase {
 
     public void testExceedRunningTaskLimit() throws IOException {
         when(memoryTracker.canAllocateReserved(anyString(), anyLong())).thenReturn(true);
-        adTaskCacheManager.put(TestHelpers.randomAdTask());
-        adTaskCacheManager.put(TestHelpers.randomAdTask());
+        adTaskCacheManager.add(TestHelpers.randomAdTask());
+        adTaskCacheManager.add(TestHelpers.randomAdTask());
         assertEquals(2, adTaskCacheManager.size());
-        LimitExceededException e = expectThrows(LimitExceededException.class, () -> adTaskCacheManager.put(TestHelpers.randomAdTask()));
+        LimitExceededException e = expectThrows(LimitExceededException.class, () -> adTaskCacheManager.add(TestHelpers.randomAdTask()));
         assertEquals("Can't run more than 2 historical detectors per data node", e.getMessage());
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskCacheManagerTests.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.ad.task;
 
 import static com.amazon.opendistroforelasticsearch.ad.MemoryTracker.Origin.HISTORICAL_SINGLE_ENTITY_DETECTOR;
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -97,8 +98,8 @@ public class ADTaskCacheManagerTests extends ESTestCase {
         ADTask adTask1 = TestHelpers.randomAdTask();
         adTaskCacheManager.put(adTask1);
         assertEquals(1, adTaskCacheManager.size());
-        IllegalArgumentException e1 = expectThrows(IllegalArgumentException.class, () -> adTaskCacheManager.put(adTask1));
-        assertEquals("AD task is already running", e1.getMessage());
+        DuplicateTaskException e1 = expectThrows(DuplicateTaskException.class, () -> adTaskCacheManager.put(adTask1));
+        assertEquals(DETECTOR_IS_RUNNING, e1.getMessage());
 
         ADTask adTask2 = TestHelpers
             .randomAdTask(
@@ -110,7 +111,7 @@ public class ADTaskCacheManagerTests extends ESTestCase {
                 adTask1.getDetector()
             );
         DuplicateTaskException e2 = expectThrows(DuplicateTaskException.class, () -> adTaskCacheManager.put(adTask2));
-        assertEquals("There is one task executing for detector", e2.getMessage());
+        assertEquals(DETECTOR_IS_RUNNING, e2.getMessage());
     }
 
     public void testPutTaskWithMemoryExceedLimit() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManagerTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManagerTests.java
@@ -19,6 +19,7 @@ import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomDetecto
 import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomFeature;
 import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomUser;
 import static com.amazon.opendistroforelasticsearch.ad.constant.CommonName.ANOMALY_RESULT_INDEX_ALIAS;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -42,18 +43,24 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 
 import com.amazon.opendistroforelasticsearch.ad.ADUnitTestCase;
+import com.amazon.opendistroforelasticsearch.ad.cluster.HashRing;
 import com.amazon.opendistroforelasticsearch.ad.indices.AnomalyDetectionIndices;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
 import com.amazon.opendistroforelasticsearch.ad.transport.AnomalyDetectorJobResponse;
+import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 import com.google.common.collect.ImmutableList;
 
 public class ADTaskManagerTests extends ADUnitTestCase {
 
     private Settings settings;
     private Client client;
+    private ClusterService clusterService;
     private ClusterSettings clusterSettings;
+    private DiscoveryNodeFilterer nodeFilter;
     private AnomalyDetectionIndices anomalyDetectionIndices;
+    private ADTaskCacheManager adTaskCacheManager;
+    private HashRing hashRing;
     private ADTaskManager adTaskManager;
 
     private Instant startTime;
@@ -67,15 +74,32 @@ public class ADTaskManagerTests extends ADUnitTestCase {
         startTime = now.minus(10, ChronoUnit.DAYS);
         endTime = now.minus(1, ChronoUnit.DAYS);
 
-        settings = Settings.builder().put(MAX_OLD_AD_TASK_DOCS_PER_DETECTOR.getKey(), 2).build();
+        settings = Settings
+            .builder()
+            .put(MAX_OLD_AD_TASK_DOCS_PER_DETECTOR.getKey(), 2)
+            .put(BATCH_TASK_PIECE_INTERVAL_SECONDS.getKey(), 1)
+            .build();
 
-        clusterSettings = clusterSetting(settings, MAX_OLD_AD_TASK_DOCS_PER_DETECTOR);
+        clusterSettings = clusterSetting(settings, MAX_OLD_AD_TASK_DOCS_PER_DETECTOR, BATCH_TASK_PIECE_INTERVAL_SECONDS);
 
-        final ClusterService clusterService = new ClusterService(settings, clusterSettings, null);
+        clusterService = new ClusterService(settings, clusterSettings, null);
 
         client = mock(Client.class);
+        nodeFilter = mock(DiscoveryNodeFilterer.class);
         anomalyDetectionIndices = mock(AnomalyDetectionIndices.class);
-        adTaskManager = new ADTaskManager(settings, clusterService, client, NamedXContentRegistry.EMPTY, anomalyDetectionIndices);
+        adTaskCacheManager = mock(ADTaskCacheManager.class);
+        hashRing = mock(HashRing.class);
+
+        adTaskManager = new ADTaskManager(
+            settings,
+            clusterService,
+            client,
+            NamedXContentRegistry.EMPTY,
+            anomalyDetectionIndices,
+            nodeFilter,
+            hashRing,
+            adTaskCacheManager
+        );
 
         listener = spy(new ActionListener<AnomalyDetectorJobResponse>() {
             @Override
@@ -100,7 +124,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
             randomAlphaOfLength(5)
         );
 
-        adTaskManager.createADTaskIndex(detector, randomUser(), listener);
+        adTaskManager.startHistoricalDetector(detector, randomUser(), listener);
         verify(listener, times(1)).onFailure(exceptionCaptor.capture());
         assertEquals(
             "Create index .opendistro-anomaly-detection-state with mappings not acknowledged",
@@ -122,7 +146,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
             randomAlphaOfLength(5)
         );
 
-        adTaskManager.createADTaskIndex(detector, randomUser(), listener);
+        adTaskManager.startHistoricalDetector(detector, randomUser(), listener);
         verify(listener, never()).onFailure(any());
     }
 
@@ -141,7 +165,7 @@ public class ADTaskManagerTests extends ADUnitTestCase {
             randomAlphaOfLength(5)
         );
 
-        adTaskManager.createADTaskIndex(detector, randomUser(), listener);
+        adTaskManager.startHistoricalDetector(detector, randomUser(), listener);
         verify(listener, times(1)).onFailure(exceptionCaptor.capture());
         assertEquals(error, exceptionCaptor.getValue().getMessage());
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADCancelTaskTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomDiscoveryNode;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import com.amazon.opendistroforelasticsearch.ad.ADUnitTestCase;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskCancellationState;
+import com.google.common.collect.ImmutableList;
+
+public class ADCancelTaskTests extends ADUnitTestCase {
+
+    public void testADCancelTaskRequest() throws IOException {
+        ADCancelTaskRequest request = new ADCancelTaskRequest(randomAlphaOfLength(5), randomAlphaOfLength(5), randomDiscoveryNode());
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        request.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        ADCancelTaskRequest parsedRequest = new ADCancelTaskRequest(input);
+        assertEquals(request.getDetectorId(), parsedRequest.getDetectorId());
+        assertEquals(request.getUserName(), parsedRequest.getUserName());
+    }
+
+    public void testInvalidADCancelTaskRequest() {
+        ADCancelTaskRequest request = new ADCancelTaskRequest(null, null, randomDiscoveryNode());
+        ActionRequestValidationException validationException = request.validate();
+        assertTrue(validationException.getMessage().contains(CommonErrorMessages.AD_ID_MISSING_MSG));
+    }
+
+    public void testSerializeResponse() throws IOException {
+        ADTaskCancellationState state = ADTaskCancellationState.CANCELLED;
+        ADCancelTaskNodeResponse nodeResponse = new ADCancelTaskNodeResponse(randomDiscoveryNode(), state);
+
+        List<ADCancelTaskNodeResponse> nodes = ImmutableList.of(nodeResponse);
+        ADCancelTaskResponse response = new ADCancelTaskResponse(new ClusterName("test"), nodes, ImmutableList.of());
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeNodesTo(output, nodes);
+        StreamInput input = output.bytes().streamInput();
+
+        List<ADCancelTaskNodeResponse> adCancelTaskNodeResponses = response.readNodesFrom(input);
+        assertEquals(1, adCancelTaskNodeResponses.size());
+        assertEquals(state, adCancelTaskNodeResponses.get(0).getState());
+
+        BytesStreamOutput output2 = new BytesStreamOutput();
+        response.writeTo(output2);
+        StreamInput input2 = output2.bytes().streamInput();
+
+        ADCancelTaskResponse response2 = new ADCancelTaskResponse(input2);
+        assertEquals(1, response2.getNodes().size());
+        assertEquals(state, response2.getNodes().get(0).getState());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTests.java
@@ -57,18 +57,25 @@ public class ADTaskProfileTests extends ESSingleNodeTestCase {
         request.writeTo(output);
         NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
         ADTaskProfileRequest parsedRequest = new ADTaskProfileRequest(input);
-        assertEquals(request.getAdTaskId(), parsedRequest.getAdTaskId());
+        assertEquals(request.getDetectorId(), parsedRequest.getDetectorId());
     }
 
     public void testInvalidADTaskProfileRequest() {
         DiscoveryNode node = new DiscoveryNode(UUIDs.randomBase64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
         ADTaskProfileRequest request = new ADTaskProfileRequest(null, node);
         ActionRequestValidationException validationException = request.validate();
-        assertTrue(validationException.getMessage().contains(CommonErrorMessages.AD_TASK_ID_MISSING));
+        assertTrue(validationException.getMessage().contains(CommonErrorMessages.AD_ID_MISSING_MSG));
     }
 
     public void testADTaskProfileNodeResponse() throws IOException {
-        ADTaskProfile adTaskProfile = new ADTaskProfile(randomInt(), randomLong(), randomBoolean(), randomInt(), randomAlphaOfLength(5));
+        ADTaskProfile adTaskProfile = new ADTaskProfile(
+            randomInt(),
+            randomLong(),
+            randomBoolean(),
+            randomInt(),
+            randomLong(),
+            randomAlphaOfLength(5)
+        );
         ADTaskProfileNodeResponse response = new ADTaskProfileNodeResponse(randomDiscoveryNode(), adTaskProfile);
         testADTaskProfileResponse(response);
     }
@@ -79,7 +86,14 @@ public class ADTaskProfileTests extends ESSingleNodeTestCase {
     }
 
     public void testADTaskProfileNodeResponseReadMethod() throws IOException {
-        ADTaskProfile adTaskProfile = new ADTaskProfile(randomInt(), randomLong(), randomBoolean(), randomInt(), randomAlphaOfLength(5));
+        ADTaskProfile adTaskProfile = new ADTaskProfile(
+            randomInt(),
+            randomLong(),
+            randomBoolean(),
+            randomInt(),
+            randomLong(),
+            randomAlphaOfLength(5)
+        );
         ADTaskProfileNodeResponse response = new ADTaskProfileNodeResponse(randomDiscoveryNode(), adTaskProfile);
         testADTaskProfileResponse(response);
     }
@@ -109,6 +123,7 @@ public class ADTaskProfileTests extends ESSingleNodeTestCase {
             randomLong(),
             randomBoolean(),
             randomInt(),
+            randomLong(),
             randomAlphaOfLength(5)
         );
         ADTaskProfileNodeResponse nodeResponse = new ADTaskProfileNodeResponse(node, profile);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTests.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.TestHelpers.randomDiscoveryNode;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskProfile;
+import com.google.common.collect.ImmutableList;
+
+public class ADTaskProfileTests extends ESSingleNodeTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return getInstanceFromNode(NamedWriteableRegistry.class);
+    }
+
+    public void testADTaskProfileRequest() throws IOException {
+        ADTaskProfileRequest request = new ADTaskProfileRequest(randomAlphaOfLength(5), randomDiscoveryNode());
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        request.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        ADTaskProfileRequest parsedRequest = new ADTaskProfileRequest(input);
+        assertEquals(request.getAdTaskId(), parsedRequest.getAdTaskId());
+    }
+
+    public void testInvalidADTaskProfileRequest() {
+        DiscoveryNode node = new DiscoveryNode(UUIDs.randomBase64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+        ADTaskProfileRequest request = new ADTaskProfileRequest(null, node);
+        ActionRequestValidationException validationException = request.validate();
+        assertTrue(validationException.getMessage().contains(CommonErrorMessages.AD_TASK_ID_MISSING));
+    }
+
+    public void testADTaskProfileNodeResponse() throws IOException {
+        ADTaskProfile adTaskProfile = new ADTaskProfile(randomInt(), randomLong(), randomBoolean(), randomInt(), randomAlphaOfLength(5));
+        ADTaskProfileNodeResponse response = new ADTaskProfileNodeResponse(randomDiscoveryNode(), adTaskProfile);
+        testADTaskProfileResponse(response);
+    }
+
+    public void testADTaskProfileNodeResponseWithNullProfile() throws IOException {
+        ADTaskProfileNodeResponse response = new ADTaskProfileNodeResponse(randomDiscoveryNode(), null);
+        testADTaskProfileResponse(response);
+    }
+
+    public void testADTaskProfileNodeResponseReadMethod() throws IOException {
+        ADTaskProfile adTaskProfile = new ADTaskProfile(randomInt(), randomLong(), randomBoolean(), randomInt(), randomAlphaOfLength(5));
+        ADTaskProfileNodeResponse response = new ADTaskProfileNodeResponse(randomDiscoveryNode(), adTaskProfile);
+        testADTaskProfileResponse(response);
+    }
+
+    public void testADTaskProfileNodeResponseReadMethodWithNullProfile() throws IOException {
+        ADTaskProfileNodeResponse response = new ADTaskProfileNodeResponse(randomDiscoveryNode(), null);
+        testADTaskProfileResponse(response);
+    }
+
+    private void testADTaskProfileResponse(ADTaskProfileNodeResponse response) throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        ADTaskProfileNodeResponse parsedResponse = ADTaskProfileNodeResponse.readNodeResponse(input);
+        if (response.getAdTaskProfile() != null) {
+            assertTrue(response.getAdTaskProfile().equals(parsedResponse.getAdTaskProfile()));
+        } else {
+            assertNull(parsedResponse.getAdTaskProfile());
+        }
+    }
+
+    public void testSerializeResponse() throws IOException {
+        DiscoveryNode node = randomDiscoveryNode();
+        ADTaskProfile profile = new ADTaskProfile(
+            TestHelpers.randomAdTask(),
+            randomInt(),
+            randomLong(),
+            randomBoolean(),
+            randomInt(),
+            randomAlphaOfLength(5)
+        );
+        ADTaskProfileNodeResponse nodeResponse = new ADTaskProfileNodeResponse(node, profile);
+        ImmutableList<ADTaskProfileNodeResponse> nodes = ImmutableList.of(nodeResponse);
+        ADTaskProfileResponse response = new ADTaskProfileResponse(new ClusterName("test"), nodes, ImmutableList.of());
+
+        BytesStreamOutput output = new BytesStreamOutput();
+        response.writeNodesTo(output, nodes);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+
+        List<ADTaskProfileNodeResponse> adTaskProfileNodeResponses = response.readNodesFrom(input);
+        assertEquals(1, adTaskProfileNodeResponses.size());
+        assertEquals(profile, adTaskProfileNodeResponses.get(0).getAdTaskProfile());
+
+        BytesStreamOutput output2 = new BytesStreamOutput();
+        response.writeTo(output2);
+        NamedWriteableAwareStreamInput input2 = new NamedWriteableAwareStreamInput(output2.bytes().streamInput(), writableRegistry());
+
+        ADTaskProfileResponse response2 = new ADTaskProfileResponse(input2);
+        assertEquals(1, response2.getNodes().size());
+        assertEquals(profile, response2.getNodes().get(0).getAdTaskProfile());
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ADTaskProfileTransportActionTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
+import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.HistoricalDetectorIntegTestCase;
+
+public class ADTaskProfileTransportActionTests extends HistoricalDetectorIntegTestCase {
+
+    private Instant startTime;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        startTime = Instant.now().minus(10, ChronoUnit.DAYS);
+        ingestTestData(testIndex, startTime, detectionIntervalInMinutes, "error", 2000);
+        createDetectorIndex();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings
+            .builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(BATCH_TASK_PIECE_INTERVAL_SECONDS.getKey(), 1)
+            .put(MAX_BATCH_TASK_PER_NODE.getKey(), 1)
+            .build();
+    }
+
+    public void testProfile() {
+
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
@@ -15,10 +15,13 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages.DETECTOR_ALREADY_RUNNING;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.PROFILE;
 import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.START_JOB;
+import static com.amazon.opendistroforelasticsearch.ad.util.RestHandlerUtils.STOP_JOB;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
@@ -29,29 +32,38 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.junit.After;
 import org.junit.Before;
 
 import com.amazon.opendistroforelasticsearch.ad.HistoricalDetectorIntegTestCase;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonName;
+import com.amazon.opendistroforelasticsearch.ad.mock.plugin.MockReindexPlugin;
+import com.amazon.opendistroforelasticsearch.ad.mock.transport.MockAnomalyDetectorJobAction;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskProfile;
 import com.amazon.opendistroforelasticsearch.ad.model.ADTaskState;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectionDateRange;
-import com.amazon.opendistroforelasticsearch.ad.plugin.MockReindexPlugin;
+import com.amazon.opendistroforelasticsearch.ad.stats.StatNames;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2)
 public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIntegTestCase {
@@ -86,18 +98,14 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
         final ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>();
         plugins.add(MockReindexPlugin.class);
         plugins.addAll(super.getMockPlugins());
+        plugins.remove(MockTransportService.TestPlugin.class);
         return Collections.unmodifiableList(plugins);
     }
 
     public void testDetectorIndexNotFound() {
         deleteDetectorIndex();
         String detectorId = randomAlphaOfLength(5);
-        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
-            detectorId,
-            UNASSIGNED_SEQ_NO,
-            UNASSIGNED_PRIMARY_TERM,
-            START_JOB
-        );
+        AnomalyDetectorJobRequest request = startDetectorJobRequest(detectorId);
         IndexNotFoundException exception = expectThrows(
             IndexNotFoundException.class,
             () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(3000)
@@ -107,20 +115,22 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
 
     public void testDetectorNotFound() {
         String detectorId = randomAlphaOfLength(5);
-        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
-            detectorId,
-            UNASSIGNED_SEQ_NO,
-            UNASSIGNED_PRIMARY_TERM,
-            START_JOB
-        );
+        AnomalyDetectorJobRequest request = startDetectorJobRequest(detectorId);
         ElasticsearchStatusException exception = expectThrows(
             ElasticsearchStatusException.class,
-            () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(3000)
+            () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000)
         );
         assertTrue(exception.getMessage().contains("AnomalyDetector is not found"));
     }
 
     public void testValidHistoricalDetector() throws IOException, InterruptedException {
+        ADTask adTask = startHistoricalDetector();
+        Thread.sleep(10000);
+        ADTask finishedTask = getADTask(adTask.getTaskId());
+        assertEquals(ADTaskState.FINISHED.name(), finishedTask.getState());
+    }
+
+    private ADTask startHistoricalDetector() throws IOException {
         DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
         AnomalyDetector detector = TestHelpers
             .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
@@ -132,9 +142,26 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
             START_JOB
         );
         AnomalyDetectorJobResponse response = client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
-        Thread.sleep(10000);
-        GetResponse doc = getDoc(CommonName.DETECTION_STATE_INDEX, response.getId());
-        assertEquals(ADTaskState.FINISHED.name(), doc.getSourceAsMap().get(ADTask.STATE_FIELD));
+        return getADTask(response.getId());
+    }
+
+    public void testStartHistoricalDetectorWithUser() throws IOException, InterruptedException {
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
+        String detectorId = createDetector(detector);
+        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
+            detectorId,
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            START_JOB
+        );
+        Client nodeClient = getDataNodeClient();
+        if (nodeClient != null) {
+            AnomalyDetectorJobResponse response = nodeClient.execute(MockAnomalyDetectorJobAction.INSTANCE, request).actionGet(100000);
+            ADTask adTask = getADTask(response.getId());
+            assertNotNull(adTask.getStartedBy());
+        }
     }
 
     public void testRunMultipleTasksForHistoricalDetector() throws IOException, InterruptedException {
@@ -142,23 +169,42 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
         AnomalyDetector detector = TestHelpers
             .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
         String detectorId = createDetector(detector);
-        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
-            detectorId,
-            UNASSIGNED_SEQ_NO,
-            UNASSIGNED_PRIMARY_TERM,
-            START_JOB
-        );
+        AnomalyDetectorJobRequest request = startDetectorJobRequest(detectorId);
         AnomalyDetectorJobResponse response = client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
         assertNotNull(response.getId());
         ElasticsearchStatusException exception = expectThrows(
             ElasticsearchStatusException.class,
             () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000)
         );
-        assertTrue(exception.getMessage().contains("Detector is already running"));
+        assertTrue(exception.getMessage().contains(DETECTOR_ALREADY_RUNNING));
+        assertEquals(DETECTOR_ALREADY_RUNNING, exception.getMessage());
+        Thread.sleep(10000);
+        List<ADTask> adTasks = searchADTasks(detectorId, null, 100);
+        assertEquals(1, adTasks.size());
+        assertEquals(ADTaskState.FINISHED.name(), adTasks.get(0).getState());
     }
 
-    public void testCleanOldTaskDocs() throws IOException, InterruptedException {
-        updateTransientSettings(ImmutableMap.of(BATCH_TASK_PIECE_INTERVAL_SECONDS.getKey(), 1));
+    public void testRaceConditionByStartingMultipleTasks() throws IOException, InterruptedException {
+        DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
+        String detectorId = createDetector(detector);
+        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
+            detectorId,
+            UNASSIGNED_SEQ_NO,
+            UNASSIGNED_PRIMARY_TERM,
+            START_JOB
+        );
+        client().execute(AnomalyDetectorJobAction.INSTANCE, request);
+        client().execute(AnomalyDetectorJobAction.INSTANCE, request);
+
+        Thread.sleep(3000);
+        List<ADTask> adTasks = searchADTasks(detectorId, null, 100);
+        assertEquals(1, adTasks.size());
+        assertTrue(adTasks.get(0).getLatest());
+    }
+
+    public void testCleanOldTaskDocs() throws InterruptedException, IOException {
         DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
         AnomalyDetector detector = TestHelpers
             .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
@@ -174,6 +220,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
         assertEquals(states.size(), count);
 
         AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(detectorId, randomLong(), randomLong(), START_JOB);
+
         AtomicReference<AnomalyDetectorJobResponse> response = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
         client().execute(AnomalyDetectorJobAction.INSTANCE, request, ActionListener.wrap(r -> {
@@ -187,22 +234,31 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
         assertEquals(maxOldAdTaskDocsPerDetector + 1, count);
     }
 
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        // delete index will clear search context, this can avoid in-flight contexts error
+        deleteIndexIfExists(AnomalyDetector.ANOMALY_DETECTORS_INDEX);
+        deleteIndexIfExists(CommonName.DETECTION_STATE_INDEX);
+    }
+
     public void testStartRealtimeDetector() throws IOException {
-        AnomalyDetector detector = TestHelpers
-            .randomDetector(null, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
-        String detectorId = createDetector(detector);
-        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
-            detectorId,
-            UNASSIGNED_SEQ_NO,
-            UNASSIGNED_PRIMARY_TERM,
-            START_JOB
-        );
-        AnomalyDetectorJobResponse response = client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
-        assertEquals(detectorId, response.getId());
+        String detectorId = startRealtimeDetector();
         GetResponse doc = getDoc(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, detectorId);
         AnomalyDetectorJob job = toADJob(doc);
         assertTrue(job.isEnabled());
         assertEquals(detectorId, job.getName());
+    }
+
+    private String startRealtimeDetector() throws IOException {
+        AnomalyDetector detector = TestHelpers
+            .randomDetector(null, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
+        String detectorId = createDetector(detector);
+        AnomalyDetectorJobRequest request = startDetectorJobRequest(detectorId);
+        AnomalyDetectorJobResponse response = client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
+        assertEquals(detectorId, response.getId());
+        return response.getId();
     }
 
     public void testRealtimeDetectorWithoutFeature() throws IOException {
@@ -242,16 +298,99 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
 
     private void testInvalidDetector(AnomalyDetector detector, String error) throws IOException {
         String detectorId = createDetector(detector);
-        AnomalyDetectorJobRequest request = new AnomalyDetectorJobRequest(
-            detectorId,
-            UNASSIGNED_SEQ_NO,
-            UNASSIGNED_PRIMARY_TERM,
-            START_JOB
-        );
+        AnomalyDetectorJobRequest request = startDetectorJobRequest(detectorId);
         ElasticsearchStatusException exception = expectThrows(
             ElasticsearchStatusException.class,
             () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000)
         );
         assertEquals(error, exception.getMessage());
+    }
+
+    private AnomalyDetectorJobRequest startDetectorJobRequest(String detectorId) {
+        return new AnomalyDetectorJobRequest(detectorId, UNASSIGNED_SEQ_NO, UNASSIGNED_PRIMARY_TERM, START_JOB);
+    }
+
+    private AnomalyDetectorJobRequest stopDetectorJobRequest(String detectorId) {
+        return new AnomalyDetectorJobRequest(detectorId, UNASSIGNED_SEQ_NO, UNASSIGNED_PRIMARY_TERM, STOP_JOB);
+    }
+
+    public void testStopRealtimeDetector() throws IOException {
+        String detectorId = startRealtimeDetector();
+        AnomalyDetectorJobRequest request = stopDetectorJobRequest(detectorId);
+        client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
+        GetResponse doc = getDoc(AnomalyDetectorJob.ANOMALY_DETECTOR_JOB_INDEX, detectorId);
+        AnomalyDetectorJob job = toADJob(doc);
+        assertFalse(job.isEnabled());
+        assertEquals(detectorId, job.getName());
+    }
+
+    public void testStopHistoricalDetector() throws IOException, InterruptedException {
+        ADTask adTask = startHistoricalDetector();
+        assertEquals(ADTaskState.INIT.name(), adTask.getState());
+        AnomalyDetectorJobRequest request = stopDetectorJobRequest(adTask.getDetectorId());
+        client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
+        Thread.sleep(10000);
+        ADTask stoppedTask = getADTask(adTask.getTaskId());
+        assertEquals(ADTaskState.STOPPED.name(), stoppedTask.getState());
+        assertEquals(0, getExecutingADTask());
+    }
+
+    public void testProfileHistoricalDetector() throws IOException, InterruptedException {
+        ADTask adTask = startHistoricalDetector();
+        GetAnomalyDetectorRequest request = taskProfileRequest(adTask.getDetectorId());
+        GetAnomalyDetectorResponse response = client().execute(GetAnomalyDetectorAction.INSTANCE, request).actionGet(10000);
+        assertNotNull(response.getDetectorProfile().getAdTaskProfile());
+
+        ADTask finishedTask = getADTask(adTask.getTaskId());
+        int i = 0;
+        while (TestHelpers.historicalDetectorRunningStats.contains(finishedTask.getState()) && i < 10) {
+            finishedTask = getADTask(adTask.getTaskId());
+            Thread.sleep(2000);
+            i++;
+        }
+        assertEquals(ADTaskState.FINISHED.name(), finishedTask.getState());
+
+        response = client().execute(GetAnomalyDetectorAction.INSTANCE, request).actionGet(10000);
+        assertNull(response.getDetectorProfile().getAdTaskProfile().getNodeId());
+        ADTask profileAdTask = response.getDetectorProfile().getAdTaskProfile().getAdTask();
+        assertEquals(finishedTask.getTaskId(), profileAdTask.getTaskId());
+        assertEquals(finishedTask.getDetectorId(), profileAdTask.getDetectorId());
+        assertEquals(finishedTask.getDetector(), profileAdTask.getDetector());
+        assertEquals(finishedTask.getState(), profileAdTask.getState());
+    }
+
+    public void testProfileWithMultipleRunningTask() throws IOException {
+        ADTask adTask1 = startHistoricalDetector();
+        ADTask adTask2 = startHistoricalDetector();
+
+        GetAnomalyDetectorRequest request1 = taskProfileRequest(adTask1.getDetectorId());
+        GetAnomalyDetectorRequest request2 = taskProfileRequest(adTask2.getDetectorId());
+        GetAnomalyDetectorResponse response1 = client().execute(GetAnomalyDetectorAction.INSTANCE, request1).actionGet(10000);
+        GetAnomalyDetectorResponse response2 = client().execute(GetAnomalyDetectorAction.INSTANCE, request2).actionGet(10000);
+        ADTaskProfile taskProfile1 = response1.getDetectorProfile().getAdTaskProfile();
+        ADTaskProfile taskProfile2 = response2.getDetectorProfile().getAdTaskProfile();
+        assertNotNull(taskProfile1.getNodeId());
+        assertNotNull(taskProfile2.getNodeId());
+        assertNotEquals(taskProfile1.getNodeId(), taskProfile2.getNodeId());
+    }
+
+    private GetAnomalyDetectorRequest taskProfileRequest(String detectorId) throws IOException {
+        return new GetAnomalyDetectorRequest(detectorId, Versions.MATCH_ANY, false, false, "", PROFILE, true, null);
+    }
+
+    private long getExecutingADTask() {
+        ADStatsRequest adStatsRequest = new ADStatsRequest(getDataNodesArray());
+        Set<String> validStats = ImmutableSet.of(StatNames.AD_EXECUTING_BATCH_TASK_COUNT.getName());
+        adStatsRequest.addAll(validStats);
+        StatsAnomalyDetectorResponse statsResponse = client().execute(StatsAnomalyDetectorAction.INSTANCE, adStatsRequest).actionGet(5000);
+        AtomicLong totalExecutingTask = new AtomicLong(0);
+        statsResponse
+            .getAdStatsResponse()
+            .getADStatsNodesResponse()
+            .getNodes()
+            .forEach(
+                node -> { totalExecutingTask.getAndAdd((Long) node.getStatsMap().get(StatNames.AD_EXECUTING_BATCH_TASK_COUNT.getName())); }
+            );
+        return totalExecutingTask.get();
     }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
@@ -15,7 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.ad.transport;
 
-import static com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages.DETECTOR_ALREADY_RUNNING;
+import static com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages.DETECTOR_IS_RUNNING;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.BATCH_TASK_PIECE_INTERVAL_SECONDS;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_BATCH_TASK_PER_NODE;
 import static com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings.MAX_OLD_AD_TASK_DOCS_PER_DETECTOR;
@@ -176,8 +176,8 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
             ElasticsearchStatusException.class,
             () -> client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000)
         );
-        assertTrue(exception.getMessage().contains(DETECTOR_ALREADY_RUNNING));
-        assertEquals(DETECTOR_ALREADY_RUNNING, exception.getMessage());
+        assertTrue(exception.getMessage().contains(DETECTOR_IS_RUNNING));
+        assertEquals(DETECTOR_IS_RUNNING, exception.getMessage());
         Thread.sleep(10000);
         List<ADTask> adTasks = searchADTasks(detectorId, null, 100);
         assertEquals(1, adTasks.size());
@@ -198,10 +198,12 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
         client().execute(AnomalyDetectorJobAction.INSTANCE, request);
         client().execute(AnomalyDetectorJobAction.INSTANCE, request);
 
-        Thread.sleep(3000);
+        Thread.sleep(5000);
         List<ADTask> adTasks = searchADTasks(detectorId, null, 100);
+
         assertEquals(1, adTasks.size());
         assertTrue(adTasks.get(0).getLatest());
+        assertNotEquals(ADTaskState.FAILED.name(), adTasks.get(0).getState());
     }
 
     public void testCleanOldTaskDocs() throws InterruptedException, IOException {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.InternalSettingsPlugin;
+
+import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.google.common.collect.ImmutableMap;
+
+public class ForwardADTaskTests extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(InternalSettingsPlugin.class, AnomalyDetectorPlugin.class);
+    }
+
+    @Override
+    protected NamedWriteableRegistry writableRegistry() {
+        return getInstanceFromNode(NamedWriteableRegistry.class);
+    }
+
+    public void testForwardADTaskRequest() throws IOException {
+        ForwardADTaskRequest request = new ForwardADTaskRequest(
+            TestHelpers.randomAnomalyDetector(ImmutableMap.of(), Instant.now()),
+            TestHelpers.randomUser()
+        );
+        testForwardADTaskRequest(request);
+    }
+
+    public void testForwardADTaskRequestWithoutUser() throws IOException {
+        ForwardADTaskRequest request = new ForwardADTaskRequest(TestHelpers.randomAnomalyDetector(ImmutableMap.of(), Instant.now()), null);
+        testForwardADTaskRequest(request);
+    }
+
+    public void testInvalidForwardADTaskRequest() {
+        ForwardADTaskRequest request = new ForwardADTaskRequest(null, TestHelpers.randomUser());
+
+        ActionRequestValidationException exception = request.validate();
+        assertTrue(exception.getMessage().contains(CommonErrorMessages.DETECTOR_MISSING));
+    }
+
+    private void testForwardADTaskRequest(ForwardADTaskRequest request) throws IOException {
+        BytesStreamOutput output = new BytesStreamOutput();
+        request.writeTo(output);
+        NamedWriteableAwareStreamInput input = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), writableRegistry());
+        ForwardADTaskRequest parsedRequest = new ForwardADTaskRequest(input);
+        if (request.getUser() != null) {
+            assertTrue(request.getUser().equals(parsedRequest.getUser()));
+        } else {
+            assertNull(parsedRequest.getUser());
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/ForwardADTaskTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.test.InternalSettingsPlugin;
 import com.amazon.opendistroforelasticsearch.ad.AnomalyDetectorPlugin;
 import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
+import com.amazon.opendistroforelasticsearch.ad.model.ADTaskAction;
 import com.google.common.collect.ImmutableMap;
 
 public class ForwardADTaskTests extends ESSingleNodeTestCase {
@@ -47,18 +48,23 @@ public class ForwardADTaskTests extends ESSingleNodeTestCase {
     public void testForwardADTaskRequest() throws IOException {
         ForwardADTaskRequest request = new ForwardADTaskRequest(
             TestHelpers.randomAnomalyDetector(ImmutableMap.of(), Instant.now()),
-            TestHelpers.randomUser()
+            TestHelpers.randomUser(),
+            ADTaskAction.START
         );
         testForwardADTaskRequest(request);
     }
 
     public void testForwardADTaskRequestWithoutUser() throws IOException {
-        ForwardADTaskRequest request = new ForwardADTaskRequest(TestHelpers.randomAnomalyDetector(ImmutableMap.of(), Instant.now()), null);
+        ForwardADTaskRequest request = new ForwardADTaskRequest(
+            TestHelpers.randomAnomalyDetector(ImmutableMap.of(), Instant.now()),
+            null,
+            ADTaskAction.START
+        );
         testForwardADTaskRequest(request);
     }
 
     public void testInvalidForwardADTaskRequest() {
-        ForwardADTaskRequest request = new ForwardADTaskRequest(null, TestHelpers.randomUser());
+        ForwardADTaskRequest request = new ForwardADTaskRequest(null, TestHelpers.randomUser(), ADTaskAction.START);
 
         ActionRequestValidationException exception = request.validate();
         assertTrue(exception.getMessage().contains(CommonErrorMessages.DETECTOR_MISSING));

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorActionTests.java
@@ -29,6 +29,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import com.amazon.opendistroforelasticsearch.ad.model.ADTask;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
 import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetectorJob;
 import com.amazon.opendistroforelasticsearch.ad.model.DetectorProfile;
@@ -44,7 +45,7 @@ public class GetAnomalyDetectorActionTests {
     @Test
     public void testGetRequest() throws IOException {
         BytesStreamOutput out = new BytesStreamOutput();
-        GetAnomalyDetectorRequest request = new GetAnomalyDetectorRequest("1234", 4321, false, "nonempty", "", false, null);
+        GetAnomalyDetectorRequest request = new GetAnomalyDetectorRequest("1234", 4321, false, false, "nonempty", "", false, null);
         request.writeTo(out);
         StreamInput input = out.bytes().streamInput();
         GetAnomalyDetectorRequest newRequest = new GetAnomalyDetectorRequest(input);
@@ -65,6 +66,8 @@ public class GetAnomalyDetectorActionTests {
             2345,
             detector,
             detectorJob,
+            false,
+            Mockito.mock(ADTask.class),
             false,
             RestStatus.OK,
             Mockito.mock(DetectorProfile.class),

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/GetAnomalyDetectorTests.java
@@ -44,6 +44,7 @@ import org.junit.BeforeClass;
 import com.amazon.opendistroforelasticsearch.ad.AbstractADTest;
 import com.amazon.opendistroforelasticsearch.ad.constant.CommonErrorMessages;
 import com.amazon.opendistroforelasticsearch.ad.settings.AnomalyDetectorSettings;
+import com.amazon.opendistroforelasticsearch.ad.task.ADTaskManager;
 import com.amazon.opendistroforelasticsearch.ad.util.DiscoveryNodeFilterer;
 
 public class GetAnomalyDetectorTests extends AbstractADTest {
@@ -58,6 +59,7 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
     private String typeStr;
     private String rawPath;
     private PlainActionFuture<GetAnomalyDetectorResponse> future;
+    private ADTaskManager adTaskManager;
 
     @BeforeClass
     public static void setUpBeforeClass() {
@@ -96,6 +98,8 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
         client = mock(Client.class);
         when(client.threadPool()).thenReturn(threadPool);
 
+        adTaskManager = mock(ADTaskManager.class);
+
         action = new GetAnomalyDetectorTransportAction(
             transportService,
             nodeFilter,
@@ -103,7 +107,8 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
             clusterService,
             client,
             Settings.EMPTY,
-            xContentRegistry()
+            xContentRegistry(),
+            adTaskManager
         );
     }
 
@@ -112,7 +117,7 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
 
         rawPath = "_opendistro/_anomaly_detection/detectors/T4c3dXUBj-2IZN7itix_/_profile";
 
-        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, typeStr, rawPath, false, entityValue);
+        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, false, typeStr, rawPath, false, entityValue);
 
         future = new PlainActionFuture<>();
         action.doExecute(null, request, future);
@@ -137,7 +142,7 @@ public class GetAnomalyDetectorTests extends AbstractADTest {
 
         rawPath = "_opendistro/_anomaly_detection/detectors/T4c3dXUBj-2IZN7itix_/_profile";
 
-        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, typeStr, rawPath, false, entityValue);
+        request = new GetAnomalyDetectorRequest(detectorId, 0L, false, false, typeStr, rawPath, false, entityValue);
 
         future = new PlainActionFuture<>();
         action.doExecute(null, request, future);


### PR DESCRIPTION
*Issue #, if available:*

## Description of changes:
In last PR https://github.com/opendistro-for-elasticsearch/anomaly-detection/pull/355 we added starting historical detector change. As historical detector may run for a long time, we should allow user to kill running historical detector before its task done to avoid consuming unnecessary resource if user think no need to run the historical detector any more for example user find they configured wrong feature. 

This PR's main change:
1. Support stopping historical detector. Add stop detector method in ADTaskManager, and add cancel task transport action. Will reuse the same stop detector API to stop realtime&historical detector
2. Reuse current profile API to support AD task profile. Will return AD task and runtime info like training data size, model trained or not.
2. As frontend(AD Kibana) needs to show the latest task state/progress, will return AD task in get detector API if user set return task URL param as true. Add `task` URL param in get detector API, if user set it as true, will return latest AD task together with detector.
3. The start detector may have race condition if user send out multiple start historical detector requests for same detector at the same time. This PR fixed the race condition. Use hash ring(has on detector id) to find coordinating node of the historical detector first, then forward the request to the same coordinating node. Will cache all running historical detectors on coordinating node. If detector is already in cache, will reject the start historical detector request; otherwise, use the same logic in last PR https://github.com/opendistro-for-elasticsearch/anomaly-detection/pull/355 to gather nodes' states and dispatch task to worker node and run historical detection task.

## Test
1. `./gradlew build`
2. `./gradlew integTest -PnumNodes=3`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
