### PR TITLE
Moving common-utils to 1.11.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,7 +312,7 @@ dependencies {
     compile "org.elasticsearch:elasticsearch:${es_version}"
     compileOnly "org.elasticsearch.plugin:elasticsearch-scripting-painless-spi:${versions.elasticsearch}"
     compileOnly "com.amazon.opendistroforelasticsearch:opendistro-job-scheduler-spi:1.11.0.0"
-    compile "com.amazon.opendistroforelasticsearch:common-utils:1.11.0.1"
+    compile "com.amazon.opendistroforelasticsearch:common-utils:1.11.1.0"
     compile group: 'com.google.guava', name: 'guava', version:'29.0-jre'
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
@@ -445,7 +445,7 @@ public final class ParseUtils {
     }
 
     public static User getUserContext(Client client) {
-        String userStr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER_AND_ROLES);
+        String userStr = client.threadPool().getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
         logger.debug("Filtering result by " + userStr);
         return User.parse(userStr);
     }


### PR DESCRIPTION
Backporting change https://github.com/opendistro-for-elasticsearch/anomaly-detection/commit/48ac4f78fdea29cd3a8ba6797eb37e6882f679be to opendistro-1.11

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
