### PR TITLE
validate detector only when start detector; fix flaky test case

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteAnomalyDetectorTransportActionTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/transport/DeleteAnomalyDetectorTransportActionTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.ad.transport;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
+
+import com.amazon.opendistroforelasticsearch.ad.HistoricalDetectorIntegTestCase;
+import com.amazon.opendistroforelasticsearch.ad.TestHelpers;
+import com.amazon.opendistroforelasticsearch.ad.model.AnomalyDetector;
+import com.amazon.opendistroforelasticsearch.ad.model.Feature;
+import com.google.common.collect.ImmutableList;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2)
+public class DeleteAnomalyDetectorTransportActionTests extends HistoricalDetectorIntegTestCase {
+    private Instant startTime;
+    private Instant endTime;
+    private String type = "error";
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        startTime = Instant.now().minus(10, ChronoUnit.DAYS);
+        endTime = Instant.now();
+        ingestTestData(testIndex, startTime, detectionIntervalInMinutes, type, 2000);
+        createDetectorIndex();
+    }
+
+    public void testDeleteAnomalyDetectorWithoutFeature() throws IOException {
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(null);
+        testDeleteDetector(detector);
+    }
+
+    public void testDeleteAnomalyDetectorWithoutEnabledFeature() throws IOException {
+        Feature feature = TestHelpers.randomFeature(false);
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableList.of(feature));
+        testDeleteDetector(detector);
+    }
+
+    public void testDeleteAnomalyDetectorWithEnabledFeature() throws IOException {
+        Feature feature = TestHelpers.randomFeature(true);
+        AnomalyDetector detector = TestHelpers.randomAnomalyDetector(ImmutableList.of(feature));
+        testDeleteDetector(detector);
+    }
+
+    private void testDeleteDetector(AnomalyDetector detector) throws IOException {
+        String detectorId = createDetector(detector);
+        DeleteAnomalyDetectorRequest request = new DeleteAnomalyDetectorRequest(detectorId);
+        DeleteResponse deleteResponse = client().execute(DeleteAnomalyDetectorAction.INSTANCE, request).actionGet(10000);
+        System.out.println(deleteResponse);
+        assertEquals("deleted", deleteResponse.getResult().getLowercase());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

## Description of changes:
1. Only validate feature when start detector
2. Fix flaky test case


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
