### PR TITLE
Update draft release notes config

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -5,7 +5,7 @@ template: |
 
 # Setting the formatting and sorting for the release notes body
 name-template: Version (set version here)
-change-template: "* $TITLE (#$NUMBER)"
+change-template: "* $TITLE ([#$NUMBER]($URL))"
 sort-by: merged_at
 sort-direction: ascending
 replacers:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Identical to the [AD Kibana plugin change](https://github.com/opendistro-for-elasticsearch/anomaly-detection-kibana-plugin/pull/358).

Updates the config file to use the raw URL in the embedded link to simplify the creation of the release notes in the `release-notes` directory, per ODFE standards.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
