### PR TITLE
change the backend role filtering to keep consistent with alerting pl…

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtils.java
@@ -50,7 +50,6 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.NestedQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -79,6 +78,7 @@ import com.amazon.opendistroforelasticsearch.ad.rest.handler.AnomalyDetectorFunc
 import com.amazon.opendistroforelasticsearch.ad.transport.GetAnomalyDetectorResponse;
 import com.amazon.opendistroforelasticsearch.commons.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.commons.authuser.User;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Parsing utility functions.
@@ -425,31 +425,17 @@ public final class ParseUtils {
     }
 
     public static SearchSourceBuilder addUserBackendRolesFilter(User user, SearchSourceBuilder searchSourceBuilder) {
+        if (user == null) {
+            return searchSourceBuilder;
+        }
         BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
         String userFieldName = "user";
         String userBackendRoleFieldName = "user.backend_roles.keyword";
-        if (user == null) {
-            // For old monitor and detector, they have no user field, user = null
-            ExistsQueryBuilder userRolesFilterQuery = QueryBuilders.existsQuery(userFieldName);
-            NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder(userFieldName, userRolesFilterQuery, ScoreMode.None);
-            boolQueryBuilder.mustNot(nestedQueryBuilder);
-        } else if (user.getBackendRoles() == null || user.getBackendRoles().size() == 0) {
-            // For simple FGAC user, they may have no backend roles, these users should be able to see detectors
-            // of other users whose backend role is empty. user != null, user.backend_role == null
-            ExistsQueryBuilder userRolesFilterQuery = QueryBuilders.existsQuery(userBackendRoleFieldName);
-            NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder(userFieldName, userRolesFilterQuery, ScoreMode.None);
-
-            ExistsQueryBuilder userExistsQuery = QueryBuilders.existsQuery(userFieldName);
-            NestedQueryBuilder userExistsNestedQueryBuilder = new NestedQueryBuilder(userFieldName, userExistsQuery, ScoreMode.None);
-
-            boolQueryBuilder.mustNot(nestedQueryBuilder);
-            boolQueryBuilder.must(userExistsNestedQueryBuilder);
-        } else {
-            // For normal case, user should have backend roles.
-            TermsQueryBuilder userRolesFilterQuery = QueryBuilders.termsQuery(userBackendRoleFieldName, user.getBackendRoles());
-            NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder(userFieldName, userRolesFilterQuery, ScoreMode.None);
-            boolQueryBuilder.must(nestedQueryBuilder);
-        }
+        List<String> backendRoles = user.getBackendRoles() != null ? user.getBackendRoles() : ImmutableList.of();
+        // For normal case, user should have backend roles.
+        TermsQueryBuilder userRolesFilterQuery = QueryBuilders.termsQuery(userBackendRoleFieldName, backendRoles);
+        NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder(userFieldName, userRolesFilterQuery, ScoreMode.None);
+        boolQueryBuilder.must(nestedQueryBuilder);
         QueryBuilder query = searchSourceBuilder.query();
         if (query == null) {
             searchSourceBuilder.query(boolQueryBuilder);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtilsTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/ad/util/ParseUtilsTests.java
@@ -117,12 +117,7 @@ public class ParseUtilsTests extends ESTestCase {
     public void testAddUserRoleFilterWithNullUser() {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         addUserBackendRolesFilter(null, searchSourceBuilder);
-        assertEquals(
-            "{\"query\":{\"bool\":{\"must_not\":[{\"nested\":{\"query\":{\"exists\":{\"field\":\"user\",\"boost\":1.0}},"
-                + "\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"adjust_pure_negative\":true,"
-                + "\"boost\":1.0}}}",
-            searchSourceBuilder.toString()
-        );
+        assertEquals("{}", searchSourceBuilder.toString());
     }
 
     public void testAddUserRoleFilterWithNullUserBackendRole() {
@@ -132,10 +127,9 @@ public class ParseUtilsTests extends ESTestCase {
             searchSourceBuilder
         );
         assertEquals(
-            "{\"query\":{\"bool\":{\"must\":[{\"nested\":{\"query\":{\"exists\":{\"field\":\"user\",\"boost\":1.0}},"
-                + "\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"must_not\":[{\"nested\":"
-                + "{\"query\":{\"exists\":{\"field\":\"user.backend_roles.keyword\",\"boost\":1.0}},\"path\":\"user\",\"ignore_unmapped\""
-                + ":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"adjust_pure_negative\":true,\"boost\":1.0}}}",
+            "{\"query\":{\"bool\":{\"must\":[{\"nested\":{\"query\":{\"terms\":{\"user.backend_roles.keyword\":[],"
+                + "\"boost\":1.0}},\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}],"
+                + "\"adjust_pure_negative\":true,\"boost\":1.0}}}",
             searchSourceBuilder.toString()
         );
     }
@@ -152,10 +146,9 @@ public class ParseUtilsTests extends ESTestCase {
             searchSourceBuilder
         );
         assertEquals(
-            "{\"query\":{\"bool\":{\"must\":[{\"nested\":{\"query\":{\"exists\":{\"field\":\"user\",\"boost\":1.0}},"
-                + "\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"must_not\":[{\"nested\":"
-                + "{\"query\":{\"exists\":{\"field\":\"user.backend_roles.keyword\",\"boost\":1.0}},\"path\":\"user\",\"ignore_unmapped\""
-                + ":false,\"score_mode\":\"none\",\"boost\":1.0}}],\"adjust_pure_negative\":true,\"boost\":1.0}}}",
+            "{\"query\":{\"bool\":{\"must\":[{\"nested\":{\"query\":{\"terms\":{\"user.backend_roles.keyword\":[],"
+                + "\"boost\":1.0}},\"path\":\"user\",\"ignore_unmapped\":false,\"score_mode\":\"none\",\"boost\":1.0}}],"
+                + "\"adjust_pure_negative\":true,\"boost\":1.0}}}",
             searchSourceBuilder.toString()
         );
     }


### PR DESCRIPTION
…ugin


## Description of changes:
Now we have two different logics for AD document level access control
1.For search APIs we will add user role filter query. When user is null, will add `user==null` filter, if user is not null, but backend role is null or empty will add `user != null and backend_roles == null or empty` query. So for user who has no backend role, they can still see their detectors after enabling backend role filtering

2.For other APIs like get/update/start/stop, we will check if the detector’s user backend role can match current thread user’s backend role. If either detector’s user backend role or current thread user backend role is null, we will throw no permission exception. That means if user doesn’t configure backend role, after enabling backend role filtering, they will not see their detectors.

For alerting plugin, if user's backend role is empty, the user can't see any monitors. User has to configure backend roles before enabling alerting backend role filtering. We will change to the same way of alerting plugin ([alerting plugin code link](https://github.com/opendistro-for-elasticsearch/alerting/blob/master/core/src/main/kotlin/com/amazon/opendistroforelasticsearch/alerting/elasticapi/ElasticExtensions.kt#L148)).

## Test
1. `./gradlew build`
2. `./gradlew integTest -PnumNodes=3`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
