### PR TITLE
Fix the bug that hidden index setting was overriden

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/ad/indices/AnomalyDetectionIndices.java
@@ -474,11 +474,9 @@ public class AnomalyDetectionIndices implements LocalNodeMasterListener {
             logger.error("Fail to roll over AD result index, as can't get AD result index mapping");
             return;
         }
-        CreateIndexRequest createRequest = rollOverRequest
-            .getCreateIndexRequest();
+        CreateIndexRequest createRequest = rollOverRequest.getCreateIndexRequest();
 
-        createRequest.index(AD_RESULT_HISTORY_INDEX_PATTERN)
-            .mapping(CommonName.MAPPING_TYPE, adResultMapping, XContentType.JSON);
+        createRequest.index(AD_RESULT_HISTORY_INDEX_PATTERN).mapping(CommonName.MAPPING_TYPE, adResultMapping, XContentType.JSON);
 
         choosePrimaryShards(createRequest);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR fixes a bug where hidden index setting was overriden by the later call to choosePrimaryShards in AnomalyDetectionIndices.

Testing done:
1. Manually verified newly created AD indices are all hidden.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
