### PR TITLE
add user in AD task

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
@@ -212,7 +212,11 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
      */
     public static String getDetectionStateMappings() throws IOException {
         URL url = AnomalyDetectionIndices.class.getClassLoader().getResource(ANOMALY_DETECTION_STATE_INDEX_MAPPING_FILE);
-        return Resources.toString(url, Charsets.UTF_8);
+        String detectionStateMappings = Resources.toString(url, Charsets.UTF_8);
+        String detectorIndexMappings = AnomalyDetectionIndices.getAnomalyDetectorMappings();
+        detectorIndexMappings = detectorIndexMappings
+            .substring(detectorIndexMappings.indexOf("\"properties\""), detectorIndexMappings.lastIndexOf("}"));
+        return detectionStateMappings.replace("DETECTOR_INDEX_MAPPING_PLACE_HOLDER", detectorIndexMappings);
     }
 
     /**

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/model/ADTask.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.xcontent.XContentParser;
 
 import com.amazon.opendistroforelasticsearch.ad.annotation.Generated;
 import com.amazon.opendistroforelasticsearch.ad.util.ParseUtils;
+import com.amazon.opendistroforelasticsearch.commons.authuser.User;
 import com.google.common.base.Objects;
 
 /**
@@ -54,6 +55,7 @@ public class ADTask implements ToXContentObject, Writeable {
     public static final String COORDINATING_NODE_FIELD = "coordinating_node";
     public static final String WORKER_NODE_FIELD = "worker_node";
     public static final String DETECTOR_FIELD = "detector";
+    public static final String USER_FIELD = "user";
 
     private String taskId = null;
     private Instant lastUpdateTime = null;
@@ -74,6 +76,7 @@ public class ADTask implements ToXContentObject, Writeable {
 
     private String coordinatingNode = null;
     private String workerNode = null;
+    private User user = null;
 
     private ADTask() {}
 
@@ -100,6 +103,11 @@ public class ADTask implements ToXContentObject, Writeable {
         this.stoppedBy = input.readOptionalString();
         this.coordinatingNode = input.readOptionalString();
         this.workerNode = input.readOptionalString();
+        if (input.readBoolean()) {
+            this.user = new User(input);
+        } else {
+            user = null;
+        }
     }
 
     @Override
@@ -127,6 +135,12 @@ public class ADTask implements ToXContentObject, Writeable {
         out.writeOptionalString(stoppedBy);
         out.writeOptionalString(coordinatingNode);
         out.writeOptionalString(workerNode);
+        if (user != null) {
+            out.writeBoolean(true); // user exists
+            user.writeTo(out);
+        } else {
+            out.writeBoolean(false); // user does not exist
+        }
     }
 
     public static Builder builder() {
@@ -152,6 +166,7 @@ public class ADTask implements ToXContentObject, Writeable {
         private String stoppedBy = null;
         private String coordinatingNode = null;
         private String workerNode = null;
+        private User user = null;
 
         public Builder() {}
 
@@ -245,6 +260,11 @@ public class ADTask implements ToXContentObject, Writeable {
             return this;
         }
 
+        public Builder user(User user) {
+            this.user = user;
+            return this;
+        }
+
         public ADTask build() {
             ADTask adTask = new ADTask();
             adTask.taskId = this.taskId;
@@ -265,6 +285,7 @@ public class ADTask implements ToXContentObject, Writeable {
             adTask.stoppedBy = this.stoppedBy;
             adTask.coordinatingNode = this.coordinatingNode;
             adTask.workerNode = this.workerNode;
+            adTask.user = this.user;
 
             return adTask;
         }
@@ -328,6 +349,9 @@ public class ADTask implements ToXContentObject, Writeable {
         if (detector != null) {
             xContentBuilder.field(DETECTOR_FIELD, detector);
         }
+        if (user != null) {
+            xContentBuilder.field(USER_FIELD, user);
+        }
         return xContentBuilder.endObject();
     }
 
@@ -354,6 +378,7 @@ public class ADTask implements ToXContentObject, Writeable {
         String parsedTaskId = taskId;
         String coordinatingNode = null;
         String workerNode = null;
+        User user = null;
 
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
@@ -415,6 +440,9 @@ public class ADTask implements ToXContentObject, Writeable {
                 case WORKER_NODE_FIELD:
                     workerNode = parser.text();
                     break;
+                case USER_FIELD:
+                    user = User.parse(parser);
+                    break;
                 default:
                     parser.skipChildren();
                     break;
@@ -461,6 +489,7 @@ public class ADTask implements ToXContentObject, Writeable {
             .coordinatingNode(coordinatingNode)
             .workerNode(workerNode)
             .detector(anomalyDetector)
+            .user(user)
             .build();
     }
 
@@ -489,7 +518,8 @@ public class ADTask implements ToXContentObject, Writeable {
             && Objects.equal(getCheckpointId(), that.getCheckpointId())
             && Objects.equal(getCoordinatingNode(), that.getCoordinatingNode())
             && Objects.equal(getWorkerNode(), that.getWorkerNode())
-            && Objects.equal(getDetector(), that.getDetector());
+            && Objects.equal(getDetector(), that.getDetector())
+            && Objects.equal(getUser(), that.getUser());
     }
 
     @Generated
@@ -514,7 +544,8 @@ public class ADTask implements ToXContentObject, Writeable {
                 checkpointId,
                 coordinatingNode,
                 workerNode,
-                detector
+                detector,
+                user
             );
     }
 
@@ -598,4 +629,7 @@ public class ADTask implements ToXContentObject, Writeable {
         return workerNode;
     }
 
+    public User getUser() {
+        return user;
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/task/ADTaskManager.java
@@ -698,6 +698,7 @@ public class ADTaskManager {
             .lastUpdateTime(now)
             .startedBy(userName)
             .coordinatingNode(clusterService.localNode().getId())
+            .user(user)
             .build();
 
         IndexRequest request = new IndexRequest(CommonName.DETECTION_STATE_INDEX);

--- a/src/main/resources/mappings/anomaly-detection-state.json
+++ b/src/main/resources/mappings/anomaly-detection-state.json
@@ -59,11 +59,9 @@
     "worker_node": {
       "type": "keyword"
     },
-    "detector": {
+    "user": {
+      "type": "nested",
       "properties": {
-        "schema_version": {
-          "type": "integer"
-        },
         "name": {
           "type": "text",
           "fields": {
@@ -73,151 +71,34 @@
             }
           }
         },
-        "description": {
-          "type": "text"
-        },
-        "time_field": {
-          "type": "keyword"
-        },
-        "indices": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
+        "backend_roles": {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword"
             }
           }
         },
-        "filter_query": {
-          "type": "object",
-          "enabled": false
-        },
-        "feature_attributes": {
-          "type": "nested",
-          "properties": {
-            "feature_id": {
-              "type": "keyword",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            },
-            "feature_name": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            },
-            "feature_enabled": {
-              "type": "boolean"
-            },
-            "aggregation_query": {
-              "type": "object",
-              "enabled": false
+        "roles": {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword"
             }
           }
         },
-        "detection_interval": {
-          "properties": {
-            "period": {
-              "properties": {
-                "interval": {
-                  "type": "integer"
-                },
-                "unit": {
-                  "type": "keyword"
-                }
-              }
-            }
-          }
-        },
-        "window_delay": {
-          "properties": {
-            "period": {
-              "properties": {
-                "interval": {
-                  "type": "integer"
-                },
-                "unit": {
-                  "type": "keyword"
-                }
-              }
-            }
-          }
-        },
-        "shingle_size": {
-          "type": "integer"
-        },
-        "last_update_time": {
-          "type": "date",
-          "format": "strict_date_time||epoch_millis"
-        },
-        "ui_metadata": {
-          "type": "object",
-          "enabled": false
-        },
-        "user": {
-          "type": "nested",
-          "properties": {
-            "name": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword",
-                  "ignore_above": 256
-                }
-              }
-            },
-            "backend_roles": {
-              "type" : "text",
-              "fields" : {
-                "keyword" : {
-                  "type" : "keyword"
-                }
-              }
-            },
-            "roles": {
-              "type" : "text",
-              "fields" : {
-                "keyword" : {
-                  "type" : "keyword"
-                }
-              }
-            },
-            "custom_attribute_names": {
-              "type" : "text",
-              "fields" : {
-                "keyword" : {
-                  "type" : "keyword"
-                }
-              }
-            }
-          }
-        },
-        "category_field": {
-          "type": "keyword"
-        },
-        "detector_type": {
-          "type": "keyword"
-        },
-        "detection_date_range": {
-          "properties": {
-            "start_time": {
-              "type": "date",
-              "format": "strict_date_time||epoch_millis"
-            },
-            "end_time": {
-              "type": "date",
-              "format": "strict_date_time||epoch_millis"
+        "custom_attribute_names": {
+          "type" : "text",
+          "fields" : {
+            "keyword" : {
+              "type" : "keyword"
             }
           }
         }
       }
+    },
+    "detector": {
+      DETECTOR_INDEX_MAPPING_PLACE_HOLDER
     }
   }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndicesTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndicesTests.java
@@ -153,4 +153,12 @@ public class AnomalyDetectionIndicesTests extends ESIntegTestCase {
         IndexResponse indexResponse = client().index(new IndexRequest(indexName).source(xContentBuilder)).actionGet();
         assertEquals("Doc was not created", RestStatus.CREATED, indexResponse.status());
     }
+
+    public void testGetDetectionStateIndexMapping() throws IOException {
+        String detectorIndexMappings = AnomalyDetectionIndices.getAnomalyDetectorMappings();
+        detectorIndexMappings = detectorIndexMappings
+            .substring(detectorIndexMappings.indexOf("\"properties\""), detectorIndexMappings.lastIndexOf("}"));
+        String detectionStateIndexMapping = AnomalyDetectionIndices.getDetectionStateMappings();
+        assertTrue(detectionStateIndexMapping.contains(detectorIndexMappings));
+    }
 }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/AnomalyDetectorJobTransportActionTests.java
@@ -115,7 +115,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
         assertEquals(ADTaskState.FINISHED.name(), finishedTask.getState());
     }
 
-    public void testStartHistoricalDetectorWithUser() throws IOException, InterruptedException {
+    public void testStartHistoricalDetectorWithUser() throws IOException {
         DetectionDateRange dateRange = new DetectionDateRange(startTime, endTime);
         AnomalyDetector detector = TestHelpers
             .randomDetector(dateRange, ImmutableList.of(maxValueFeature()), testIndex, detectionIntervalInMinutes, timeField);
@@ -131,6 +131,7 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
             AnomalyDetectorJobResponse response = nodeClient.execute(MockAnomalyDetectorJobAction.INSTANCE, request).actionGet(100000);
             ADTask adTask = getADTask(response.getId());
             assertNotNull(adTask.getStartedBy());
+            assertNotNull(adTask.getUser());
         }
     }
 
@@ -299,6 +300,8 @@ public class AnomalyDetectorJobTransportActionTests extends HistoricalDetectorIn
     public void testStopHistoricalDetector() throws IOException, InterruptedException {
         ADTask adTask = startHistoricalDetector(startTime, endTime);
         assertEquals(ADTaskState.INIT.name(), adTask.getState());
+        assertNull(adTask.getStartedBy());
+        assertNull(adTask.getUser());
         AnomalyDetectorJobRequest request = stopDetectorJobRequest(adTask.getDetectorId());
         client().execute(AnomalyDetectorJobAction.INSTANCE, request).actionGet(10000);
         Thread.sleep(10000);


### PR DESCRIPTION
*Issue #, if available:*

## Description of changes:
1. Add user in AD task to support search AD task API
2. Add placeholder in detection state index mapping and inject detector index mapping in code. So we can only maintain detector index mapping in one place.

## Test
1. `./gradlew build`
2. `./gradlew integTest -PnumNodes=3`
3. Start cluster and test both backend role filtering enabled and disabled cases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
