### PR TITLE
Bump gson dependency version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,7 @@ configurations.all {
         force "org.objenesis:objenesis:3.0.1"
         force "net.bytebuddy:byte-buddy:1.9.15"
         force "net.bytebuddy:byte-buddy-agent:1.9.15"
-        force "com.google.code.gson:gson:2.8.6"
+        force "com.google.code.gson:gson:2.8.9"
     }
 }
 
@@ -357,7 +357,7 @@ dependencies {
     compile "com.amazon.opendistroforelasticsearch:common-utils:${opendistroVersion}.0"
     compile group: 'com.google.guava', name: 'guava', version:'29.0-jre'
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
+    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
     compile group: 'com.yahoo.datasketches', name: 'sketches-core', version: '0.13.4'
     compile group: 'com.yahoo.datasketches', name: 'memory', version: '0.12.2'
     compile group: 'commons-lang', name: 'commons-lang', version: '2.6'


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

Bump gson dependency version.

Will track that [performance analyzer](https://github.com/opendistro-for-elasticsearch/performance-analyzer) performs a similar bump such that they are on the same version of gson.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
