### PR TITLE
Update default branch in workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,11 +2,11 @@ name: Build and Test Anomaly detection
 on:
   push:
     branches:
-      - master
+      - main
       - opendistro-*
   pull_request:
     branches:
-      - master
+      - main
       - opendistro-*
 
 jobs:
@@ -84,4 +84,3 @@ jobs:
         with:
           file: ./build/reports/jacoco/test/jacocoTestReport.xml
           flags: plugin
-

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With the recent efforts to change the default branch name from `master` to `main`, some workflows had `master` hardcoded - this changes those to `main` instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
